### PR TITLE
Add Tournaments nav link and reserve draft reinforcements space

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ clj-nrepl-eval -p 7888 "(claude-workspace/halt!)"
 
 This is faster than `clojure -M:dev -i start_dev_server.clj` because it supports incremental reloading (`restart!`) without a full JVM restart, and gives Claude a REPL for debugging.
 
+**When to kill the nREPL process:** Only kill and restart the nREPL when ending a Claude session, switching branches, or after changing migrations/seed data. For normal code changes, `(claude-workspace/restart!)` is sufficient — it reloads all namespaces without a JVM restart.
+
 **Running a specific test namespace:**
 
 ```bash

--- a/components/rts-web/resources/rts-web/asset/style/app.css
+++ b/components/rts-web/resources/rts-web/asset/style/app.css
@@ -540,7 +540,7 @@ a:hover:has(img) {
   flex-wrap: wrap;
   gap: var(--space-1);
   padding: var(--space-2) var(--space-4);
-  min-height: 146px;
+  min-height: calc(130px + var(--space-2) * 2);
 }
 
 .draft-slot {

--- a/components/rts-web/resources/rts-web/asset/style/app.css
+++ b/components/rts-web/resources/rts-web/asset/style/app.css
@@ -540,6 +540,7 @@ a:hover:has(img) {
   flex-wrap: wrap;
   gap: var(--space-1);
   padding: var(--space-2) var(--space-4);
+  min-height: var(--space-16);
 }
 
 .draft-slot {

--- a/components/rts-web/resources/rts-web/asset/style/app.css
+++ b/components/rts-web/resources/rts-web/asset/style/app.css
@@ -540,7 +540,7 @@ a:hover:has(img) {
   flex-wrap: wrap;
   gap: var(--space-1);
   padding: var(--space-2) var(--space-4);
-  min-height: var(--space-16);
+  min-height: 146px;
 }
 
 .draft-slot {

--- a/components/rts-web/resources/rts-web/template/entrypoint.html
+++ b/components/rts-web/resources/rts-web/template/entrypoint.html
@@ -88,6 +88,13 @@
                     </a>
                     {% endif %}
                 </div>
+                <div id="game-tournaments-link">
+                    {% if game-eid %}
+                    <a class="nav-item" href="/view/game/{{game-eid}}/tournament/index.html">
+                        Tournaments
+                    </a>
+                    {% endif %}
+                </div>
             </div>
             <div class="navbar-end">
                 <div id="game-socials" class="cluster cluster-2">


### PR DESCRIPTION
## Summary

- Add "Tournaments" nav link to the entrypoint navbar, visible when a game is selected (same conditional as Factions dropdown and My Drafts)
- Reserve minimum height on draft slots so the reinforcements section doesn't collapse when enabled but empty

## Screenshots

### Navbar with Tournaments link
![Navbar](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/ui-cleanup/navbar-tournaments-link.png)

### Draft with empty reinforcements section (reserved space)
![Reinforcements](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/ui-cleanup/draft-reinforcements-reserved.png)

## Test plan

- [x] `clojure -M:poly check` passes
- [x] All unit tests pass
- [x] Playwright: Tournaments link absent on dashboard, present on game pages, navigates correctly
- [x] Playwright: Domination draft shows reinforcements section with reserved space when empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)