### PR TITLE
Merge view and API dependencies, split configuration by namespace

### DIFF
--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -21,6 +21,11 @@
 (def default-dependencies {:hostname   hostname
                            :connection (integrant.core/ref ::db/connection)})
 
+(defn- handlers
+  "Maps each Integrant key to default-dependencies."
+  [& keys]
+  (zipmap keys (repeat default-dependencies)))
+
 ;;; ─── Per-namespace handler configuration ───────────────────────────────────
 
 (def infrastructure-configuration
@@ -35,36 +40,46 @@
     :com.devereux-henley.rts-web.web.configuration/auth-hostname auth-hostname}})
 
 (def view-configuration
-  {:com.devereux-henley.rts-web.web.view/dashboard-view          default-dependencies
-   :com.devereux-henley.rts-web.web.view/game-view               default-dependencies
-   :com.devereux-henley.rts-web.web.view/about-view              default-dependencies
-   :com.devereux-henley.rts-web.web.view/contact-view            default-dependencies
-   :com.devereux-henley.rts-web.web.view/login-view              {:auth-hostname auth-hostname}
-   :com.devereux-henley.rts-web.web.view/logout-view             {:auth-hostname auth-hostname}
-   :com.devereux-henley.rts-web.web.view/game-context-middleware default-dependencies
-   :com.devereux-henley.rts-web.web.view/game-index-view         default-dependencies
-   :com.devereux-henley.rts-web.web.view/faction-view            default-dependencies
-   :com.devereux-henley.rts-web.web.view/unit-view               default-dependencies
-   :com.devereux-henley.rts-web.web.view/draft-view              default-dependencies
-   :com.devereux-henley.rts-web.web.view/my-drafts-view          default-dependencies
-   :com.devereux-henley.rts-web.web.view/create-draft-view       default-dependencies})
+  (merge
+   (handlers :com.devereux-henley.rts-web.web.view/dashboard-view
+             :com.devereux-henley.rts-web.web.view/game-view
+             :com.devereux-henley.rts-web.web.view/about-view
+             :com.devereux-henley.rts-web.web.view/contact-view
+             :com.devereux-henley.rts-web.web.view/game-context-middleware
+             :com.devereux-henley.rts-web.web.view/game-index-view
+             :com.devereux-henley.rts-web.web.view/faction-view
+             :com.devereux-henley.rts-web.web.view/unit-view
+             :com.devereux-henley.rts-web.web.view/draft-view
+             :com.devereux-henley.rts-web.web.view/my-drafts-view
+             :com.devereux-henley.rts-web.web.view/create-draft-view)
+   {:com.devereux-henley.rts-web.web.view/login-view  {:auth-hostname auth-hostname}
+    :com.devereux-henley.rts-web.web.view/logout-view {:auth-hostname auth-hostname}}))
 
 (def game-configuration
-  {:com.devereux-henley.rts-web.web.game/get-game                default-dependencies
-   :com.devereux-henley.rts-web.web.game/get-games               default-dependencies
-   :com.devereux-henley.rts-web.web.game/get-faction             default-dependencies
-   :com.devereux-henley.rts-web.web.game/get-game-social-link    default-dependencies
-   :com.devereux-henley.rts-web.web.game/create-draft            default-dependencies})
+  (handlers :com.devereux-henley.rts-web.web.game/get-game
+            :com.devereux-henley.rts-web.web.game/get-games
+            :com.devereux-henley.rts-web.web.game/get-faction
+            :com.devereux-henley.rts-web.web.game/get-game-social-link))
 
 (def draft-configuration
-  {:com.devereux-henley.rts-web.web.draft/get-draft-unit         default-dependencies
-   :com.devereux-henley.rts-web.web.draft/get-draft-entry        default-dependencies
-   :com.devereux-henley.rts-web.web.draft/draft-add-unit         default-dependencies
-   :com.devereux-henley.rts-web.web.draft/draft-update-unit      default-dependencies
-   :com.devereux-henley.rts-web.web.draft/draft-remove-unit      default-dependencies})
+  (handlers :com.devereux-henley.rts-web.web.draft/get-draft-unit
+            :com.devereux-henley.rts-web.web.draft/get-draft-entry
+            :com.devereux-henley.rts-web.web.draft/draft-add-unit
+            :com.devereux-henley.rts-web.web.draft/draft-update-unit
+            :com.devereux-henley.rts-web.web.draft/draft-remove-unit
+            :com.devereux-henley.rts-web.web.game/create-draft))
 
 (def social-media-configuration
-  {:com.devereux-henley.rts-web.web.social-media/get-platform    default-dependencies})
+  (handlers :com.devereux-henley.rts-web.web.social-media/get-platform))
+
+;;; ─── Routes ────────────────────────────────────────────────────────────────
+
+(def base-routes
+  [rts-web/root-route
+   rts-web/status-route
+   rts-web/icon-routes
+   rts-web/view-routes
+   rts-web/api-routes])
 
 ;;; ─── Assembled system maps ─────────────────────────────────────────────────
 
