### PR TITLE
Add Playwright e2e tests integrated with poly test.

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: '21'
 
       - name: Install Clojure CLI
-        uses: DeLaGuardo/setup-clojure@13.0
+        uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
           clj-kondo: latest

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -26,6 +26,11 @@ jobs:
           cli: latest
           clj-kondo: latest
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Cache Maven & Gitlibs
         uses: actions/cache@v4
         with:
@@ -36,6 +41,18 @@ jobs:
           key: ${{ runner.os }}-cljdeps-${{ hashFiles('**/deps.edn') }}
           restore-keys: |
             ${{ runner.os }}-cljdeps-
+
+      - name: Install Playwright
+        working-directory: components/e2e
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Start dev server
+        run: |
+          mkdir -p db
+          clojure -M:dev -i components/e2e/resources/e2e/start_dev_server.clj &
+          timeout 120 bash -c 'until curl -sf http://localhost:3001/status > /dev/null 2>&1; do sleep 2; done'
 
       - name: Polylith check
         run: clojure -M:poly check
@@ -54,6 +71,10 @@ jobs:
 
       - name: Polylith test
         run: clojure -M:poly test
+
+      - name: Stop dev server
+        if: always()
+        run: curl -sf -X POST http://localhost:3001/shutdown || true
 
       - name: clj-kondo prime cache
         run: clj-kondo --copy-configs --dependencies --lint "$(clojure -A:dev -Spath)"

--- a/.github/workflows/tag-stable.yml
+++ b/.github/workflows/tag-stable.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: '21'
 
       - name: Install Clojure CLI
-        uses: DeLaGuardo/setup-clojure@13.0
+        uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
           clj-kondo: latest

--- a/.github/workflows/tag-stable.yml
+++ b/.github/workflows/tag-stable.yml
@@ -29,6 +29,11 @@ jobs:
           cli: latest
           clj-kondo: latest
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Cache Maven & Gitlibs
         uses: actions/cache@v4
         with:
@@ -39,6 +44,18 @@ jobs:
           key: ${{ runner.os }}-cljdeps-${{ hashFiles('**/deps.edn') }}
           restore-keys: |
             ${{ runner.os }}-cljdeps-
+
+      - name: Install Playwright
+        working-directory: components/e2e
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Start dev server
+        run: |
+          mkdir -p db
+          clojure -M:dev -i components/e2e/resources/e2e/start_dev_server.clj &
+          timeout 120 bash -c 'until curl -sf http://localhost:3001/status > /dev/null 2>&1; do sleep 2; done'
 
       - name: Polylith check
         run: clojure -M:poly check
@@ -57,6 +74,10 @@ jobs:
 
       - name: Polylith test
         run: clojure -M:poly test
+
+      - name: Stop dev server
+        if: always()
+        run: curl -sf -X POST http://localhost:3001/shutdown || true
 
       - name: clj-kondo prime cache
         run: clj-kondo --copy-configs --dependencies --lint "$(clojure -A:dev -Spath)"

--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -68,6 +68,7 @@
 
          :com.devereux-henley.rts-web.web.routes/routes
          [rts-web/root-route
+          rts-web/status-route
           rts-web/icon-routes
           rts-web/view-routes
           rts-web/api-routes]
@@ -91,6 +92,8 @@
 
          :com.devereux-henley.rts-web.web.routes/routes
          [rts-web/root-route
+          rts-web/status-route
+          rts-web/shutdown-route
           rts-web/icon-routes
           rts-web/view-routes
           rts-web/api-routes

--- a/components/e2e/.gitignore
+++ b/components/e2e/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+test-results/
+playwright-report/

--- a/components/e2e/deps.edn
+++ b/components/e2e/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src" "resources"]
+ :deps {}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/e2e/package-lock.json
+++ b/components/e2e/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "com.devereux-henley-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "com.devereux-henley-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/components/e2e/package.json
+++ b/components/e2e/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "com.devereux-henley-e2e",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.52.0"
+  }
+}

