### PR TITLE
Add match entity with CRUD and result recording (MVP 4)

### DIFF
--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -86,7 +86,7 @@
             :com.devereux-henley.rts-web.web.tournament/get-matches
             :com.devereux-henley.rts-web.web.tournament/get-match
             :com.devereux-henley.rts-web.web.tournament/create-match
-            :com.devereux-henley.rts-web.web.tournament/record-match-result
+            :com.devereux-henley.rts-web.web.tournament/update-match-result
             :com.devereux-henley.rts-web.web.view/tournament-list-view
             :com.devereux-henley.rts-web.web.view/create-tournament-view
             :com.devereux-henley.rts-web.web.view/tournament-view))

--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -83,6 +83,10 @@
             :com.devereux-henley.rts-web.web.tournament/update-status
             :com.devereux-henley.rts-web.web.tournament/get-registration
             :com.devereux-henley.rts-web.web.tournament/update-registration
+            :com.devereux-henley.rts-web.web.tournament/get-matches
+            :com.devereux-henley.rts-web.web.tournament/get-match
+            :com.devereux-henley.rts-web.web.tournament/create-match
+            :com.devereux-henley.rts-web.web.tournament/record-match-result
             :com.devereux-henley.rts-web.web.view/tournament-list-view
             :com.devereux-henley.rts-web.web.view/create-tournament-view
             :com.devereux-henley.rts-web.web.view/tournament-view))

--- a/components/e2e/tests/tournament.spec.js
+++ b/components/e2e/tests/tournament.spec.js
@@ -325,3 +325,112 @@ test.describe('Tournament Registration Subresource API', () => {
     expect((await entryRes.json()).message).toMatch(/not open/i);
   });
 });
+
+async function createActiveTournament(request) {
+  const eid = await createTournament(request);
+  await request.post(`${BASE}/api/tournament/${eid}/entry/me`, {
+    headers: headers('dev-admin'),
+  });
+  await request.post(`${BASE}/api/tournament/${eid}/entry/me`, {
+    headers: headers('dev-player-one'),
+  });
+  await request.put(`${BASE}/api/tournament/${eid}/status`, {
+    headers: headers('dev-admin'),
+    data: { status: 'active' },
+  });
+  return eid;
+}
+
+test.describe('Tournament Match API', () => {
+  test('create match returns 201 when tournament is active', async ({ request }) => {
+    const eid = await createActiveTournament(request);
+    const res = await request.post(`${BASE}/api/tournament/${eid}/match`, {
+      headers: headers('dev-admin'),
+      data: {
+        'phase-index': 0,
+        'round-index': 0,
+        'player-one-sub': 'dev-admin',
+        'player-two-sub': 'dev-player-one',
+      },
+    });
+    expect(res.status()).toBe(201);
+    const body = await res.json();
+    expect(body.type).toBe('tournament/match');
+    expect(body['player-one-sub']).toBe('dev-admin');
+    expect(body['player-two-sub']).toBe('dev-player-one');
+    expect(body.status).toBe('pending');
+  });
+
+  test('create match rejects when tournament not active', async ({ request }) => {
+    const eid = await createTournament(request);
+    const res = await request.post(`${BASE}/api/tournament/${eid}/match`, {
+      headers: headers('dev-admin'),
+      data: {
+        'phase-index': 0,
+        'round-index': 0,
+        'player-one-sub': 'dev-admin',
+        'player-two-sub': 'dev-player-one',
+      },
+    });
+    expect(res.status()).toBe(422);
+    expect((await res.json()).type).toBe('tournament/match-error');
+  });
+
+  test('list matches for tournament', async ({ request }) => {
+    const eid = await createActiveTournament(request);
+    await request.post(`${BASE}/api/tournament/${eid}/match`, {
+      headers: headers('dev-admin'),
+      data: { 'phase-index': 0, 'round-index': 0, 'player-one-sub': 'dev-admin', 'player-two-sub': 'dev-player-one' },
+    });
+    const res = await request.get(`${BASE}/api/tournament/${eid}/match`, {
+      headers: headers('dev-admin'),
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.matches).toHaveLength(1);
+  });
+
+  test('record match result updates standings', async ({ request }) => {
+    const eid = await createActiveTournament(request);
+    const createRes = await request.post(`${BASE}/api/tournament/${eid}/match`, {
+      headers: headers('dev-admin'),
+      data: { 'phase-index': 0, 'round-index': 0, 'player-one-sub': 'dev-admin', 'player-two-sub': 'dev-player-one' },
+    });
+    const matchEid = (await createRes.json()).eid;
+
+    const res = await request.put(`${BASE}/api/tournament/${eid}/match/${matchEid}/result`, {
+      headers: headers('dev-admin'),
+      data: { 'winner-sub': 'dev-admin' },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.type).toBe('tournament/match-result-recorded');
+
+    const winner = body.standings.find(s => s['player-sub'] === 'dev-admin');
+    expect(winner.wins).toBe(1);
+    expect(winner.points).toBe(3);
+
+    const loser = body.standings.find(s => s['player-sub'] === 'dev-player-one');
+    expect(loser.losses).toBe(1);
+  });
+
+  test('record result on non-pending match returns 422', async ({ request }) => {
+    const eid = await createActiveTournament(request);
+    const createRes = await request.post(`${BASE}/api/tournament/${eid}/match`, {
+      headers: headers('dev-admin'),
+      data: { 'phase-index': 0, 'round-index': 0, 'player-one-sub': 'dev-admin', 'player-two-sub': 'dev-player-one' },
+    });
+    const matchEid = (await createRes.json()).eid;
+
+    await request.put(`${BASE}/api/tournament/${eid}/match/${matchEid}/result`, {
+      headers: headers('dev-admin'),
+      data: { 'winner-sub': 'dev-admin' },
+    });
+    const res = await request.put(`${BASE}/api/tournament/${eid}/match/${matchEid}/result`, {
+      headers: headers('dev-admin'),
+      data: { 'winner-sub': 'dev-admin' },
+    });
+    expect(res.status()).toBe(422);
+    expect((await res.json()).type).toBe('tournament/match-error');
+  });
+});

--- a/components/rts-data-access/resources/rts-data-access/sql/tournament/create-match.sql
+++ b/components/rts-data-access/resources/rts-data-access/sql/tournament/create-match.sql
@@ -1,0 +1,4 @@
+INSERT INTO match (eid, tournament_id, phase_index, round_index, player_one_sub, player_two_sub, status, created_at, updated_at)
+SELECT ?, t.id, ?, ?, ?, ?, 'pending', ?, ?
+FROM tournament t
+WHERE t.eid = ?

--- a/components/rts-data-access/resources/rts-data-access/sql/tournament/get-match-by-eid.sql
+++ b/components/rts-data-access/resources/rts-data-access/sql/tournament/get-match-by-eid.sql
@@ -1,0 +1,16 @@
+SELECT
+  m.id,
+  m.eid,
+  t.eid AS tournament_eid,
+  m.phase_index,
+  m.round_index,
+  m.player_one_sub,
+  m.player_two_sub,
+  m.winner_sub,
+  m.status,
+  m.created_at,
+  m.updated_at
+FROM
+  match m
+  INNER JOIN tournament t ON t.id = m.tournament_id
+WHERE m.eid = ?

--- a/components/rts-data-access/resources/rts-data-access/sql/tournament/get-matches-for-round.sql
+++ b/components/rts-data-access/resources/rts-data-access/sql/tournament/get-matches-for-round.sql
@@ -1,0 +1,19 @@
+SELECT
+  m.id,
+  m.eid,
+  t.eid AS tournament_eid,
+  m.phase_index,
+  m.round_index,
+  m.player_one_sub,
+  m.player_two_sub,
+  m.winner_sub,
+  m.status,
+  m.created_at,
+  m.updated_at
+FROM
+  match m
+  INNER JOIN tournament t ON t.id = m.tournament_id
+WHERE t.eid = ?
+  AND m.phase_index = ?
+  AND m.round_index = ?
+ORDER BY m.id ASC

--- a/components/rts-data-access/resources/rts-data-access/sql/tournament/get-matches-for-tournament.sql
+++ b/components/rts-data-access/resources/rts-data-access/sql/tournament/get-matches-for-tournament.sql
@@ -1,0 +1,17 @@
+SELECT
+  m.id,
+  m.eid,
+  t.eid AS tournament_eid,
+  m.phase_index,
+  m.round_index,
+  m.player_one_sub,
+  m.player_two_sub,
+  m.winner_sub,
+  m.status,
+  m.created_at,
+  m.updated_at
+FROM
+  match m
+  INNER JOIN tournament t ON t.id = m.tournament_id
+WHERE t.eid = ?
+ORDER BY m.phase_index ASC, m.round_index ASC, m.id ASC

--- a/components/rts-data-access/resources/rts-data-access/sql/tournament/update-match-result.sql
+++ b/components/rts-data-access/resources/rts-data-access/sql/tournament/update-match-result.sql
@@ -1,0 +1,6 @@
+UPDATE match
+SET winner_sub = ?,
+    status = 'complete',
+    updated_at = ?
+WHERE eid = ?
+  AND status = 'pending'

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
@@ -88,6 +88,7 @@
 (def create-tournament-params schema/create-tournament-params)
 (def tournament-state-entity schema/tournament-state-entity)
 (def tournament-entry-entity schema/tournament-entry-entity)
+(def match-entity schema/match-entity)
 
 ;;; ─── Tournament DB queries ────────────────────────────────────────────────
 
@@ -100,6 +101,11 @@
 (def delete-entry query.tournament/delete-entry)
 (def get-entries-for-tournament query.tournament/get-entries-for-tournament)
 (def get-entry-by-tournament-and-player query.tournament/get-entry-by-tournament-and-player)
+(def create-match query.tournament/create-match)
+(def get-match-by-eid query.tournament/get-match-by-eid)
+(def get-matches-for-tournament query.tournament/get-matches-for-tournament)
+(def get-matches-for-round query.tournament/get-matches-for-round)
+(def update-match-result query.tournament/update-match-result)
 
 ;;; ─── Social Media DB entities ──────────────────────────────────────────────
 

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/tournament.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/tournament.clj
@@ -89,6 +89,58 @@
    [get-entry-by-tournament-and-player-query tournament-eid player-sub]
    schema/tournament-entry-entity))
 