@@ -86,11 +101,7 @@
           :session-name  session-name}
 
          :com.devereux-henley.rts-web.web.routes/routes
-         [rts-web/root-route
-          rts-web/status-route
-          rts-web/icon-routes
-          rts-web/view-routes
-          rts-web/api-routes]
+         base-routes
 
          ::web/app
          {:routes          (integrant.core/ref :com.devereux-henley.rts-web.web.routes/routes)
@@ -110,13 +121,7 @@
          ::dev-auth/list-users-handler       {:users (integrant.core/ref ::dev-auth/users)}
 
          :com.devereux-henley.rts-web.web.routes/routes
-         [rts-web/root-route
-          rts-web/status-route
-          rts-web/shutdown-route
-          rts-web/icon-routes
-          rts-web/view-routes
-          rts-web/api-routes
-          dev-auth/routes]
+         (into base-routes [rts-web/shutdown-route dev-auth/routes])
 
          ::web/app
          {:routes          (integrant.core/ref :com.devereux-henley.rts-web.web.routes/routes)

--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -18,46 +18,65 @@
 (def hostname (or (System/getenv "RTS_API_HOSTNAME") "http://localhost:3001"))
 (def auth-hostname (or (System/getenv "AUTH_HOSTNAME") "http://localhost:4000"))
 (def session-name (str "ory_session_" (or (System/getenv "AUTH_SLUG") "eloquentyalowwhtijq6my4")))
-(def default-api-dependencies {:hostname   hostname
-                               :connection (integrant.core/ref ::db/connection)})
-(def default-view-dependencies {})
+(def default-dependencies {:hostname   hostname
+                           :connection (integrant.core/ref ::db/connection)})
+
+;;; ─── Per-namespace handler configuration ───────────────────────────────────
+
+(def infrastructure-configuration
+  {::rts-data/migrate   {:db-spec       db/db-spec
+                         :migration-dir rts-data/migration-dir}
+   ::db/connection      {:migrations (integrant.core/ref ::rts-data/migrate)}
+   ::web/openapi-handler {}
+   ::web/service        {:handler       (integrant.core/ref ::web/app)
+                         :configuration {:port port, :join? false}}
+   :com.devereux-henley.rts-web.web.configuration/configuration
+   {:com.devereux-henley.rts-web.web.configuration/openid-url    (str auth-hostname "/" ".well-known/openid-configuration")
+    :com.devereux-henley.rts-web.web.configuration/auth-hostname auth-hostname}})
+
+(def view-configuration
+  {:com.devereux-henley.rts-web.web.view/dashboard-view          default-dependencies
+   :com.devereux-henley.rts-web.web.view/game-view               default-dependencies
+   :com.devereux-henley.rts-web.web.view/about-view              default-dependencies
+   :com.devereux-henley.rts-web.web.view/contact-view            default-dependencies
+   :com.devereux-henley.rts-web.web.view/login-view              {:auth-hostname auth-hostname}
+   :com.devereux-henley.rts-web.web.view/logout-view             {:auth-hostname auth-hostname}
+   :com.devereux-henley.rts-web.web.view/game-context-middleware default-dependencies
+   :com.devereux-henley.rts-web.web.view/game-index-view         default-dependencies
+   :com.devereux-henley.rts-web.web.view/faction-view            default-dependencies
+   :com.devereux-henley.rts-web.web.view/unit-view               default-dependencies
+   :com.devereux-henley.rts-web.web.view/draft-view              default-dependencies
+   :com.devereux-henley.rts-web.web.view/my-drafts-view          default-dependencies
+   :com.devereux-henley.rts-web.web.view/create-draft-view       default-dependencies})
+
+(def game-configuration
+  {:com.devereux-henley.rts-web.web.game/get-game                default-dependencies
+   :com.devereux-henley.rts-web.web.game/get-games               default-dependencies
+   :com.devereux-henley.rts-web.web.game/get-faction             default-dependencies
+   :com.devereux-henley.rts-web.web.game/get-game-social-link    default-dependencies
+   :com.devereux-henley.rts-web.web.game/create-draft            default-dependencies})
+
+(def draft-configuration
+  {:com.devereux-henley.rts-web.web.draft/get-draft-unit         default-dependencies
+   :com.devereux-henley.rts-web.web.draft/get-draft-entry        default-dependencies
+   :com.devereux-henley.rts-web.web.draft/draft-add-unit         default-dependencies
+   :com.devereux-henley.rts-web.web.draft/draft-update-unit      default-dependencies
+   :com.devereux-henley.rts-web.web.draft/draft-remove-unit      default-dependencies})
+
+(def social-media-configuration
+  {:com.devereux-henley.rts-web.web.social-media/get-platform    default-dependencies})
+
+;;; ─── Assembled system maps ─────────────────────────────────────────────────
 
 (def base-configuration
   "Shared integrant wiring used by every profile. Auth middleware and the
    `::web/app` entry point are contributed by the individual profiles so they
    can swap Ory for a dev stub without copy-pasting the rest of the system."
-  {::rts-data/migrate                                                     {:db-spec       db/db-spec
-                                                                           :migration-dir rts-data/migration-dir}
-   ::db/connection                                                        {:migrations (integrant.core/ref ::rts-data/migrate)}
-   ::web/openapi-handler                                                  {}
-   :com.devereux-henley.rts-web.web.view/dashboard-view                   default-view-dependencies
-   :com.devereux-henley.rts-web.web.view/game-view                        default-view-dependencies
-   :com.devereux-henley.rts-web.web.view/about-view                       default-view-dependencies
-   :com.devereux-henley.rts-web.web.view/contact-view                     default-view-dependencies
-   :com.devereux-henley.rts-web.web.view/login-view                       {:auth-hostname auth-hostname}
-   :com.devereux-henley.rts-web.web.view/logout-view                      {:auth-hostname auth-hostname}
-   :com.devereux-henley.rts-web.web.view/game-context-middleware          default-api-dependencies
-   :com.devereux-henley.rts-web.web.view/faction-view                     default-api-dependencies
-   :com.devereux-henley.rts-web.web.view/unit-view                        default-api-dependencies
-   :com.devereux-henley.rts-web.web.view/draft-view                       default-api-dependencies
-   :com.devereux-henley.rts-web.web.draft/get-draft-unit                  default-api-dependencies
-   :com.devereux-henley.rts-web.web.draft/get-draft-entry                 default-api-dependencies
-   :com.devereux-henley.rts-web.web.draft/draft-add-unit                  default-api-dependencies
-   :com.devereux-henley.rts-web.web.draft/draft-update-unit               default-api-dependencies
-   :com.devereux-henley.rts-web.web.draft/draft-remove-unit               default-api-dependencies
-   :com.devereux-henley.rts-web.web.view/my-drafts-view                   default-api-dependencies
-   :com.devereux-henley.rts-web.web.view/game-index-view                  default-view-dependencies
-   :com.devereux-henley.rts-web.web.view/create-draft-view                default-api-dependencies
-   :com.devereux-henley.rts-web.web.game/get-game                         default-api-dependencies
-   :com.devereux-henley.rts-web.web.game/get-games                        default-api-dependencies
-   :com.devereux-henley.rts-web.web.game/get-faction                      default-api-dependencies
-   :com.devereux-henley.rts-web.web.game/get-game-social-link             default-api-dependencies
-   :com.devereux-henley.rts-web.web.social-media/get-platform             default-api-dependencies
-   :com.devereux-henley.rts-web.web.game/create-draft                     default-api-dependencies
-   :com.devereux-henley.rts-web.web.configuration/configuration           {:com.devereux-henley.rts-web.web.configuration/openid-url    (str auth-hostname "/" ".well-known/openid-configuration")
-                                                                           :com.devereux-henley.rts-web.web.configuration/auth-hostname auth-hostname}
-   ::web/service                                                          {:handler       (integrant.core/ref ::web/app)
-                                                                           :configuration {:port port, :join? false}}})
+  (merge infrastructure-configuration
+         view-configuration
+         game-configuration
+         draft-configuration
+         social-media-configuration))
 
 (def core-configuration
   "Production profile. Uses Ory for authentication."

--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -67,7 +67,7 @@
             :com.devereux-henley.rts-web.web.draft/draft-add-unit
             :com.devereux-henley.rts-web.web.draft/draft-update-unit
             :com.devereux-henley.rts-web.web.draft/draft-remove-unit
-            :com.devereux-henley.rts-web.web.game/create-draft))
+            :com.devereux-henley.rts-web.web.draft/create-draft))
 
 (def social-media-configuration
   (handlers :com.devereux-henley.rts-web.web.social-media/get-platform))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/draft.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/draft.clj