--- a/components/e2e/playwright.config.js
+++ b/components/e2e/playwright.config.js
@@ -1,0 +1,18 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  timeout: 30000,
+  retries: 0,
+  reporter: [['list'], ['json', { outputFile: 'test-results/results.json' }]],
+  use: {
+    baseURL: 'http://localhost:3001',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/components/e2e/resources/e2e/start_dev_server.clj
+++ b/components/e2e/resources/e2e/start_dev_server.clj
@@ -1,0 +1,10 @@
+(require '[com.devereux-henley.rts-api.configuration :as config])
+(require '[com.devereux-henley.rts-api.db :as db])
+(require '[com.devereux-henley.rts-data.contract :as rts-data])
+(require '[integrant.core :as ig])
+
+(let [system (ig/init (ig/expand config/development-configuration))]
+  (rts-data/seed-db db/db-spec)
+  (println "Dev server started on port 3001")
+  (.addShutdownHook (Runtime/getRuntime) (Thread. #(ig/halt! system)))
+  @(promise))

--- a/components/e2e/src/com/devereux_henley/e2e/contract.clj
+++ b/components/e2e/src/com/devereux_henley/e2e/contract.clj
@@ -1,0 +1,48 @@
+(ns com.devereux-henley.e2e.contract
+  (:require
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell])
+  (:import
+   [java.net HttpURLConnection URL]))
+
+(defn playwright-available?
+  "Returns true when npx is on the PATH and Playwright's node_modules are installed
+   under the e2e component directory."
+  [e2e-dir]
+  (and (.isDirectory (io/file e2e-dir "node_modules"))
+       (zero? (:exit (shell/sh "which" "npx")))))
+
+(defn server-reachable?
+  "Returns true when the application server responds at the given base URL."
+  [base-url]
+  (try
+    (let [conn (-> (URL. (str base-url "/status"))
+                   (.openConnection))]
+      (.setConnectTimeout ^HttpURLConnection conn 2000)
+      (.setReadTimeout ^HttpURLConnection conn 2000)
+      (.setRequestMethod ^HttpURLConnection conn "GET")
+      (let [code (.getResponseCode ^HttpURLConnection conn)]
+        (.disconnect ^HttpURLConnection conn)
+        (< code 500)))
+    (catch Exception _ false)))
+
+(defn run-playwright
+  "Runs Playwright tests from inside the e2e component directory so npx resolves
+   the local node_modules. Returns the shell result map."
+  [e2e-dir]
+  (shell/sh "npx" "playwright" "test" :dir e2e-dir))
+
+(defn shutdown-server
+  "Posts to the dev-only /shutdown endpoint for a clean Integrant halt."
+  [base-url]
+  (try
+    (let [conn (-> (URL. (str base-url "/shutdown"))
+                   (.openConnection))]
+      (.setConnectTimeout ^HttpURLConnection conn 2000)
+      (.setReadTimeout ^HttpURLConnection conn 2000)
+      (.setRequestMethod ^HttpURLConnection conn "POST")
+      (.setDoOutput ^HttpURLConnection conn true)
+      (let [code (.getResponseCode ^HttpURLConnection conn)]
+        (.disconnect ^HttpURLConnection conn)
+        (< code 500)))
+    (catch Exception _ false)))

--- a/components/e2e/test/com/devereux_henley/e2e/playwright_test.clj
+++ b/components/e2e/test/com/devereux_henley/e2e/playwright_test.clj
@@ -1,0 +1,30 @@
+(ns com.devereux-henley.e2e.playwright-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [com.devereux-henley.e2e.contract :as e2e]))
+
+(def ^:private e2e-dir "components/e2e")
+(def ^:private base-url "http://localhost:3001")
+(def ^:private ci? (some? (System/getenv "CI")))
+
+(deftest playwright-e2e-tests
+  (cond
+    (not (e2e/playwright-available? e2e-dir))
+    (if ci?
+      (is false "Playwright not installed — npm ci + playwright install must run before poly test")
+      (println "SKIP: Playwright not installed — run `npm install` in" e2e-dir))
+
+    (not (e2e/server-reachable? base-url))
+    (if ci?
+      (is false "Dev server not reachable — start_dev_server.clj must run before poly test")
+      (println "SKIP: Dev server not reachable at" base-url "— start it first"))
+
+    :else
+    (testing "All Playwright specs pass"
+      (let [{:keys [exit out err]} (e2e/run-playwright e2e-dir)]
+        (when-not (zero? exit)
+          (println "--- Playwright stdout ---")
+          (println out)
+          (println "--- Playwright stderr ---")
+          (println err))
+        (is (zero? exit) "Playwright tests failed — see output above")))))

--- a/components/e2e/tests/draft-api.spec.js
+++ b/components/e2e/tests/draft-api.spec.js
@@ -1,0 +1,253 @@
+const { test, expect } = require('@playwright/test');
+
+const BASE = 'http://localhost:3001';
+const GAME_EID = 'eea787d7-1065-45eb-a3f6-e26f32c294a1';
+const EMPIRE_FACTION_EID = '35dd38fa-2bcc-4492-8f58-a106d0d02cbb';
+const LAND_BATTLE_MODE_EID = 'a1b2c3d4-0001-4000-8000-000000000001';
+const DOMINATION_MODE_EID = 'a1b2c3d4-0002-4000-8000-000000000002';
+const ARCH_LECTOR_EID = '00010001-0000-4000-8000-000000000000';
+const GENERAL_EID = '00010006-0000-4000-8000-000000000000';
+const SWORDSMEN_EID = '0001002a-0000-4000-8000-000000000000';
+const BALTHASAR_GELT_EID = '00010002-0000-4000-8000-000000000000';
+
+const HEADERS = {
+  Accept: 'application/hal+json',
+  'Content-Type': 'application/json',
+  Cookie: 'dev_impersonation=dev-admin',
+};
+
+async function createDraft(request, gameModeEid) {
+  const eid = crypto.randomUUID();
+  const res = await request.put(`${BASE}/api/draft/${eid}?version=1`, {
+    headers: HEADERS,
+    data: {
+      'faction-eid': EMPIRE_FACTION_EID,
+      'game-mode-eid': gameModeEid,
+      'game-eid': GAME_EID,
+    },
+  });
+  expect(res.status()).toBe(201);
+  const body = await res.json();
+  expect(body.eid).toBe(eid);
+  return body;
+}
+
+async function addUnit(request, draftEid, unitEid, section) {
+  const res = await request.post(
+    `${BASE}/api/draft/${draftEid}/unit/${unitEid}?section=${section}`,
+    { headers: HEADERS, data: {} }
+  );
+  return { status: res.status(), body: await res.json() };
+}
+
+test.describe('Draft API (application/hal+json)', () => {
+  test('create a draft returns draft resource with _links', async ({ request }) => {
+    const draft = await createDraft(request, LAND_BATTLE_MODE_EID);
+
+    expect(draft.type).toBe('game/draft');
+    expect(draft['faction-eid']).toBe(EMPIRE_FACTION_EID);
+    expect(draft['game-mode-eid']).toBe(LAND_BATTLE_MODE_EID);
+    expect(draft['player-sub']).toBe('dev-admin');
+    expect(draft._links).toBeDefined();
+    expect(draft._links.self).toContain(`/api/draft/${draft.eid}`);
+  });
+
+  test('get draft unit returns unit resource with statistics', async ({ request }) => {
+    const draft = await createDraft(request, LAND_BATTLE_MODE_EID);
+
+    const res = await request.get(
+      `${BASE}/api/draft/${draft.eid}/unit/${ARCH_LECTOR_EID}`,
+      { headers: HEADERS }
+    );
+    expect(res.status()).toBe(200);
+    const unit = await res.json();
+
+    expect(unit.type).toBe('draft/unit');
+    expect(unit.name).toBe('Arch Lector');
+    expect(unit['unit-category-name']).toBe('Lord');
+    expect(unit['unit-statistics']).toBeDefined();
+    expect(unit['unit-statistics'].length).toBeGreaterThan(0);
+    expect(unit._links).toBeDefined();
+    expect(unit._links.self).toContain(`/unit/${ARCH_LECTOR_EID}`);
+    expect(unit._links.draft).toContain(`/api/draft/${draft.eid}`);
+  });
+
+  test('add lord to main returns add-success with budget', async ({ request }) => {
+    const draft = await createDraft(request, LAND_BATTLE_MODE_EID);
+    const { status, body } = await addUnit(request, draft.eid, ARCH_LECTOR_EID, 'main');
+
+    expect(status).toBe(200);
+    expect(body.type).toBe('draft/add-success');
+    expect(body['new-unit'].name).toBe('Arch Lector');
+    expect(body['new-unit']['is-lord']).toBe(true);
+    expect(body['new-unit']['entry-eid']).toBeDefined();
+    expect(body['new-unit']['total-cost']).toBe(550);
+    expect(body.section.section).toBe('main');
+    expect(body.budget['section-cost']).toBe(550);
+    expect(body.budget['section-max']).toBe(12400);
+    expect(body.budget['section-over-budget']).toBe(false);
+  });
+
+  test('add infantry to main section', async ({ request }) => {
+    const draft = await createDraft(request, LAND_BATTLE_MODE_EID);
+    const { status, body } = await addUnit(request, draft.eid, SWORDSMEN_EID, 'main');
+
+    expect(status).toBe(200);
+    expect(body.type).toBe('draft/add-success');
+    expect(body['new-unit'].name).toBe('Swordsmen');
+    expect(body['new-unit']['total-cost']).toBe(375);
+    expect(body.budget['section-cost']).toBe(375);
+  });
+
+  test('add unit to reinforcements section', async ({ request }) => {
+    const draft = await createDraft(request, DOMINATION_MODE_EID);
+    const { status, body } = await addUnit(request, draft.eid, SWORDSMEN_EID, 'reinforcements');
+
+    expect(status).toBe(200);
+    expect(body.type).toBe('draft/add-success');
+    expect(body.section.section).toBe('reinforcements');
+    expect(body.budget.section).toBe('reinforcements');
+    expect(body.budget['section-cost']).toBe(375);
+    expect(body.budget['section-max']).toBe(9000);
+  });
+
+  test('get draft entry returns entry resource with _links', async ({ request }) => {
+    const draft = await createDraft(request, LAND_BATTLE_MODE_EID);
+    const { body: addBody } = await addUnit(request, draft.eid, ARCH_LECTOR_EID, 'main');
+    const entryEid = addBody['new-unit']['entry-eid'];
+
+    const res = await request.get(
+      `${BASE}/api/draft/${draft.eid}/entry/${entryEid}?section=main`,
+      { headers: HEADERS }
+    );
+    expect(res.status()).toBe(200);
+    const entry = await res.json();
+
+    expect(entry.type).toBe('draft/entry');
+    expect(entry.eid).toBe(entryEid);
+    expect(entry['draft-eid']).toBe(draft.eid);
+    expect(entry['unit-eid']).toBe(ARCH_LECTOR_EID);
+    expect(entry.section).toBe('main');
+    expect(entry._links.self).toContain(`/entry/${entryEid}`);
+    expect(entry._links.draft).toContain(`/api/draft/${draft.eid}`);
+    expect(entry._links.unit).toContain(`/unit/${ARCH_LECTOR_EID}`);
+  });
+
+  test('get draft entry with embed=unit includes _embedded.unit', async ({ request }) => {
+    const draft = await createDraft(request, LAND_BATTLE_MODE_EID);
+    const { body: addBody } = await addUnit(request, draft.eid, ARCH_LECTOR_EID, 'main');
+    const entryEid = addBody['new-unit']['entry-eid'];
+
+    const res = await request.get(
+      `${BASE}/api/draft/${draft.eid}/entry/${entryEid}?section=main&embed=unit`,
+      { headers: HEADERS }
+    );
+    const entry = await res.json();
+
+    expect(entry._embedded).toBeDefined();
+    expect(entry._embedded.unit).toBeDefined();
+    expect(entry._embedded.unit.name).toBe('Arch Lector');
+    expect(entry._embedded.unit['unit-category-name']).toBe('Lord');
+    expect(entry._embedded.unit['unit-statistics'].length).toBeGreaterThan(0);
+  });
+
+  test('update placed unit selections changes cost', async ({ request }) => {
+    const draft = await createDraft(request, LAND_BATTLE_MODE_EID);
+    const { body: addBody } = await addUnit(request, draft.eid, BALTHASAR_GELT_EID, 'main');
+    const entryEid = addBody['new-unit']['entry-eid'];
+    const costBefore = addBody['new-unit']['total-cost'];
+
+    const res = await request.get(
+      `${BASE}/api/draft/${draft.eid}/entry/${entryEid}?section=main&embed=unit`,
+      { headers: HEADERS }
+    );
+    const entry = await res.json();
+    const spell = entry._embedded.unit['draftable-spells']?.[0];
+    const item = entry._embedded.unit.items?.[0];
+    const selectionKey = spell?.key || item?.key;
+    const selectionField = spell ? 'spells' : 'items';
+
+    if (selectionKey) {
+      const patchRes = await request.patch(
+        `${BASE}/api/draft/${draft.eid}/entry/${entryEid}?section=main`,
+        { headers: HEADERS, data: { [selectionField]: [selectionKey] } }
+      );
+      expect(patchRes.status()).toBe(200);
+      const patchBody = await patchRes.json();
+
+      expect(patchBody.type).toBe('draft/update-success');
+      expect(patchBody['entry-eid']).toBe(entryEid);
+      expect(patchBody['total-cost']).toBeGreaterThan(costBefore);
+      expect(patchBody.budget['section-cost']).toBe(patchBody['total-cost']);
+    }
+  });
+
+  test('remove unit returns remove-success and resets budget', async ({ request }) => {
+    const draft = await createDraft(request, LAND_BATTLE_MODE_EID);
+    const { body: addBody } = await addUnit(request, draft.eid, SWORDSMEN_EID, 'main');
+    const entryEid = addBody['new-unit']['entry-eid'];
+
+    expect(addBody.budget['section-cost']).toBe(375);
+
+    const res = await request.delete(
+      `${BASE}/api/draft/${draft.eid}/entry/${entryEid}?section=main`,
+      { headers: HEADERS }
+    );
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+
+    expect(body.type).toBe('draft/remove-success');
+    expect(body['removed-entry-eid']).toBe(entryEid);
+    expect(body['removed-is-lord']).toBe(false);
+    expect(body.budget['section-cost']).toBe(0);
+  });
+
+  test('removing a lord resets removed-is-lord flag', async ({ request }) => {
+    const draft = await createDraft(request, LAND_BATTLE_MODE_EID);
+    const { body: addBody } = await addUnit(request, draft.eid, ARCH_LECTOR_EID, 'main');
+
+    const res = await request.delete(
+      `${BASE}/api/draft/${draft.eid}/entry/${addBody['new-unit']['entry-eid']}?section=main`,
+      { headers: HEADERS }
+    );
+    const body = await res.json();
+
+    expect(body['removed-is-lord']).toBe(true);
+  });
+
+  test('lord cap rejects second lord with 422', async ({ request }) => {
+    const draft = await createDraft(request, LAND_BATTLE_MODE_EID);
+    await addUnit(request, draft.eid, ARCH_LECTOR_EID, 'main');
+    const { status, body } = await addUnit(request, draft.eid, GENERAL_EID, 'main');
+
+    expect(status).toBe(422);
+    expect(body.type).toBe('draft/add-error');
+    expect(body.message).toMatch(/lord/i);
+  });
+
+  test('per-unit cap rejects 5th copy with 422', async ({ request }) => {
+    const draft = await createDraft(request, LAND_BATTLE_MODE_EID);
+    for (let i = 0; i < 4; i++) {
+      const { status } = await addUnit(request, draft.eid, SWORDSMEN_EID, 'main');
+      expect(status).toBe(200);
+    }
+
+    const { status, body } = await addUnit(request, draft.eid, SWORDSMEN_EID, 'main');
+    expect(status).toBe(422);
+    expect(body.type).toBe('draft/add-error');
+    expect(body.message).toMatch(/4 copies/i);
+  });
+
+  test('budget accumulates across multiple units', async ({ request }) => {
+    const draft = await createDraft(request, LAND_BATTLE_MODE_EID);
+
+    const { body: first } = await addUnit(request, draft.eid, ARCH_LECTOR_EID, 'main');
+    expect(first.budget['section-cost']).toBe(550);
+
+    const { body: second } = await addUnit(request, draft.eid, SWORDSMEN_EID, 'main');
+    expect(second.budget['section-cost']).toBe(550 + 375);
+
+    const { body: third } = await addUnit(request, draft.eid, SWORDSMEN_EID, 'main');
+    expect(third.budget['section-cost']).toBe(550 + 375 + 375);
+  });
+});

--- a/components/e2e/tests/draft-operations.spec.js
+++ b/components/e2e/tests/draft-operations.spec.js
@@ -1,0 +1,185 @@
+const { test, expect } = require('@playwright/test');
+
+const GAME_EID = 'eea787d7-1065-45eb-a3f6-e26f32c294a1';
+const EMPIRE_FACTION_EID = '35dd38fa-2bcc-4492-8f58-a106d0d02cbb';
+const DOMINATION_MODE_EID = 'a1b2c3d4-0002-4000-8000-000000000002';
+const LAND_BATTLE_MODE_EID = 'a1b2c3d4-0001-4000-8000-000000000001';
+
+function addDevCookie(context) {
+  return context.addCookies([
+    {
+      name: 'dev_impersonation',
+      value: 'dev-admin',
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+async function createDraft(page, gameModeEid) {
+  await page.goto(`/view/game/${GAME_EID}/draft/create.html`);
+  await page.locator('#faction-eid').selectOption(EMPIRE_FACTION_EID);
+  await page.locator('#game-mode-eid').selectOption(gameModeEid);
+
+  await page.locator('#create-draft-form button[type="submit"]').click();
+  await expect(page.locator('.draft-page')).toBeVisible({ timeout: 10000 });
+}
+
+async function selectUnit(page, name) {
+  const card = page.locator(`.draft-unit-card[aria-label*="${name}"]`).first();
+  await card.click();
+  await expect(page.locator('#draft-unit .draft-stats-name')).toContainText(name, { timeout: 5000 });
+}
+
+async function clickAddToMain(page) {
+  const btn = page.locator('.draft-add-btn:not(.draft-add-btn--reinf)');
+  await btn.click();
+  await expect(btn).not.toHaveClass(/htmx-request/, { timeout: 10000 });
+}
+
+async function clickAddToReinforcements(page) {
+  const btn = page.locator('.draft-add-btn--reinf');
+  await btn.click();
+  await expect(btn).not.toHaveClass(/htmx-request/, { timeout: 10000 });
+}
+
+test.describe.serial('Draft unit operations', () => {
+  test.beforeEach(async ({ context }) => {
+    await addDevCookie(context);
+  });
+
+  test('select a unit from the roster', async ({ page }) => {
+    await createDraft(page, DOMINATION_MODE_EID);
+
+    const card = page.locator('.draft-unit-card').first();
+    await card.click();
+
+    await expect(page.locator('#draft-unit')).toBeVisible();
+    await expect(page.locator('#draft-unit')).not.toHaveAttribute('hidden', '');
+    await expect(page.locator('.draft-stats-name')).toBeVisible();
+  });
+
+  test('add a lord to the main army section', async ({ page }) => {
+    await createDraft(page, LAND_BATTLE_MODE_EID);
+
+    const lordSlot = page.locator('#main-army-section-lord-slot');
+    await expect(lordSlot).toHaveAttribute('aria-label', /empty/i);
+
+    await selectUnit(page, 'Arch Lector');
+    await clickAddToMain(page);
+
+    await expect(lordSlot).toHaveAttribute('aria-label', /Arch Lector/i, { timeout: 5000 });
+  });
+
+  test('add an infantry unit to the main army section', async ({ page }) => {
+    await createDraft(page, LAND_BATTLE_MODE_EID);
+
+    const mainSlots = page.locator('#main-army-section-slots');
+    await expect(mainSlots.locator('.draft-slot--filled')).toHaveCount(0);
+
+    await selectUnit(page, 'Swordsmen');
+    await clickAddToMain(page);
+
+    await expect(mainSlots.locator('.draft-slot--filled')).toHaveCount(1, { timeout: 5000 });
+  });
+
+  test('add a unit to the reinforcements section', async ({ page }) => {
+    await createDraft(page, DOMINATION_MODE_EID);
+
+    await expect(page.locator('#reinforcements-section')).toBeVisible();
+
+    await selectUnit(page, 'Swordsmen');
+    await clickAddToReinforcements(page);
+
+    const reinfSlots = page.locator('#reinforcements-section-slots');
+    await expect(reinfSlots.locator('.draft-slot--filled')).toHaveCount(1, { timeout: 5000 });
+  });
+
+  test('update a placed unit selections', async ({ page }) => {
+    await createDraft(page, LAND_BATTLE_MODE_EID);
+
+    await selectUnit(page, 'Balthasar Gelt');
+    await clickAddToMain(page);
+
+    const lordSlot = page.locator('#main-army-section-lord-slot');
+    await expect(lordSlot).toHaveAttribute('aria-label', /Balthasar Gelt/i, { timeout: 5000 });
+
+    await lordSlot.locator('.draft-slot-card-button').click();
+    await expect(page.locator('.draft-editing-hint')).toBeVisible({ timeout: 5000 });
+
+    const checkbox = page.locator('.draft-spell-check, .draft-ability-check, .draft-item-check').first();
+    if (await checkbox.count() > 0) {
+      const costBefore = await lordSlot.locator('.draft-slot-cost').textContent();
+      await checkbox.check();
+      await page.waitForTimeout(800);
+
+      const costAfter = await lordSlot.locator('.draft-slot-cost').textContent();
+      expect(costAfter).not.toBe(costBefore);
+    }
+  });
+
+  test('remove a unit from the draft', async ({ page }) => {
+    await createDraft(page, LAND_BATTLE_MODE_EID);
+
+    await selectUnit(page, 'Swordsmen');
+    await clickAddToMain(page);
+
+    const mainSlots = page.locator('#main-army-section-slots');
+    await expect(mainSlots.locator('.draft-slot--filled')).toHaveCount(1, { timeout: 5000 });
+
+    const slot = mainSlots.locator('.draft-slot--filled').first();
+    await slot.hover();
+    await slot.locator('.draft-slot-remove').click();
+    await expect(mainSlots.locator('.draft-slot--filled')).toHaveCount(0, { timeout: 5000 });
+  });
+
+  test('lord cap prevents adding a second lord', async ({ page }) => {
+    await createDraft(page, LAND_BATTLE_MODE_EID);
+
+    await selectUnit(page, 'Arch Lector');
+    await clickAddToMain(page);
+
+    const lordSlot = page.locator('#main-army-section-lord-slot');
+    await expect(lordSlot).toHaveAttribute('aria-label', /Arch Lector/i, { timeout: 5000 });
+
+    await selectUnit(page, 'General of the Empire');
+    await clickAddToMain(page);
+
+    const errorAlert = page.locator('#draft-action-error');
+    await expect(errorAlert).toBeVisible({ timeout: 5000 });
+    await expect(errorAlert).toContainText(/lord/i);
+  });
+
+  test('per-unit cap prevents adding more than 4 copies', async ({ page }) => {
+    await createDraft(page, LAND_BATTLE_MODE_EID);
+
+    for (let i = 0; i < 4; i++) {
+      await selectUnit(page, 'Swordsmen');
+      await clickAddToMain(page);
+    }
+
+    const mainSlots = page.locator('#main-army-section-slots');
+    await expect(mainSlots.locator('.draft-slot--filled')).toHaveCount(4, { timeout: 5000 });
+
+    await selectUnit(page, 'Swordsmen');
+    await clickAddToMain(page);
+
+    const errorAlert = page.locator('#draft-action-error');
+    await expect(errorAlert).toBeVisible({ timeout: 5000 });
+    await expect(errorAlert).toContainText(/4 copies/i);
+  });
+
+  test('budget updates reflect added unit costs', async ({ page }) => {
+    await createDraft(page, LAND_BATTLE_MODE_EID);
+
+    const budgetUsed = page.locator('#main-army-section-budget .draft-budget-used');
+    await expect(budgetUsed).toHaveText('0');
+
+    await selectUnit(page, 'Swordsmen');
+    await clickAddToMain(page);
+
+    await expect(budgetUsed).not.toHaveText('0', { timeout: 5000 });
+  });
+});

--- a/components/e2e/tests/draft.spec.js
+++ b/components/e2e/tests/draft.spec.js
@@ -1,0 +1,52 @@
+const { test, expect } = require('@playwright/test');
+
+const GAME_EID = 'eea787d7-1065-45eb-a3f6-e26f32c294a1';
+
+test.describe('Authenticated draft flows', () => {
+  test.beforeEach(async ({ context }) => {
+    await context.addCookies([
+      {
+        name: 'dev_impersonation',
+        value: 'dev-admin',
+        domain: 'localhost',
+        path: '/',
+        httpOnly: true,
+        sameSite: 'Lax',
+      },
+    ]);
+  });
+
+  test('navbar shows user name when authenticated', async ({ page }) => {
+    await page.goto(`/view/game/${GAME_EID}/index.html`);
+    await expect(page.locator('button[aria-label*="Account menu"]')).toBeVisible();
+  });
+
+  test('my drafts link appears in game context', async ({ page }) => {
+    await page.goto(`/view/game/${GAME_EID}/index.html`);
+    const myDraftsLink = page.locator('a[href*="/draft/me.html"]');
+    await expect(myDraftsLink).toBeVisible();
+  });
+
+  test('my drafts page loads', async ({ page }) => {
+    await page.goto(`/view/game/${GAME_EID}/draft/me.html`);
+    await expect(page).toHaveTitle(/Drafts/);
+    await expect(page.locator('main#content')).toBeVisible();
+  });
+
+  test('create draft page loads with form', async ({ page }) => {
+    await page.goto(`/view/game/${GAME_EID}/draft/create.html`);
+    await expect(page).toHaveTitle(/Create.*Draft/i);
+    await expect(page.locator('main#content')).toBeVisible();
+  });
+
+  test('account dropdown shows logout option', async ({ page }) => {
+    await page.goto(`/view/game/${GAME_EID}/index.html`);
+
+    const accountButton = page.locator('button[aria-label*="Account menu"]');
+    await accountButton.click();
+
+    const profileMenu = page.locator('#profile-menu');
+    await expect(profileMenu).toBeVisible();
+    await expect(profileMenu.locator('a[href="/view/logout.html"]')).toBeVisible();
+  });
+});

--- a/components/e2e/tests/game-browsing.spec.js
+++ b/components/e2e/tests/game-browsing.spec.js
@@ -1,0 +1,50 @@
+const { test, expect } = require('@playwright/test');
+
+const GAME_EID = 'eea787d7-1065-45eb-a3f6-e26f32c294a1';
+const EMPIRE_FACTION_EID = '35dd38fa-2bcc-4492-8f58-a106d0d02cbb';
+
+test.describe('Game browsing', () => {
+  test('game index page loads with factions', async ({ page }) => {
+    await page.goto(`/view/game/${GAME_EID}/index.html`);
+    await expect(page).toHaveTitle(/Warhammer III/);
+    await expect(page.locator('main#content')).toBeVisible();
+    await expect(page.locator('#factions-dropdown-btn')).toBeVisible();
+  });
+
+  test('faction page loads with units', async ({ page }) => {
+    await page.goto(`/view/game/${GAME_EID}/faction/${EMPIRE_FACTION_EID}/index.html`);
+    await expect(page).toHaveTitle(/The Empire/);
+    await expect(page.locator('main#content')).toBeVisible();
+  });
+
+  test('factions dropdown populates after selecting a game', async ({ page }) => {
+    await page.goto(`/view/game/${GAME_EID}/index.html`);
+
+    const factionsButton = page.locator('#factions-dropdown-btn');
+    await expect(factionsButton).toBeVisible();
+    await factionsButton.click();
+
+    const factionsMenu = page.locator('#factions-menu');
+    await expect(factionsMenu).toBeVisible();
+
+    const factionLinks = factionsMenu.locator('a.dropdown-item');
+    const count = await factionLinks.count();
+    expect(count).toBeGreaterThan(0);
+
+    await expect(factionLinks.first()).toBeVisible();
+  });
+
+  test('clicking a faction link navigates to faction page', async ({ page }) => {
+    await page.goto(`/view/game/${GAME_EID}/index.html`);
+
+    const factionsButton = page.locator('#factions-dropdown-btn');
+    await factionsButton.click();
+
+    const firstFaction = page.locator('#factions-menu a.dropdown-item').first();
+    const factionName = await firstFaction.textContent();
+    await firstFaction.click();
+
+    await expect(page.locator('main#content')).toBeVisible();
+    await expect(page).toHaveTitle(new RegExp(factionName.trim()));
+  });
+});

--- a/components/e2e/tests/navigation.spec.js
+++ b/components/e2e/tests/navigation.spec.js
@@ -1,0 +1,44 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Static page navigation', () => {
+  test('dashboard loads', async ({ page }) => {
+    await page.goto('/view/dashboard.html');
+    await expect(page).toHaveTitle(/RTS/);
+    await expect(page.locator('nav.navbar')).toBeVisible();
+    await expect(page.locator('main#content')).toBeVisible();
+  });
+
+  test('about page loads', async ({ page }) => {
+    await page.goto('/view/about.html');
+    await expect(page).toHaveTitle(/About/);
+    await expect(page.locator('main#content')).toBeVisible();
+  });
+
+  test('contact page loads', async ({ page }) => {
+    await page.goto('/view/contact.html');
+    await expect(page).toHaveTitle(/Contact/);
+    await expect(page.locator('main#content')).toBeVisible();
+  });
+
+  test('root redirects to dashboard', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/view\/dashboard\.html/);
+  });
+
+  test('games dropdown opens and contains game links', async ({ page }) => {
+    await page.goto('/view/dashboard.html');
+    const gamesButton = page.locator('button', { hasText: 'Games' });
+    await expect(gamesButton).toBeVisible();
+
+    await gamesButton.click();
+    const gameMenu = page.locator('#game-menu');
+    await expect(gameMenu).toBeVisible();
+    await expect(gameMenu.locator('a.dropdown-item')).toHaveCount(1);
+    await expect(gameMenu.locator('a.dropdown-item')).toContainText('Total War: Warhammer III');
+  });
+
+  test('navbar shows account menu for dev user', async ({ page }) => {
+    await page.goto('/view/dashboard.html');
+    await expect(page.locator('button[aria-label*="Account menu"]')).toBeVisible();
+  });
+});

--- a/components/rts-web/src/com/devereux_henley/rts_web/contract.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/contract.clj
@@ -7,6 +7,8 @@
    [com.devereux-henley.rts-web.web.view]))
 
 (def root-route web.routes/root-route)
+(def status-route web.routes/status-route)
+(def shutdown-route web.routes/shutdown-route)
 (def icon-routes web.routes/icon-routes)
 (def view-routes web.routes/view-routes)
 (def api-routes web.routes/api-routes)

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -16,6 +16,25 @@
           :produces ["text/html"]
           :handler  (fn [_request] {:status 301 :headers {"Location" "/view/dashboard.html"}})}}])
 