+;; ─── Match queries ───────────────────────────────────────────────────────────
+
+(def create-match-query (resource/load-query-resource "tournament" "create-match.sql"))
+
+(def get-match-by-eid-query (resource/load-query-resource "tournament" "get-match-by-eid.sql"))
+
+(def get-matches-for-tournament-query (resource/load-query-resource "tournament" "get-matches-for-tournament.sql"))
+
+(def get-matches-for-round-query (resource/load-query-resource "tournament" "get-matches-for-round.sql"))
+
+(def update-match-result-query (resource/load-query-resource "tournament" "update-match-result.sql"))
+
+(defn create-match
+  [connection tournament-eid match-spec]
+  (let [eid (str (random-uuid))
+        now (str (Instant/now))]
+    (jdbc.contract/execute-one!
+     connection
+     [create-match-query
+      eid
+      (:phase-index match-spec)
+      (:round-index match-spec)
+      (:player-one-sub match-spec)
+      (:player-two-sub match-spec)
+      now now
+      tournament-eid])
+    (jdbc.contract/query-for-entity
+     connection
+     [get-match-by-eid-query eid]
+     schema/match-entity)))
+
+(defn get-match-by-eid
+  [connection eid]
+  (jdbc.contract/query-for-entity connection [get-match-by-eid-query eid] schema/match-entity))
+
+(defn get-matches-for-tournament
+  [connection tournament-eid]
+  (jdbc.contract/query-for-entities connection [get-matches-for-tournament-query tournament-eid] schema/match-entity))
+
+(defn get-matches-for-round
+  [connection tournament-eid phase-index round-index]
+  (jdbc.contract/query-for-entities
+   connection
+   [get-matches-for-round-query tournament-eid phase-index round-index]
+   schema/match-entity))
+
+(defn update-match-result
+  [connection match-eid winner-sub]
+  (jdbc.contract/execute-one!
+   connection
+   [update-match-result-query winner-sub (str (Instant/now)) match-eid]))
+
 ;; ─── Tournament CRUD ─────────────────────────────────────────────────────────
 
 (defn create-tournament

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema.clj
@@ -232,6 +232,21 @@
     [:created-at :instant]
     [:deleted-at [:maybe :instant]]]))
 
+(def match-entity
+  (schema.contract/to-schema
+   [:map
+    [:id :int]
+    [:eid :uuid]
+    [:tournament-eid :uuid]
+    [:phase-index :int]
+    [:round-index :int]
+    [:player-one-sub :string]
+    [:player-two-sub [:maybe :string]]
+    [:winner-sub [:maybe :string]]
+    [:status :string]
+    [:created-at :instant]
+    [:updated-at :instant]]))
+
 ;; Schema for the known structured fields in the raw unit-statistics JSON (string keys).
 ;; :closed false allows the extra dynamic stat keys to pass through.
 (def unit-statistics-raw-schema

--- a/components/rts-data/resources/rts-data/migrations/000024-create-match-table.down.sql
+++ b/components/rts-data/resources/rts-data/migrations/000024-create-match-table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS match;

--- a/components/rts-data/resources/rts-data/migrations/000024-create-match-table.up.sql
+++ b/components/rts-data/resources/rts-data/migrations/000024-create-match-table.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS match (
+  id INTEGER PRIMARY KEY ASC,
+  eid TEXT NOT NULL,
+  tournament_id INTEGER NOT NULL,
+  phase_index INTEGER NOT NULL,
+  round_index INTEGER NOT NULL,
+  player_one_sub TEXT NOT NULL,
+  player_two_sub TEXT,
+  winner_sub TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(eid),
+  FOREIGN KEY(tournament_id) REFERENCES tournament(id)
+);

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
@@ -101,7 +101,7 @@
 (def get-match-by-eid                             handlers.tournament/get-match-by-eid)
 (def get-matches-for-tournament                   handlers.tournament/get-matches-for-tournament)
 (def get-matches-for-round                        handlers.tournament/get-matches-for-round)
-(def record-match-result                          handlers.tournament/record-match-result)
+(def update-match-result                          handlers.tournament/update-match-result)
 
 ;;; ─── Social Media handler functions ────────────────────────────────────────
 

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
@@ -90,9 +90,18 @@
 (def delete-entry                                 handlers.tournament/delete-entry)
 (def get-entries                                   handlers.tournament/get-entries)
 (def is-registration-open?                        handlers.tournament/is-registration-open?)
+(def match-resource                               schema/match-resource)
+(def create-match-specification                   schema/create-match-specification)
+(def record-result-specification                  schema/record-result-specification)
+
 (def available-transitions                        handlers.tournament/available-transitions)
 (def advance-tournament                           handlers.tournament/advance-tournament)
 (def close-registration-early                     handlers.tournament/close-registration-early)
+(def create-match                                 handlers.tournament/create-match)
+(def get-match-by-eid                             handlers.tournament/get-match-by-eid)
+(def get-matches-for-tournament                   handlers.tournament/get-matches-for-tournament)
+(def get-matches-for-round                        handlers.tournament/get-matches-for-round)
+(def record-match-result                          handlers.tournament/record-match-result)
 
 ;;; ─── Social Media handler functions ────────────────────────────────────────
 

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
@@ -93,6 +93,13 @@
 (def match-resource                               schema/match-resource)
 (def create-match-specification                   schema/create-match-specification)
 (def record-result-specification                  schema/record-result-specification)
+(def tournament-entries-response                  schema/tournament-entries-response)
+(def tournament-status-response                   schema/tournament-status-response)
+(def tournament-advance-response                  schema/tournament-advance-response)
+(def tournament-registration-response             schema/tournament-registration-response)
+(def tournament-entry-deleted-response            schema/tournament-entry-deleted-response)
+(def tournament-matches-response                  schema/tournament-matches-response)
+(def tournament-match-result-response             schema/tournament-match-result-response)
 
 (def available-transitions                        handlers.tournament/available-transitions)
 (def advance-tournament                           handlers.tournament/advance-tournament)

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -168,3 +168,57 @@
             (set-tournament-state dependencies tournament-eid new-state)
             {:type  :tournament/close-registration-success
              :state new-state}))))))
