### PR TITLE
Add development integrant profile with stubbed user impersonation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,8 @@ projects/**/pom.xml
 
 # Calva VS Code Extension
 .calva/output-window/output.calva-repl
-db/
+db/*
+!db/.gitkeep
 
 # RPFM-decoded game table JSONs + extracted card/portrait assets
 # (regenerated from game files via RPFM MCP, not committed)

--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -1,6 +1,10 @@
 (ns com.devereux-henley.rts-api.configuration
+  "Integrant system map. Exposes named profiles so the REPL (dev + Claude) can
+   boot a development profile that stubs Ory authentication, while production
+   jars still use `core-configuration` with real Ory wiring."
   (:require
    [com.devereux-henley.rts-api.db :as db]
+   [com.devereux-henley.rts-api.dev-auth :as dev-auth]
    [com.devereux-henley.rts-api.web :as web]
    [com.devereux-henley.rts-data.contract :as rts-data]
    [com.devereux-henley.rts-web.contract :as rts-web]
@@ -17,7 +21,11 @@
 (def default-api-dependencies {:hostname   hostname
                                :connection (integrant.core/ref ::db/connection)})
 (def default-view-dependencies {})
-(def core-configuration
+
+(def base-configuration
+  "Shared integrant wiring used by every profile. Auth middleware and the
+   `::web/app` entry point are contributed by the individual profiles so they
+   can swap Ory for a dev stub without copy-pasting the rest of the system."
   {::rts-data/migrate                                                     {:db-spec       db/db-spec
                                                                            :migration-dir rts-data/migration-dir}
    ::db/connection                                                        {:migrations (integrant.core/ref ::rts-data/migrate)}
@@ -46,15 +54,48 @@
    :com.devereux-henley.rts-web.web.game/get-game-social-link             default-api-dependencies
    :com.devereux-henley.rts-web.web.social-media/get-platform             default-api-dependencies
    :com.devereux-henley.rts-web.web.game/create-draft                     default-api-dependencies
-   :com.devereux-henley.rts-web.web.routes/routes
-   [rts-web/root-route
-    rts-web/icon-routes
-    rts-web/view-routes
-    rts-web/api-routes]
-   :com.devereux-henley.rts-web.web.configuration/configuration                          {:com.devereux-henley.rts-web.web.configuration/openid-url (str auth-hostname "/" ".well-known/openid-configuration")
-                                                                                          :com.devereux-henley.rts-web.web.configuration/auth-hostname auth-hostname}
-   ::web/app                                                               {:routes        (integrant.core/ref :com.devereux-henley.rts-web.web.routes/routes)
-                                                                            :session-name  session-name
-                                                                            :auth-hostname auth-hostname}
-   ::web/service                                                           {:handler       (integrant.core/ref ::web/app)
-                                                                            :configuration {:port port, :join? false}}})
+   :com.devereux-henley.rts-web.web.configuration/configuration           {:com.devereux-henley.rts-web.web.configuration/openid-url    (str auth-hostname "/" ".well-known/openid-configuration")
+                                                                           :com.devereux-henley.rts-web.web.configuration/auth-hostname auth-hostname}
+   ::web/service                                                          {:handler       (integrant.core/ref ::web/app)
+                                                                           :configuration {:port port, :join? false}}})
+
+(def core-configuration
+  "Production profile. Uses Ory for authentication."
+  (assoc base-configuration
+         ::web/ory-auth-middleware
+         {:auth-hostname auth-hostname
+          :session-name  session-name}
+
+         :com.devereux-henley.rts-web.web.routes/routes
+         [rts-web/root-route
+          rts-web/icon-routes
+          rts-web/view-routes
+          rts-web/api-routes]
+
+         ::web/app
+         {:routes          (integrant.core/ref :com.devereux-henley.rts-web.web.routes/routes)
+          :auth-middleware (integrant.core/ref ::web/ory-auth-middleware)}))
+
+(def development-configuration
+  "Dev profile. Swaps Ory for the cookie-based impersonation stub in
+   `dev-auth` and mounts the `/dev/*` impersonation routes. Downstream
+   handlers still see `:ory-session` on the request with the same shape as
+   the real Ory whoami response."
+  (assoc base-configuration
+         ::dev-auth/users                    {}
+         ::dev-auth/impersonation-middleware {:users           (integrant.core/ref ::dev-auth/users)
+                                              :default-user-id dev-auth/default-user-id}
+         ::dev-auth/impersonate-handler      {:users (integrant.core/ref ::dev-auth/users)}
+         ::dev-auth/logout-handler           {}
+         ::dev-auth/list-users-handler       {:users (integrant.core/ref ::dev-auth/users)}
+
+         :com.devereux-henley.rts-web.web.routes/routes
+         [rts-web/root-route
+          rts-web/icon-routes
+          rts-web/view-routes
+          rts-web/api-routes
+          dev-auth/routes]
+
+         ::web/app
+         {:routes          (integrant.core/ref :com.devereux-henley.rts-web.web.routes/routes)
+          :auth-middleware (integrant.core/ref ::dev-auth/impersonation-middleware)}))

--- a/bases/rts-api/src/com/devereux_henley/rts_api/dev_auth.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/dev_auth.clj
@@ -1,0 +1,138 @@
+(ns com.devereux-henley.rts-api.dev-auth
+  "Dev-only authentication profile. Stubs Ory with a simple cookie-session
+   impersonation layer so local development and automated tests can \"log in\"
+   as any predefined user without running the Ory stack. The request shape
+   (`:ory-session`) and nested user data match what Ory's `/sessions/whoami`
+   returns, so downstream handlers, templates, and domain code do not care
+   which profile is active."
+  (:require
+   [clojure.string :as str]
+   [com.devereux-henley.resourcekit.contract :as resourcekit]
+   [integrant.core]))
+
+(def cookie-name
+  "Name of the cookie that stores the impersonated user's id."
+  "dev_impersonation")
+
+(def dev-users
+  "Predefined dev users keyed by id. Shape mirrors an Ory /sessions/whoami
+   response so downstream code can read `[:identity :id]` and
+   `[:identity :traits :first_name]` unchanged."
+  {"dev-admin"
+   {:active   true
+    :identity {:id     "dev-admin"
+               :traits {:first_name "Dev"
+                        :last_name  "Admin"
+                        :email      "dev-admin@example.com"}}}
+   "dev-player-one"
+   {:active   true
+    :identity {:id     "dev-player-one"
+               :traits {:first_name "Player"
+                        :last_name  "One"
+                        :email      "player-one@example.com"}}}
+   "dev-player-two"
+   {:active   true
+    :identity {:id     "dev-player-two"
+               :traits {:first_name "Player"
+                        :last_name  "Two"
+                        :email      "player-two@example.com"}}}})
+
+(defn- asset-path?
+  [uri]
+  (some #(str/starts-with? uri %)
+        [(str resourcekit/asset-path "/")
+         "/style/"
+         "/image/"
+         "/icon/"
+         "/card/"]))
+
+(def default-user-id
+  "User id attached to every request when the impersonation cookie is
+   missing. Ensures the dev profile is always \"logged in\" so templates
+   never render the Ory login button."
+  "dev-admin")
+
+(defn dev-session-middleware
+  "Replacement for `web/ory-session-middleware`. Looks up the impersonation
+   cookie first; if absent (or pointing at an unknown user) it falls back to
+   `default-user-id` so every request sees a populated `:ory-session`."
+  [users default-id handler]
+  (fn [request]
+    (if (asset-path? (:uri request))
+      (handler request)
+      (let [cookie-user-id (get-in request [:cookies cookie-name :value])
+            session        (or (get users cookie-user-id)
+                               (get users default-id))]
+        (handler (assoc request :ory-session session))))))
+
+(defn- impersonate-cookie
+  [user-id]
+  {:value     user-id
+   :path      "/"
+   :http-only true
+   :same-site :lax})
+
+(def ^:private clear-cookie
+  {:value     ""
+   :path      "/"
+   :max-age   0
+   :http-only true
+   :same-site :lax})
+
+(defmethod integrant.core/init-key ::impersonation-middleware
+  [_init-key {:keys [users default-user-id]}]
+  (fn [handler]
+    (dev-session-middleware users default-user-id handler)))
+
+(defmethod integrant.core/init-key ::users
+  [_init-key _dependencies]
+  dev-users)
+
+(defmethod integrant.core/init-key ::impersonate-handler
+  [_init-key {:keys [users]}]
+  (fn [{{{:keys [user-id]} :path} :parameters :as _request}]
+    (if (contains? users user-id)
+      {:status  303
+       :headers {"Location" "/view/dashboard.html"}
+       :cookies {cookie-name (impersonate-cookie user-id)}
+       :body    ""}
+      {:status 404
+       :body   {:error (str "Unknown dev user: " user-id)
+                :known-users (vec (keys users))}})))
+
+(defmethod integrant.core/init-key ::logout-handler
+  [_init-key _dependencies]
+  (fn [_request]
+    {:status  303
+     :headers {"Location" "/view/dashboard.html"}
+     :cookies {cookie-name clear-cookie}
+     :body    ""}))
+
+(defmethod integrant.core/init-key ::list-users-handler
+  [_init-key {:keys [users]}]
+  (fn [_request]
+    {:status 200
+     :body   {:users (mapv (fn [[id user]]
+                             {:id           id
+                              :display-name (str (get-in user [:identity :traits :first_name])
+                                                 " "
+                                                 (get-in user [:identity :traits :last_name]))
+                              :email        (get-in user [:identity :traits :email])})
+                           users)}}))
+
+(def routes
+  "Reitit route tree exposing dev-only impersonation endpoints. Added to the
+   router only under the development profile."
+  ["/dev"
+   {:no-doc true}
+   ["/users"
+    {:get {:produces ["application/json"]
+           :handler  (integrant.core/ref ::list-users-handler)}}]
+   ["/impersonate/:user-id"
+    {:post {:parameters {:path [:map [:user-id :string]]}
+            :handler    (integrant.core/ref ::impersonate-handler)}
+     :get  {:parameters {:path [:map [:user-id :string]]}
+            :handler    (integrant.core/ref ::impersonate-handler)}}]
+   ["/logout"
+    {:post {:handler (integrant.core/ref ::logout-handler)}
+     :get  {:handler (integrant.core/ref ::logout-handler)}}]])

--- a/bases/rts-api/src/com/devereux_henley/rts_api/web.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/web.clj
@@ -176,8 +176,13 @@
   [_init-key _dependencies]
   (openapi/create-openapi-handler))
 
+(defmethod integrant.core/init-key ::ory-auth-middleware
+  [_init-key {:keys [auth-hostname session-name]}]
+  (fn [handler]
+    (ory-session-middleware auth-hostname session-name handler)))
+
 (defmethod integrant.core/init-key ::app
-  [_init-key {:keys [routes session-name auth-hostname]}]
+  [_init-key {:keys [routes auth-middleware]}]
   (ring/ring-handler
    (ring/router
     routes
@@ -249,7 +254,7 @@
                                             :body    "Oopsie"})})
     (ring/create-default-handler))
    {:middleware [ring.middleware.cookies/wrap-cookies
-                 (partial ory-session-middleware auth-hostname session-name)]}))
+                 auth-middleware]}))
 
 (defmethod integrant.core/init-key ::service
   [_init-key {:keys [handler configuration]}]

--- a/development/src/claude_workspace.clj
+++ b/development/src/claude_workspace.clj
@@ -2,8 +2,10 @@
   "Claude Code dev helpers. Loaded via the :dev alias alongside workspace.clj."
   (:require
    [com.devereux-henley.rts-api.configuration :as configuration]
+   [com.devereux-henley.rts-api.dev-auth :as dev-auth]
    [com.devereux-henley.rts-data.contract :as rts-data]
    [com.devereux-henley.rts-api.db :as rts-db]
+   [integrant.core]
    [integrant.repl :refer [go halt reset]]
    [migratus.core :as migratus]
    [selmer.parser]))
@@ -12,6 +14,13 @@
 ;; up template edits without needing a manual cache clear. Production code
 ;; paths re-enable caching via their own startup.
 (selmer.parser/cache-off!)
+
+;; Default the REPL to the development profile (Ory auth stubbed out with
+;; cookie-session impersonation). Boots the same system `workspace.clj` would,
+;; but stays self-contained so Claude can drive the system from this namespace
+;; alone.
+(integrant.repl/set-prep!
+ (fn [] (integrant.core/expand configuration/development-configuration)))
 
 ;; -- System helpers ----------------------------------------------------------
 
@@ -42,6 +51,18 @@
 (defn reset-db! [] (migratus/reset migratus-config))
 (defn seed-db! [] (rts-data/seed-db rts-db/db-spec))
 
+;; -- Impersonation helpers ---------------------------------------------------
+
+(def dev-users
+  "Predefined dev users available in the development profile."
+  dev-auth/dev-users)
+
+(defn impersonation-cookie
+  "Header value Claude can send on clj-http/Jetty requests to act as the given
+   dev user. Example: `{:headers {\"cookie\" (impersonation-cookie \"dev-admin\")}}`."
+  [user-id]
+  (str dev-auth/cookie-name "=" user-id))
+
 ;; -- Scratch -----------------------------------------------------------------
 
 (comment
@@ -54,4 +75,8 @@
   (migrate!)
   (rollback!)
   (reset-db!)
-  (seed-db!))
+  (seed-db!)
+
+  ;; Impersonation (development profile only)
+  (keys dev-users)
+  (impersonation-cookie "dev-admin"))

--- a/development/src/workspace.clj
+++ b/development/src/workspace.clj
@@ -7,7 +7,7 @@
    [integrant.repl :refer [go halt reset]]
    [migratus.core :as migratus]))
 
-(integrant.repl/set-prep! (fn [] (integrant.core/expand configuration/core-configuration)))
+(integrant.repl/set-prep! (fn [] (integrant.core/expand configuration/development-configuration)))
 
 (def migratus-config
   {:store         :database


### PR DESCRIPTION
Splits configuration.clj into a shared base plus core (Ory) and development (cookie-impersonation) profiles, and refactors web/app to take a pluggable auth-middleware. The dev profile attaches an Ory-shaped :ory-session to every request, defaulting to dev-admin so templates always render authenticated. /dev/impersonate/:user-id and /dev/logout let tests (and Claude) switch to other predefined users. workspace.clj and claude_workspace.clj now boot the dev profile by default.