@@ -15,6 +15,27 @@
   [embed]
   (some-> embed (as-> e (set (map keyword (if (string? e) [e] e))))))
 
+(defmethod integrant.core/init-key ::create-draft
+  [_init-key dependencies]
+  (fn [{{{:keys [faction-eid game-mode-eid game-eid]} :body
+         {:keys [version]}                            :query
+         {:keys [eid]}                                :path} :parameters
+        router                                                :reitit.core/router
+        session                                               :ory-session
+        :as                                                   _request}]
+    (let [response (web.core/handle-create-response
+                    domain/draft-resource
+                    {:hostname (:hostname dependencies) :router router}
+                    #(domain/create-draft
+                      dependencies
+                      {:faction-eid    faction-eid
+                       :game-mode-eid  game-mode-eid
+                       :player-sub     (get-in session [:identity :id])
+                       :created-by-sub (get-in session [:identity :id])
+                       :eid            eid
+                       :version        version}))]
+      (assoc-in response [:headers "HX-Redirect"] (str "/view/game/" game-eid "/draft/" eid "/index.html")))))
+
 (defmethod integrant.core/init-key ::get-draft-unit
   [_init-key dependencies]
   (fn [{{{:keys [draft-eid eid]} :path} :parameters

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/game.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/game.clj
@@ -61,10 +61,6 @@
   (or (domain/get-draft-by-eid dependencies eid)
       {:type :missing/resource :name "draft" :id eid}))
 
-(defn create-draft
-  [dependencies create-specification]
-  (domain/create-draft dependencies create-specification))
-
 (defn get-unit-by-eid
   [dependencies eid]
   (or (domain/get-unit-by-eid dependencies eid)
@@ -129,26 +125,6 @@
        {:hostname (:hostname dependencies) :router router}
        #(web.core/apply-embeds game-embed-registry dependencies embed-set
                                (get-game-by-eid dependencies eid))))))