+
+;; ─── Matches ─────────────────────────────────────────────────────────────────
+
+(defn create-match
+  "Creates a match within a tournament. Tournament must be active."
+  [dependencies tournament-eid match-spec]
+  (let [state (get-tournament-state dependencies tournament-eid)]
+    (if (not= "active" (:status state))
+      {:type :tournament/match-error :message "Tournament must be active to create matches."}
+      (let [match (db/create-match (:connection dependencies) tournament-eid match-spec)]
+        (assoc match :type :tournament/match)))))
+
+(defn get-match-by-eid
+  "Fetches a match by eid."
+  [dependencies match-eid]
+  (some-> (db/get-match-by-eid (:connection dependencies) match-eid)
+          (assoc :type :tournament/match)))
+
+(defn get-matches-for-tournament
+  "Returns all matches for a tournament."
+  [dependencies tournament-eid]
+  (mapv (fn [m] (assoc m :type :tournament/match))
+        (db/get-matches-for-tournament (:connection dependencies) tournament-eid)))
+
+(defn get-matches-for-round
+  "Returns matches for a specific phase and round."
+  [dependencies tournament-eid phase-index round-index]
+  (mapv (fn [m] (assoc m :type :tournament/match))
+        (db/get-matches-for-round (:connection dependencies) tournament-eid phase-index round-index)))
+
+(defn record-match-result
+  "Records a match result and recalculates standings in the state blob."
+  [dependencies match-eid winner-sub]
+  (let [match (db/get-match-by-eid (:connection dependencies) match-eid)]
+    (cond
+      (nil? match)
+      {:type :tournament/match-error :message "Match not found."}
+
+      (not= "pending" (:status match))
+      {:type :tournament/match-error :message "Match is not pending."}
+
+      :else
+      (do
+        (db/update-match-result (:connection dependencies) match-eid winner-sub)
+        (let [tournament-eid (:tournament-eid match)
+              state          (get-tournament-state dependencies tournament-eid)
+              all-matches    (get-matches-for-tournament dependencies tournament-eid)
+              completed      (filter #(= "complete" (:status %)) all-matches)
+              new-standings  (rules/recalculate-standings (:standings state) completed)
+              new-state      (assoc state :standings new-standings)]
+          (set-tournament-state dependencies tournament-eid new-state)
+          {:type      :tournament/match-result-recorded
+           :match-eid match-eid
+           :standings new-standings})))))

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -198,7 +198,7 @@
   (mapv (fn [m] (assoc m :type :tournament/match))
         (db/get-matches-for-round (:connection dependencies) tournament-eid phase-index round-index)))
 
-(defn record-match-result
+(defn update-match-result
   "Records a match result and recalculates standings in the state blob."
   [dependencies match-eid winner-sub]
   (let [match (db/get-match-by-eid (:connection dependencies) match-eid)]

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/rules/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/rules/tournament.clj
@@ -38,3 +38,34 @@
                       :points     0})
                    entries))
       (assoc :current-phase (when (seq (:phases state)) 0))))
+
+(defn recalculate-standings
+  "Recalculates standings from a list of completed matches.
+   Each win = 3 points, draw = 1 point, loss = 0 points."
+  [standings completed-matches]
+  (let [results (reduce
+                 (fn [acc match]
+                   (let [p1 (:player-one-sub match)
+                         p2 (:player-two-sub match)
+                         winner (:winner-sub match)]
+                     (cond
+                       (nil? winner) acc
+                       (nil? p2) acc ;; bye — no stats change
+                       (= winner "draw")
+                       (-> acc
+                           (update-in [p1 :draws] (fnil inc 0))
+                           (update-in [p1 :points] (fnil + 0) 1)
+                           (update-in [p2 :draws] (fnil inc 0))
+                           (update-in [p2 :points] (fnil + 0) 1))
+                       :else
+                       (let [loser (if (= winner p1) p2 p1)]
+                         (-> acc
+                             (update-in [winner :wins] (fnil inc 0))
+                             (update-in [winner :points] (fnil + 0) 3)
+                             (update-in [loser :losses] (fnil inc 0)))))))
+                 (into {} (map (fn [s] [(:player-sub s) (dissoc s :player-sub)])) standings)
+                 completed-matches)]
+    (mapv (fn [standing]
+            (merge standing (get results (:player-sub standing)
+                                 {:wins 0 :losses 0 :draws 0 :points 0})))
+          standings)))

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/schema.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/schema.clj
@@ -175,6 +175,87 @@
        [:self :url]
        [:tournament :url]]]])))
 
