### PR TITLE
Remove push-to-main trigger from PR check workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -3,8 +3,6 @@ name: PR Check
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 jobs:
   check:


### PR DESCRIPTION
## Summary

- Removes the `push: branches: [main]` trigger from pr-check.yml
- PR check now only runs on pull requests targeting main, not on the merge commits themselves
- Post-merge coverage is already handled by the tag-stable workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)