-
-(defmethod integrant.core/init-key ::create-draft
-  [_init-key dependencies]
-  (fn [{{{:keys [faction-eid game-mode-eid game-eid]} :body
-         {:keys [version]}                            :query
-         {:keys [eid]}                                :path} :parameters
-        router                                                :reitit.core/router
-        session                                               :ory-session
-        :as                                                   _request}]
-    (let [response (web.core/handle-create-response
-                    domain/draft-resource
-                    {:hostname (:hostname dependencies) :router router}
-                    #(create-draft dependencies
-                                   {:faction-eid    faction-eid
-                                    :game-mode-eid  game-mode-eid
-                                    :player-sub     (get-in session [:identity :id])
-                                    :created-by-sub (get-in session [:identity :id])
-                                    :eid            eid
-                                    :version        version}))]
-      (assoc-in response [:headers "HX-Redirect"] (str "/view/game/" game-eid "/draft/" eid "/index.html")))))
 
 (defmethod integrant.core/init-key ::get-games
   [_init-key dependencies]

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -235,7 +235,7 @@
                          :query schema.contract/version-query-parameter
                          :body  domain/create-draft-specification}
             :responses  {201 {:body domain/draft-resource}}
-            :handler    (integrant.core/ref ::web.game/create-draft)}}]
+            :handler    (integrant.core/ref ::web.draft/create-draft)}}]
 
    ["/social-media/:eid"
     {:name :social-media/by-eid


### PR DESCRIPTION
## Summary

- Removes the separate `default-view-dependencies` (empty map) and `default-api-dependencies`, replacing them with a single `default-dependencies`
- Splits the flat `base-configuration` map into per-namespace maps (`infrastructure-configuration`, `view-configuration`, `game-configuration`, `draft-configuration`, `social-media-configuration`) merged together via `(merge ...)`
- Adding a new handler namespace is now just one more map in the merge

## Test plan

- [x] `clojure -M:poly check` passes
- [x] `clojure -M:poly test :all` — 148 assertions, 0 failures across both projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)