+;; ─── Subresource response schemas ───────────────────────────────────────────
+
+(def standing-entry
+  (schema.contract/to-schema
+   [:map
+    [:player-sub :string]
+    [:wins :int]
+    [:losses :int]
+    [:draws :int]
+    [:points :int]]))
+
+(def tournament-entry-summary
+  (schema.contract/to-schema
+   [:map
+    [:eid :uuid]
+    [:type [:= :tournament/entry]]
+    [:tournament-eid :uuid]
+    [:player-sub :string]
+    [:created-at :instant]]))
+
+(def tournament-entries-response
+  (schema.contract/to-schema
+   [:map
+    [:type [:= :tournament/entries]]
+    [:entries [:sequential tournament-entry-summary]]]))
+
+(def tournament-status-response
+  (schema.contract/to-schema
+   [:map
+    [:type [:= :tournament/status]]
+    [:status :string]
+    [:available-transitions [:sequential :string]]]))
+
+(def tournament-advance-response
+  (schema.contract/to-schema
+   [:map
+    [:type [:= :tournament/advance-success]]
+    [:state [:map {:closed false}
+             [:status :string]]]]))
+
+(def tournament-registration-response
+  (schema.contract/to-schema
+   [:map
+    [:type [:= :tournament/registration]]
+    [:opens-at [:maybe :string]]
+    [:closes-at [:maybe :string]]
+    [:timezone [:maybe :string]]
+    [:closed-early :boolean]]))
+
+(def tournament-entry-deleted-response
+  (schema.contract/to-schema
+   [:map
+    [:type [:= :tournament/entry-deleted]]
+    [:message :string]]))
+
+(def tournament-match-summary
+  (schema.contract/to-schema
+   [:map
+    [:eid :uuid]
+    [:type [:= :tournament/match]]
+    [:tournament-eid :uuid]
+    [:phase-index :int]
+    [:round-index :int]
+    [:player-one-sub :string]
+    [:player-two-sub [:maybe :string]]
+    [:winner-sub [:maybe :string]]
+    [:status :string]]))
+
+(def tournament-matches-response
+  (schema.contract/to-schema
+   [:map
+    [:type [:= :tournament/matches]]
+    [:matches [:sequential tournament-match-summary]]]))
+
+(def tournament-match-result-response
+  (schema.contract/to-schema
+   [:map
+    [:type [:= :tournament/match-result-recorded]]
+    [:match-eid :uuid]
+    [:standings [:sequential standing-entry]]]))
+
 (def resource-identifier
   [:map
    [:eid :uuid]

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/schema.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/schema.clj
@@ -128,6 +128,38 @@
     [:map
      [:type [:= :collection/tournament]]])))
 
+(def match-resource
+  (malli.util/merge
+   schema.contract/base-resource
+   (schema.contract/to-schema
+    [:map
+     [:eid {:model/link :match/by-eid} :uuid]
+     [:type [:= :tournament/match]]
+     [:tournament-eid {:model/link :tournament/by-eid} :uuid]
+     [:phase-index :int]
+     [:round-index :int]
+     [:player-one-sub :string]
+     [:player-two-sub [:maybe :string]]
+     [:winner-sub [:maybe :string]]
+     [:status :string]
+     [:_links
+      [:map
+       [:self :url]
+       [:tournament :url]]]])))
+
+(def create-match-specification
+  (schema.contract/to-schema
+   [:map
+    [:phase-index :int]
+    [:round-index :int]
+    [:player-one-sub :string]
+    [:player-two-sub {:optional true} [:maybe :string]]]))
+
+(def record-result-specification
+  (schema.contract/to-schema
+   [:map
+    [:winner-sub :string]]))
+
 (def tournament-entry-resource
   (malli.util/merge
    schema.contract/base-resource

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
@@ -270,9 +270,9 @@
       (is (every? #(= :tournament/match (:type %)) results))
       (is (= 2 (count results))))))
 
-;; ─── record-match-result ─────────────────────────────────────────────────────
+;; ─── update-match-result ─────────────────────────────────────────────────────
 
-(deftest record-match-result-updates-standings
+(deftest update-match-result-updates-standings
   (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] test-match)
                 data-access.contract/update-match-result (fn [_ _ _] nil)
                 data-access.contract/get-matches-for-tournament
@@ -280,17 +280,17 @@
                 data-access.contract/get-tournament-state
                 (fn [_ _] {:id 1 :state active-state-json :updated-at (Instant/now)})
                 data-access.contract/upsert-tournament-state (fn [_ _ _] nil)]
-    (let [result (handlers.tournament/record-match-result test-deps (:eid test-match) "p1")]
+    (let [result (handlers.tournament/update-match-result test-deps (:eid test-match) "p1")]
       (is (= :tournament/match-result-recorded (:type result)))
       (is (= 2 (count (:standings result))))
       (is (= 3 (:points (first (filter #(= "p1" (:player-sub %)) (:standings result)))))))))
 
-(deftest record-match-result-rejects-non-pending
+(deftest update-match-result-rejects-non-pending
   (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] (assoc test-match :status "complete"))]
-    (let [result (handlers.tournament/record-match-result test-deps (:eid test-match) "p1")]
+    (let [result (handlers.tournament/update-match-result test-deps (:eid test-match) "p1")]
       (is (= :tournament/match-error (:type result))))))
 
-(deftest record-match-result-not-found
+(deftest update-match-result-not-found
   (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] nil)]
-    (let [result (handlers.tournament/record-match-result test-deps (UUID/randomUUID) "p1")]
+    (let [result (handlers.tournament/update-match-result test-deps (UUID/randomUUID) "p1")]
       (is (= :tournament/match-error (:type result))))))

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
@@ -222,3 +222,75 @@
                 (fn [_ _] {:id 1 :state "{\"status\":\"active\"}" :updated-at (Instant/now)})]
     (let [result (handlers.tournament/close-registration-early test-deps test-tournament-eid "dev-admin")]
       (is (= :tournament/advance-error (:type result))))))
+
+;; ─── create-match ────────────────────────────────────────────────────────────
+
+(def ^:private active-state-json
+  "{\"status\":\"active\",\"standings\":[{\"player-sub\":\"p1\",\"wins\":0,\"losses\":0,\"draws\":0,\"points\":0},{\"player-sub\":\"p2\",\"wins\":0,\"losses\":0,\"draws\":0,\"points\":0}],\"phases\":[]}")
+
+(def ^:private test-match
+  {:id 1 :eid (UUID/randomUUID) :tournament-eid test-tournament-eid
+   :phase-index 0 :round-index 0 :player-one-sub "p1" :player-two-sub "p2"
+   :winner-sub nil :status "pending" :created-at (Instant/now) :updated-at (Instant/now)})
+
+(deftest create-match-returns-match-when-active
+  (with-redefs [data-access.contract/get-tournament-state
+                (fn [_ _] {:id 1 :state active-state-json :updated-at (Instant/now)})
+                data-access.contract/create-match
+                (fn [_ _ _] test-match)]
+    (let [result (handlers.tournament/create-match test-deps test-tournament-eid
+                                                   {:phase-index 0 :round-index 0 :player-one-sub "p1" :player-two-sub "p2"})]
+      (is (= :tournament/match (:type result)))
+      (is (= "p1" (:player-one-sub result))))))
+
+(deftest create-match-rejects-when-not-active
+  (with-redefs [data-access.contract/get-tournament-state
+                (fn [_ _] {:id 1 :state registration-state-json :updated-at (Instant/now)})]
+    (let [result (handlers.tournament/create-match test-deps test-tournament-eid
+                                                   {:phase-index 0 :round-index 0 :player-one-sub "p1" :player-two-sub "p2"})]
+      (is (= :tournament/match-error (:type result))))))
+
+;; ─── get-match-by-eid ────────────────────────────────────────────────────────
+
+(deftest get-match-by-eid-assigns-type
+  (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] test-match)]
+    (let [result (handlers.tournament/get-match-by-eid test-deps (:eid test-match))]
+      (is (= :tournament/match (:type result))))))
+
+(deftest get-match-by-eid-returns-nil-when-not-found
+  (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] nil)]
+    (is (nil? (handlers.tournament/get-match-by-eid test-deps (UUID/randomUUID))))))
+
+;; ─── get-matches-for-tournament ──────────────────────────────────────────────
+
+(deftest get-matches-for-tournament-assigns-type
+  (with-redefs [data-access.contract/get-matches-for-tournament
+                (fn [_ _] [test-match (assoc test-match :player-one-sub "p3")])]
+    (let [results (handlers.tournament/get-matches-for-tournament test-deps test-tournament-eid)]
+      (is (every? #(= :tournament/match (:type %)) results))
+      (is (= 2 (count results))))))
+
+;; ─── record-match-result ─────────────────────────────────────────────────────
+
+(deftest record-match-result-updates-standings
+  (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] test-match)
+                data-access.contract/update-match-result (fn [_ _ _] nil)
+                data-access.contract/get-matches-for-tournament
+                (fn [_ _] [(assoc test-match :status "complete" :winner-sub "p1")])
+                data-access.contract/get-tournament-state
+                (fn [_ _] {:id 1 :state active-state-json :updated-at (Instant/now)})
+                data-access.contract/upsert-tournament-state (fn [_ _ _] nil)]
+    (let [result (handlers.tournament/record-match-result test-deps (:eid test-match) "p1")]
+      (is (= :tournament/match-result-recorded (:type result)))
+      (is (= 2 (count (:standings result))))
+      (is (= 3 (:points (first (filter #(= "p1" (:player-sub %)) (:standings result)))))))))
+
+(deftest record-match-result-rejects-non-pending
+  (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] (assoc test-match :status "complete"))]
+    (let [result (handlers.tournament/record-match-result test-deps (:eid test-match) "p1")]
+      (is (= :tournament/match-error (:type result))))))
+
+(deftest record-match-result-not-found
+  (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] nil)]
+    (let [result (handlers.tournament/record-match-result test-deps (UUID/randomUUID) "p1")]
+      (is (= :tournament/match-error (:type result))))))

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/rules/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/rules/tournament_test.clj
@@ -65,3 +65,44 @@
   (let [state  {:status "registration" :standings [] :phases []}
         result (rules/close-registration state [{:player-sub "p1"}])]
     (is (nil? (:current-phase result)))))