+(def status-route
+  ["/status"
+   {:get {:no-doc  true
+          :handler (fn [_request]
+                     {:status 200
+                      :headers {"Content-Type" "application/json"}
+                      :body    "{\"status\":\"ok\"}"})}}])
+
+(def shutdown-route
+  ["/shutdown"
+   {:post {:no-doc  true
+           :handler (fn [_request]
+                      (.start (Thread. (fn []
+                                         (Thread/sleep 100)
+                                         (System/exit 0))))
+                      {:status 200
+                       :headers {"Content-Type" "application/json"}
+                       :body    "{\"status\":\"shutting-down\"}"})}}])
+
 (def icon-routes
   ["/icon/social-media/:eid"
    {:get {:no-doc     true

--- a/deps.edn
+++ b/deps.edn
@@ -20,6 +20,7 @@
                                  "components/rts-data"
                                  "components/rts-data-access"
                                  "components/rts-domain"
+                                 "components/e2e"
                                  "bases/rts-api"]}
 
             :poly {:main-opts ["-m" "polylith.clj.core.poly-cli.core"]

--- a/projects/api/deps.edn
+++ b/projects/api/deps.edn
@@ -9,6 +9,7 @@
         mono/rts-domain              {:local/root "../../components/rts-domain"}
         mono/rts-web                 {:local/root "../../components/rts-web"}
         mono/schema                  {:local/root "../../components/schema"}
+        mono/e2e                     {:local/root "../../components/e2e"}
         mono/rts-api                 {:local/root "../../bases/rts-api"}}
  :aliases {:build {:extra-paths ["."]
                    :extra-deps  {org.clojure/tools.build {:mvn/version "0.9.4"}}

--- a/workspace.edn
+++ b/workspace.edn
@@ -7,6 +7,6 @@
  :tag-patterns {:stable "stable-*"
                 :release "v[0-9]*"}
  :projects {"development"  {:alias "dev"}
-            "api"          {:alias "api"}
+            "api"          {:alias "api" :necessary ["e2e"]}
             "deploy-data"  {:alias "deploy-data"}
             "rpfm-scraper" {:alias "rpfm-scraper"}}}


### PR DESCRIPTION
Adds an e2e Polylith component with 37 Playwright specs covering static page navigation, game/faction browsing, authenticated draft UI flows (create, add/update/remove units, lord and per-unit cap validation), and HAL+JSON API-level draft operations. A Clojure test runner shells out to Playwright and fails hard in CI (via the CI env var) if prerequisites are missing, while skipping gracefully for local dev. Adds /status and /shutdown (dev-only) endpoints for server readiness checks and programmatic teardown. Both GitHub Actions workflows install Node.js + Playwright, start the dev server, and POST /shutdown after tests.