+
+;; ─── recalculate-standings ───────────────────────────────────────────────────
+
+(deftest recalculate-standings-win
+  (let [standings [{:player-sub "p1" :wins 0 :losses 0 :draws 0 :points 0}
+                   {:player-sub "p2" :wins 0 :losses 0 :draws 0 :points 0}]
+        matches   [{:player-one-sub "p1" :player-two-sub "p2" :winner-sub "p1"}]
+        result    (rules/recalculate-standings standings matches)]
+    (is (= 1 (:wins (first result))))
+    (is (= 3 (:points (first result))))
+    (is (= 1 (:losses (second result))))
+    (is (= 0 (:points (second result))))))
+
+(deftest recalculate-standings-draw
+  (let [standings [{:player-sub "p1" :wins 0 :losses 0 :draws 0 :points 0}
+                   {:player-sub "p2" :wins 0 :losses 0 :draws 0 :points 0}]
+        matches   [{:player-one-sub "p1" :player-two-sub "p2" :winner-sub "draw"}]
+        result    (rules/recalculate-standings standings matches)]
+    (is (= 1 (:draws (first result))))
+    (is (= 1 (:points (first result))))
+    (is (= 1 (:draws (second result))))
+    (is (= 1 (:points (second result))))))
+
+(deftest recalculate-standings-bye-ignored
+  (let [standings [{:player-sub "p1" :wins 0 :losses 0 :draws 0 :points 0}]
+        matches   [{:player-one-sub "p1" :player-two-sub nil :winner-sub "p1"}]
+        result    (rules/recalculate-standings standings matches)]
+    (is (= 0 (:wins (first result))))))
+
+(deftest recalculate-standings-multiple-matches
+  (let [standings [{:player-sub "p1" :wins 0 :losses 0 :draws 0 :points 0}
+                   {:player-sub "p2" :wins 0 :losses 0 :draws 0 :points 0}]
+        matches   [{:player-one-sub "p1" :player-two-sub "p2" :winner-sub "p1"}
+                   {:player-one-sub "p2" :player-two-sub "p1" :winner-sub "p2"}]
+        result    (rules/recalculate-standings standings matches)]
+    (is (= 1 (:wins (first result))))
+    (is (= 1 (:losses (first result))))
+    (is (= 3 (:points (first result))))
+    (is (= 1 (:wins (second result))))
+    (is (= 1 (:losses (second result))))
+    (is (= 3 (:points (second result))))))

--- a/components/rts-web/resources/rts-web/view/tournament-index.html
+++ b/components/rts-web/resources/rts-web/view/tournament-index.html
@@ -102,6 +102,37 @@
     </section>
     {% endif %}
 
+    {% if matches|not-empty? %}
+    <section aria-labelledby="tournament-matches-heading">
+        <h3 id="tournament-matches-heading">Matches</h3>
+        <div class="table-container">
+            <table class="table" aria-labelledby="tournament-matches-heading">
+                <caption class="sr-only">Tournament matches</caption>
+                <thead>
+                    <tr>
+                        <th scope="col">Round</th>
+                        <th scope="col">Player 1</th>
+                        <th scope="col">Player 2</th>
+                        <th scope="col">Winner</th>
+                        <th scope="col">Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for match in matches %}
+                    <tr>
+                        <td>R{{match.round-index}}</td>
+                        <td>{{match.player-one-sub}}</td>
+                        <td>{% if match.player-two-sub %}{{match.player-two-sub}}{% else %}<em>bye</em>{% endif %}</td>
+                        <td>{% if match.winner-sub %}{{match.winner-sub}}{% else %}—{% endif %}</td>
+                        <td>{{match.status}}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+    {% endif %}
+
     <section aria-labelledby="tournament-entries-heading">
         <h3 id="tournament-entries-heading">Entries</h3>
         {% if session %}

--- a/components/rts-web/resources/rts-web/view/tournament-index.html
+++ b/components/rts-web/resources/rts-web/view/tournament-index.html
@@ -102,34 +102,37 @@
     </section>
     {% endif %}
 
-    {% if matches|not-empty? %}
+    {% if matches-by-round|not-empty? %}
     <section aria-labelledby="tournament-matches-heading">
         <h3 id="tournament-matches-heading">Matches</h3>
-        <div class="table-container">
-            <table class="table" aria-labelledby="tournament-matches-heading">
-                <caption class="sr-only">Tournament matches</caption>
-                <thead>
-                    <tr>
-                        <th scope="col">Round</th>
-                        <th scope="col">Player 1</th>
-                        <th scope="col">Player 2</th>
-                        <th scope="col">Winner</th>
-                        <th scope="col">Status</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for match in matches %}
-                    <tr>
-                        <td>R{{match.round-index}}</td>
-                        <td>{{match.player-one-sub}}</td>
-                        <td>{% if match.player-two-sub %}{{match.player-two-sub}}{% else %}<em>bye</em>{% endif %}</td>
-                        <td>{% if match.winner-sub %}{{match.winner-sub}}{% else %}—{% endif %}</td>
-                        <td>{{match.status}}</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+        {% for round-group in matches-by-round %}
+        <section aria-labelledby="round-{{round-group.phase}}-{{round-group.round}}-heading">
+            <h4 id="round-{{round-group.phase}}-{{round-group.round}}-heading">Phase {{round-group.phase}} — Round {{round-group.round}}</h4>
+            <div class="table-container">
+                <table class="table" aria-labelledby="round-{{round-group.phase}}-{{round-group.round}}-heading">
+                    <caption class="sr-only">Phase {{round-group.phase}}, Round {{round-group.round}} matches</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col">Player 1</th>
+                            <th scope="col">Player 2</th>
+                            <th scope="col">Winner</th>
+                            <th scope="col">Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for match in round-group.matches %}
+                        <tr>
+                            <td>{{match.player-one-sub}}</td>
+                            <td>{% if match.player-two-sub %}{{match.player-two-sub}}{% else %}<em>bye</em>{% endif %}</td>
+                            <td>{% if match.winner-sub %}{{match.winner-sub}}{% else %}—{% endif %}</td>
+                            <td>{{match.status}}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </section>
+        {% endfor %}
     </section>
     {% endif %}
 

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -371,7 +371,7 @@
                                    [:eid :uuid]
                                    [:match-eid :uuid]])
                            :body domain/record-result-specification}
-              :handler    (integrant.core/ref ::web.tournament/record-match-result)}}]]]]
+              :handler    (integrant.core/ref ::web.tournament/update-match-result)}}]]]]
 
    ["/social-media/:eid"
     {:name :social-media/by-eid

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -289,13 +289,13 @@
                               :produces     ["application/json"]
                               :operation-id "tournament-entry/create-mine"}
                  :parameters {:path schema.contract/id-path-parameter}
-                 :responses  {201 {:body domain/tournament-entry-resource}}
                  :handler    (integrant.core/ref ::web.tournament/create-entry)}
         :delete {:summary    "Remove the current player's tournament entry."
                  :openapi    {:tags         ["tournament"]
                               :produces     ["application/json"]
                               :operation-id "tournament-entry/delete-mine"}
                  :parameters {:path schema.contract/id-path-parameter}
+                 :responses  {200 {:body domain/tournament-entry-deleted-response}}
                  :handler    (integrant.core/ref ::web.tournament/delete-entry)}}]
       [""
        {:get {:summary    "List active entries for a tournament."
@@ -303,6 +303,7 @@
                            :produces     ["application/json"]
                            :operation-id "tournament-entry/list"}
               :parameters {:path schema.contract/id-path-parameter}
+              :responses  {200 {:body domain/tournament-entries-response}}
               :handler    (integrant.core/ref ::web.tournament/get-entries)}}]]
      ["/status"
       {:get {:summary    "Get the current tournament status and available transitions."
@@ -310,6 +311,7 @@
                           :produces     ["application/json"]
                           :operation-id "tournament-status/get"}
              :parameters {:path schema.contract/id-path-parameter}
+             :responses  {200 {:body domain/tournament-status-response}}
              :handler    (integrant.core/ref ::web.tournament/get-status)}
        :put {:summary    "Transition the tournament to a new status."
              :openapi    {:tags         ["tournament"]
@@ -319,6 +321,7 @@
                           :body (schema.contract/to-schema
                                  [:map
                                   [:status [:enum "active" "complete" "cancelled"]]])}
+             :responses  {200 {:body domain/tournament-advance-response}}
              :handler    (integrant.core/ref ::web.tournament/update-status)}}]
      ["/registration"
       {:get   {:summary    "Get the tournament registration window."
@@ -326,6 +329,7 @@
                             :produces     ["application/json"]
                             :operation-id "tournament-registration/get"}
                :parameters {:path schema.contract/id-path-parameter}
+               :responses  {200 {:body domain/tournament-registration-response}}
                :handler    (integrant.core/ref ::web.tournament/get-registration)}
        :patch {:summary    "Update the registration window (e.g. close early)."
                :openapi    {:tags         ["tournament"]
@@ -343,6 +347,7 @@
                             :produces     ["application/json"]
                             :operation-id "tournament-match/list"}
                :parameters {:path schema.contract/id-path-parameter}
+               :responses  {200 {:body domain/tournament-matches-response}}
                :handler    (integrant.core/ref ::web.tournament/get-matches)}
         :post {:summary    "Create a match within a tournament."
                :openapi    {:tags         ["tournament"]
@@ -350,7 +355,6 @@
                             :operation-id "tournament-match/create"}
                :parameters {:path schema.contract/id-path-parameter
                             :body domain/create-match-specification}
-               :responses  {201 {:body domain/match-resource}}
                :handler    (integrant.core/ref ::web.tournament/create-match)}}]
       ["/:match-eid"
        {:name :match/by-eid
@@ -374,6 +378,7 @@
                                    [:eid :uuid]
                                    [:match-eid :uuid]])
                            :body domain/record-result-specification}
+              :responses  {200 {:body domain/tournament-match-result-response}}
               :handler    (integrant.core/ref ::web.tournament/update-match-result)}}]]]]
 
    ["/social-media/:eid"

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -334,7 +334,44 @@
                             :body (schema.contract/to-schema
                                    [:map
                                     [:closed-early :boolean]])}
-               :handler    (integrant.core/ref ::web.tournament/update-registration)}}]]]
+               :handler    (integrant.core/ref ::web.tournament/update-registration)}}]
+     ["/match"
+      [""
+       {:get  {:summary    "List matches for a tournament."
+               :openapi    {:tags         ["tournament"]
+                            :produces     ["application/json"]
+                            :operation-id "tournament-match/list"}
+               :parameters {:path schema.contract/id-path-parameter}
+               :handler    (integrant.core/ref ::web.tournament/get-matches)}
+        :post {:summary    "Create a match within a tournament."
+               :openapi    {:tags         ["tournament"]
+                            :produces     ["application/json"]
+                            :operation-id "tournament-match/create"}
+               :parameters {:path schema.contract/id-path-parameter
+                            :body domain/create-match-specification}
+               :handler    (integrant.core/ref ::web.tournament/create-match)}}]
+      ["/:match-eid"
+       {:name :match/by-eid
+        :get  {:summary    "Get a match by eid."
+               :openapi    {:tags         ["tournament"]
+                            :produces     ["application/json"]
+                            :operation-id "tournament-match/get"}
+               :parameters {:path (schema.contract/to-schema
+                                   [:map
+                                    [:eid :uuid]
+                                    [:match-eid :uuid]])}
+               :handler    (integrant.core/ref ::web.tournament/get-match)}}]
+      ["/:match-eid/result"
+       {:put {:summary    "Record a match result."
+              :openapi    {:tags         ["tournament"]
+                           :produces     ["application/json"]
+                           :operation-id "tournament-match/record-result"}
+              :parameters {:path (schema.contract/to-schema
+                                  [:map
+                                   [:eid :uuid]
+                                   [:match-eid :uuid]])
+                           :body domain/record-result-specification}
+              :handler    (integrant.core/ref ::web.tournament/record-match-result)}}]]]]
 
    ["/social-media/:eid"
     {:name :social-media/by-eid

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -289,6 +289,7 @@
                               :produces     ["application/json"]
                               :operation-id "tournament-entry/create-mine"}
                  :parameters {:path schema.contract/id-path-parameter}
+                 :responses  {201 {:body domain/tournament-entry-resource}}
                  :handler    (integrant.core/ref ::web.tournament/create-entry)}
         :delete {:summary    "Remove the current player's tournament entry."
                  :openapi    {:tags         ["tournament"]
@@ -349,6 +350,7 @@
                             :operation-id "tournament-match/create"}
                :parameters {:path schema.contract/id-path-parameter
                             :body domain/create-match-specification}
+               :responses  {201 {:body domain/match-resource}}
                :handler    (integrant.core/ref ::web.tournament/create-match)}}]
       ["/:match-eid"
        {:name :match/by-eid
@@ -360,6 +362,7 @@
                                    [:map
                                     [:eid :uuid]
                                     [:match-eid :uuid]])}
+               :responses  {200 {:body domain/match-resource}}
                :handler    (integrant.core/ref ::web.tournament/get-match)}}]
       ["/:match-eid/result"
        {:put {:summary    "Record a match result."

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/tournament.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/tournament.clj
@@ -182,12 +182,12 @@
         {:status 422 :body result}
         {:status 201 :body result}))))
 
-(defmethod integrant.core/init-key ::record-match-result
+(defmethod integrant.core/init-key ::update-match-result
   [_init-key dependencies]
   (fn [{{{:keys [match-eid]}     :path
          {:keys [winner-sub]} :body} :parameters
         :as                           _request}]
-    (let [result (domain/record-match-result dependencies match-eid winner-sub)]
+    (let [result (domain/update-match-result dependencies match-eid winner-sub)]
       (if (= :tournament/match-error (:type result))
         {:status 422 :body result}
         {:status 200 :body result}))))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/tournament.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/tournament.clj
@@ -143,3 +143,51 @@
       (case (:type result)
         :tournament/close-registration-success {:status 200 :body result}
         {:status 422 :body result}))))
+
+;; ─── Match handlers ─────────────────────────────────────────────────────────
+
+(defmethod integrant.core/init-key ::get-matches
+  [_init-key dependencies]
+  (fn [{{{:keys [eid]} :path} :parameters
+        :as                   _request}]
+    {:status 200
+     :body   {:type    :tournament/matches
+              :matches (domain/get-matches-for-tournament dependencies eid)}}))
+
+(defmethod integrant.core/init-key ::get-match
+  [_init-key dependencies]
+  (fn [{{{:keys [match-eid]} :path} :parameters
+        router                      :reitit.core/router
+        :as                         _request}]
+    (web.core/handle-fetch-response
+     domain/match-resource
+     {:hostname (:hostname dependencies) :router router}
+     #(or (domain/get-match-by-eid dependencies match-eid)
+          {:type :missing/resource :name "match" :id match-eid}))))
+
+(defmethod integrant.core/init-key ::create-match
+  [_init-key dependencies]
+  (fn [{{{:keys [eid]}                                     :path
+         {:keys [phase-index round-index
+                 player-one-sub player-two-sub]} :body} :parameters
+        :as                                                  _request}]
+    (let [result (domain/create-match
+                  dependencies
+                  eid
+                  {:phase-index    phase-index
+                   :round-index    round-index
+                   :player-one-sub player-one-sub
+                   :player-two-sub player-two-sub})]
+      (if (= :tournament/match-error (:type result))
+        {:status 422 :body result}
+        {:status 201 :body result}))))
+
+(defmethod integrant.core/init-key ::record-match-result
+  [_init-key dependencies]
+  (fn [{{{:keys [match-eid]}     :path
+         {:keys [winner-sub]} :body} :parameters
+        :as                           _request}]
+    (let [result (domain/record-match-result dependencies match-eid winner-sub)]
+      (if (= :tournament/match-error (:type result))
+        {:status 422 :body result}
+        {:status 200 :body result}))))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
@@ -235,7 +235,11 @@
            (fn [data request]
              (let [state        (domain/get-tournament-state dependencies (:eid data))
                    entries      (domain/get-entries dependencies (:eid data))
-                   matches      (domain/get-matches-for-tournament dependencies (:eid data))
+                   raw-matches  (domain/get-matches-for-tournament dependencies (:eid data))
+                   matches-by-round (->> raw-matches
+                                         (group-by (fn [m] {:phase (:phase-index m) :round (:round-index m)}))
+                                         (sort-by (fn [[k _]] [(:phase k) (:round k)]))
+                                         (mapv (fn [[k ms]] {:phase (:phase k) :round (:round k) :matches ms})))
                    player-sub   (get-in request [:ory-session :identity :id])
                    has-entry    (some #(= player-sub (:player-sub %)) entries)
                    now          (java.time.Instant/now)
@@ -243,7 +247,7 @@
                    is-organizer (= player-sub (:created-by-sub data))]
                {:tournament-state  state
                 :entries           entries
-                :matches           matches
+                :matches-by-round  matches-by-round
                 :has-entry         has-entry
                 :registration-open reg-open
                 :is-organizer      is-organizer}))))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
@@ -235,6 +235,7 @@
            (fn [data request]
              (let [state        (domain/get-tournament-state dependencies (:eid data))
                    entries      (domain/get-entries dependencies (:eid data))
+                   matches      (domain/get-matches-for-tournament dependencies (:eid data))
                    player-sub   (get-in request [:ory-session :identity :id])
                    has-entry    (some #(= player-sub (:player-sub %)) entries)
                    now          (java.time.Instant/now)
@@ -242,6 +243,7 @@
                    is-organizer (= player-sub (:created-by-sub data))]
                {:tournament-state  state
                 :entries           entries
+                :matches           matches
                 :has-entry         has-entry
                 :registration-open reg-open
                 :is-organizer      is-organizer}))))

--- a/docs/rts-api.md
+++ b/docs/rts-api.md
@@ -17,6 +17,7 @@ Visual walkthroughs of each e2e-tested user flow, with annotated screenshots.
 - [Draft Operations](rts-api/flows/draft-operations.md) — create, unit selection, add/remove/edit, validation
 - [Tournament Registration](rts-api/flows/tournament-registration.md) — register, withdraw, validation rules
 - [Tournament State Machine](rts-api/flows/tournament-state-machine.md) — advance lifecycle, organizer controls, standings
+- [Tournament Matches](rts-api/flows/tournament-matches.md) — create matches, record results, standings updates
 
 ## Key paths
 

--- a/docs/rts-api/flows/tournament-matches.md
+++ b/docs/rts-api/flows/tournament-matches.md
@@ -1,0 +1,32 @@
+# Flow: Tournament Matches
+
+Covers match creation, result recording, and standings updates. Matches are nested subresources of a tournament and can only be created when the tournament is active.
+
+## Active tournament with pending match
+
+After activating a tournament and creating a match, the matches table appears with the matchup, round, and "pending" status. Standings show both players at 0/0/0.
+
+![Pending match](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/flows/rts-api/match-pending.png)
+
+## After recording a result
+
+Recording a result via `PUT /api/tournament/:eid/match/:match-eid/result` sets the match status to "complete", records the winner, and recalculates standings. Win = 3 points, draw = 1 point each, loss = 0 points. Byes are ignored.
+
+![Result recorded](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/flows/rts-api/match-result-recorded.png)
+
+## Validation rules
+
+| Rule | Behaviour |
+|------|-----------|
+| Create match when tournament not active | 422 — "Tournament must be active to create matches." |
+| Record result on non-pending match | 422 — "Match is not pending." |
+| Match not found | 422 — "Match not found." |
+
+## API endpoints
+
+| Method | Path | Body | Description |
+|--------|------|------|-------------|
+| GET | `/api/tournament/:eid/match` | — | List all matches |
+| POST | `/api/tournament/:eid/match` | `{phase-index, round-index, player-one-sub, player-two-sub}` | Create match (201 or 422) |
+| GET | `/api/tournament/:eid/match/:match-eid` | — | Get match by eid |
+| PUT | `/api/tournament/:eid/match/:match-eid/result` | `{winner-sub}` | Record result, recalculate standings |

--- a/docs/rts-api/tournament-plan.md
+++ b/docs/rts-api/tournament-plan.md
@@ -274,35 +274,82 @@ CREATE TABLE IF NOT EXISTS match (
 
 ## MVP 5: Swiss Round Phase Logic
 
-Automated Swiss pairing based on standings after each round.
+Automated Swiss pairing based on standings after each round. Also introduces the game sub-resource for best-of-N match formats.
 
-### No new tables
+### New table
 
-Pure domain logic.
+- `000025-create-game-table.up.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS game (
+  id INTEGER PRIMARY KEY ASC,
+  eid TEXT NOT NULL,
+  match_id INTEGER NOT NULL,
+  game_index INTEGER NOT NULL,
+  winner_sub TEXT,
+  created_at TEXT NOT NULL,
+  UNIQUE(eid),
+  FOREIGN KEY(match_id) REFERENCES match(id)
+);
+```
+
+Add `format` column to `match` table (default 1 for bo1):
+
+- `000026-add-match-format.up.sql`: `ALTER TABLE match ADD COLUMN format INTEGER NOT NULL DEFAULT 1;`
+
+### Round format configuration
+
+Each round in the phase config specifies a `format` (best-of-N). Matches created for that round inherit the format. The match auto-completes when one player reaches the win threshold (`ceil(format / 2)`).
+
+```clojure
+{:phases [{:phase-type "swiss"
+           :rounds [{:round-index 0 :format 1}    ;; bo1
+                    {:round-index 1 :format 1}
+                    {:round-index 2 :format 3}]}  ;; bo3 for final swiss round
+          {:phase-type "single-elimination"
+           :rounds [{:round-index 0 :format 3}    ;; bo3 quarterfinals
+                    {:round-index 1 :format 3}    ;; bo3 semis
+                    {:round-index 2 :format 5}]}]} ;; bo5 grand final
+```
+
+### Game sub-resource
+
+Games are individual results within a match. A match with `format=1` (bo1) behaves identically to the current MVP 4 flow (one game = match complete).
+
+- `POST /api/tournament/:eid/match/:match-eid/game` with `{winner-sub}` — records a game result
+- `GET /api/tournament/:eid/match/:match-eid/game` — list games for a match
+- Match auto-completes when a player reaches the win threshold; standings recalculate on match completion
 
 ### Domain layer
 
 - **In `rules/tournament.clj`:**
   - `swiss-pair [standings match-history]` -- pure fn: sort by points, pair adjacent unplayed opponents, handle byes
   - `generate-swiss-round [state match-history]` -- returns updated state with new round
+  - `match-win-threshold [format]` -- `(inc (quot format 2))`
+  - `check-match-complete [games format]` -- returns winner-sub if threshold reached
 - **Handlers:**
   - `configure-phases [deps tournament-eid phase-config]` -- sets `:phases` and `:qualifier-count` in state blob (called before advancing to active)
-  - `generate-next-round [deps tournament-eid]` -- validates current round complete, computes pairings, creates match rows, updates state blob
+  - `generate-next-round [deps tournament-eid]` -- validates current round complete, computes pairings, creates match rows with round format, updates state blob
   - `complete-phase [deps tournament-eid]` -- marks current phase complete, advances `:current-phase`
+  - `record-game-result [deps match-eid winner-sub]` -- records game, checks if match completes, recalculates standings on completion
 
 ### Web layer
 
 - **Routes:**
   - `POST /api/tournament/:eid/configure-phases`
   - `POST /api/tournament/:eid/generate-round`
-- **Templates:** standings table with points, "Generate Next Round" button
+  - `POST /api/tournament/:eid/match/:match-eid/game`
+  - `GET /api/tournament/:eid/match/:match-eid/game`
+- **Templates:** standings table with points, "Generate Next Round" button, game list within match detail
 
 ### Verification
 
-- Configure a Swiss phase with 3 rounds
+- Configure a Swiss phase with 3 rounds (bo1, bo1, bo3)
 - Advance to active, generate round 1 pairings
 - Record all results, generate round 2
 - Verify no repeat pairings, verify bye handling for odd player count
+- Verify bo3 match requires 2 wins to complete
+- Verify standings only update on match completion, not individual games
 
 ---
 

--- a/docs/rts-api/tournament-plan.md
+++ b/docs/rts-api/tournament-plan.md
@@ -251,7 +251,7 @@ CREATE TABLE IF NOT EXISTS match (
 
 - **Handlers:**
   - `create-match [deps tournament-eid match-spec]` -- validates tournament is active
-  - `record-match-result [deps match-eid winner-sub]` -- records result, recalculates standings in state blob
+  - `update-match-result [deps match-eid winner-sub]` -- records result, recalculates standings in state blob
   - `get-matches-for-tournament`, `get-matches-for-round`
 - **Resource schema:** `match-resource` with `:type [:= :tournament/match]`
 - **Result flow:** recording a result updates the match row, then recalculates standings and checks round completion in the state blob
@@ -366,7 +366,7 @@ Qualified players from Swiss enter a seeded elimination bracket.
   - `advance-elimination [state match-result]` -- slots winner into next round's matchup
 - **Handlers:**
   - `start-elimination-phase [deps tournament-eid]` -- validates Swiss complete, generates bracket, creates first-round matches
-  - Enhanced `record-match-result` -- after elimination match, advances winner to next round
+  - Enhanced `update-match-result` -- after elimination match, advances winner to next round
   - `complete-tournament [deps tournament-eid]` -- transitions to `"complete"` after final match
 
 ### Web layer


### PR DESCRIPTION
## Summary

Implements the match entity — MVP 4 of the [tournament plan](docs/rts-api/tournament-plan.md).

- Migration 000024: `match` table with tournament FK, phase/round indexes, player subs, winner, status
- Match CRUD: `POST/GET /api/tournament/:eid/match`, `GET /api/tournament/:eid/match/:match-eid`
- Result recording: `PUT /api/tournament/:eid/match/:match-eid/result` with `{winner-sub}`
- Standings recalculation: `recalculate-standings` rule recomputes from all completed matches (win=3pts, draw=1pt, byes ignored)
- Matches table on tournament detail page
- Flow documentation with screenshots

## Screenshots

### Active tournament with pending match
![Pending match](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/tournament-mvp4/match-pending.png)

### After recording result — standings updated
![Result recorded](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/tournament-mvp4/match-result-recorded.png)

## Test plan

- [x] `clojure -M:poly check` passes
- [x] 4 new rules unit tests (standings: win, draw, bye, multiple matches)
- [x] 8 new handler unit tests (create match, get, record result, validation)
- [x] 5 new e2e tests (create, reject inactive, list, record result with standings, reject non-pending)
- [x] All 27 tournament e2e tests pass, all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)