### PR TITLE
Add DigitalOcean Droplet deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# VCS
+.git
+.gitignore
+.github
+
+# Build outputs / caches
+**/target
+**/.cpcache
+**/.clj-kondo/.cache
+**/.lsp
+.dir-locals.el
+
+# Local dev state
+db
+tmp-data
+deploy/.env
+
+# Editors / OS
+.vscode
+.idea
+.DS_Store
+
+# Node / Playwright
+**/node_modules
+components/e2e/test-results
+components/e2e/playwright-report
+components/e2e/playwright/.cache
+
+# Docs + deploy state not needed in image
+docs
+deploy/Caddyfile
+deploy/docker-compose.yml

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,55 @@
+name: Publish Image
+
+on:
+  push:
+    branches: [main]
+    tags: ['stable-*']
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/com.devereux-henley
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase image name
+        id: image
+        run: echo "name=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.name }}
+          tags: |
+            type=sha,format=long
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: bases/rts-api/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ db/*
 # (regenerated from game files via RPFM MCP, not committed)
 bases/rpfm-scraper/data/
 bases/rpfm-scraper/assets/
+
+# Deploy secrets + local smoke-test data
+deploy/.env
+deploy/data/

--- a/bases/rts-api/Dockerfile
+++ b/bases/rts-api/Dockerfile
@@ -1,22 +1,52 @@
-# Base image that includes the Clojure CLI tools
-FROM clojure:openjdk-17-tools-deps-buster
+# syntax=docker/dockerfile:1.7
 
-RUN mkdir -p /app
+# ---- Builder ----------------------------------------------------------------
+FROM docker.io/library/clojure:temurin-21-tools-deps-bookworm-slim AS builder
+
 WORKDIR /app
 
-# Prepare deps
-COPY components/schema/deps.edn /app/components/schema/deps.edn
-COPY components/content-negotiation/deps.edn /app/components/content-negotiation/deps.edn
-COPY components/resourcekit/deps.edn /app/components/resourcekit/deps.edn
-COPY bases/rts-api/deps.edn /app/bases/rts-api/deps.edn
-RUN clojure -P /app/bases/rts-api/deps.edn
+# Copy just the deps.edn tree first so Docker can cache the dep download layer.
+COPY projects/api/deps.edn                           projects/api/deps.edn
+COPY projects/api/build.clj                          projects/api/build.clj
+COPY bases/rts-api/deps.edn                          bases/rts-api/deps.edn
+COPY bases/rts-data-deploy/deps.edn                  bases/rts-data-deploy/deps.edn
+COPY components/content-negotiation/deps.edn         components/content-negotiation/deps.edn
+COPY components/e2e/deps.edn                         components/e2e/deps.edn
+COPY components/http/deps.edn                        components/http/deps.edn
+COPY components/jdbc/deps.edn                        components/jdbc/deps.edn
+COPY components/resourcekit/deps.edn                 components/resourcekit/deps.edn
+COPY components/rts-data/deps.edn                    components/rts-data/deps.edn
+COPY components/rts-data-access/deps.edn             components/rts-data-access/deps.edn
+COPY components/rts-domain/deps.edn                  components/rts-domain/deps.edn
+COPY components/rts-web/deps.edn                     components/rts-web/deps.edn
+COPY components/schema/deps.edn                      components/schema/deps.edn
 
-# Add sources
-COPY ./components/schema /app/components/schema
-COPY ./components/content-negotiation /app/components/content-negotiation
-COPY ./components/resourcekit /app/components/resourcekit
-COPY ./bases/rts-api /app/bases/rts-api
+RUN cd projects/api && clojure -A:build -P
 
-WORKDIR /app/bases/rts-api
+# Now bring in the actual source and build the uberjar.
+COPY bases/                 bases/
+COPY components/            components/
+COPY projects/              projects/
 
-CMD clojure -M:build
+RUN cd projects/api && clojure -T:build uber
+
+# ---- Runtime ----------------------------------------------------------------
+FROM docker.io/library/eclipse-temurin:21-jre-noble
+
+RUN groupadd --system --gid 10001 app \
+ && useradd  --system --uid 10001 --gid app --home-dir /app --shell /usr/sbin/nologin app \
+ && mkdir -p /app /data \
+ && chown -R app:app /app /data
+
+WORKDIR /app
+COPY --from=builder --chown=app:app /app/projects/api/target/rts-api.jar /app/rts-api.jar
+
+USER app
+
+ENV RTS_API_PORT=3001 \
+    RTS_DB_CONNECTION_URI=jdbc:sqlite:/data/database.db
+
+EXPOSE 3001
+VOLUME ["/data"]
+
+ENTRYPOINT ["java", "-jar", "/app/rts-api.jar"]

--- a/bases/rts-api/Makefile
+++ b/bases/rts-api/Makefile
@@ -1,12 +1,19 @@
+# All docker targets run from the repo root so the Dockerfile's COPY paths
+# (projects/api, components/, bases/) resolve correctly.
+REPO_ROOT := $(shell git rev-parse --show-toplevel)
+
 build_docker:
-	docker build -f Dockerfile -t rts-api ../..
+	docker build -f $(REPO_ROOT)/bases/rts-api/Dockerfile -t rts-api $(REPO_ROOT)
 
 run_docker:
-	docker run -d -p "3001:3001" --name "rts_api_local" rts-api:latest
+	mkdir -p $(REPO_ROOT)/tmp-data
+	docker run -d -p "3001:3001" \
+		-v $(REPO_ROOT)/tmp-data:/data \
+		-e RTS_API_HOSTNAME=http://localhost:3001 \
+		--name "rts_api_local" rts-api:latest
 
 start_docker:
 	docker container start "rts_api_local"
 
 stop_docker:
 	docker container stop "rts_api_local"
-

--- a/bases/rts-api/src/com/devereux_henley/rts_api/db.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/db.clj
@@ -1,14 +1,20 @@
 (ns com.devereux-henley.rts-api.db
   (:require
+   [clojure.string :as str]
    [integrant.core]
    [next.jdbc :as jdbc]))
 
+(def ^:private default-connection-uri "jdbc:sqlite:db/database.db")
+
+(def ^:private connection-uri
+  (or (System/getenv "RTS_DB_CONNECTION_URI") default-connection-uri))
+
 (def db
   {:dbtype "sqlite"
-   :dbname "db/database.db"})
+   :dbname (str/replace connection-uri #"^jdbc:sqlite:" "")})
 
 (def db-spec
-  {:connection-uri "jdbc:sqlite:db/database.db"})
+  {:connection-uri connection-uri})
 
 (defmethod integrant.core/init-key ::connection
   [_init-key _dependencies]

--- a/bases/rts-api/src/com/devereux_henley/rts_api/system.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/system.clj
@@ -7,6 +7,7 @@
 
 (defn go! []
   (reset! system (-> configuration/core-configuration
+                     integrant.core/expand
                      integrant.core/init)))
 
 (defn halt! []

--- a/components/e2e/tests/game-browsing.spec.js
+++ b/components/e2e/tests/game-browsing.spec.js
@@ -4,11 +4,11 @@ const GAME_EID = 'eea787d7-1065-45eb-a3f6-e26f32c294a1';
 const EMPIRE_FACTION_EID = '35dd38fa-2bcc-4492-8f58-a106d0d02cbb';
 
 test.describe('Game browsing', () => {
-  test('game index page loads with factions', async ({ page }) => {
+  test('game index page loads with atlas dropdown', async ({ page }) => {
     await page.goto(`/view/game/${GAME_EID}/index.html`);
     await expect(page).toHaveTitle(/Warhammer III/);
     await expect(page.locator('main#content')).toBeVisible();
-    await expect(page.locator('#factions-dropdown-btn')).toBeVisible();
+    await expect(page.locator('#atlas-dropdown-btn')).toBeVisible();
   });
 
   test('faction page loads with units', async ({ page }) => {
@@ -17,34 +17,31 @@ test.describe('Game browsing', () => {
     await expect(page.locator('main#content')).toBeVisible();
   });
 
-  test('factions dropdown populates after selecting a game', async ({ page }) => {
+  test('atlas dropdown links to the faction list', async ({ page }) => {
     await page.goto(`/view/game/${GAME_EID}/index.html`);
 
-    const factionsButton = page.locator('#factions-dropdown-btn');
-    await expect(factionsButton).toBeVisible();
-    await factionsButton.click();
+    const atlasButton = page.locator('#atlas-dropdown-btn');
+    await expect(atlasButton).toBeVisible();
+    await atlasButton.click();
 
-    const factionsMenu = page.locator('#factions-menu');
-    await expect(factionsMenu).toBeVisible();
+    const atlasMenu = page.locator('#atlas-menu');
+    await expect(atlasMenu).toBeVisible();
 
-    const factionLinks = factionsMenu.locator('a.dropdown-item');
-    const count = await factionLinks.count();
-    expect(count).toBeGreaterThan(0);
-
-    await expect(factionLinks.first()).toBeVisible();
+    const factionsLink = atlasMenu.locator('a.dropdown-item', { hasText: 'Factions' });
+    await expect(factionsLink).toBeVisible();
   });
 
-  test('clicking a faction link navigates to faction page', async ({ page }) => {
-    await page.goto(`/view/game/${GAME_EID}/index.html`);
+  test('clicking a faction card navigates to faction page', async ({ page }) => {
+    await page.goto(`/view/game/${GAME_EID}/faction/index.html`);
 
-    const factionsButton = page.locator('#factions-dropdown-btn');
-    await factionsButton.click();
+    const factionCards = page.locator('a.faction-card');
+    await expect(factionCards.first()).toBeVisible();
 
-    const firstFaction = page.locator('#factions-menu a.dropdown-item').first();
-    const factionName = await firstFaction.textContent();
+    const firstFaction = factionCards.first();
+    const factionName = (await firstFaction.locator('.faction-card-name').textContent()).trim();
     await firstFaction.click();
 
     await expect(page.locator('main#content')).toBeVisible();
-    await expect(page).toHaveTitle(new RegExp(factionName.trim()));
+    await expect(page).toHaveTitle(new RegExp(factionName));
   });
 });

--- a/components/e2e/tests/navigation.spec.js
+++ b/components/e2e/tests/navigation.spec.js
@@ -1,8 +1,8 @@
 const { test, expect } = require('@playwright/test');
 
 test.describe('Static page navigation', () => {
-  test('dashboard loads', async ({ page }) => {
-    await page.goto('/view/dashboard.html');
+  test('game selector loads', async ({ page }) => {
+    await page.goto('/view/game/index.html');
     await expect(page).toHaveTitle(/RTS/);
     await expect(page.locator('nav.navbar')).toBeVisible();
     await expect(page.locator('main#content')).toBeVisible();
@@ -20,25 +20,20 @@ test.describe('Static page navigation', () => {
     await expect(page.locator('main#content')).toBeVisible();
   });
 
-  test('root redirects to dashboard', async ({ page }) => {
+  test('root redirects to game selector', async ({ page }) => {
     await page.goto('/');
-    await expect(page).toHaveURL(/\/view\/dashboard\.html/);
+    await expect(page).toHaveURL(/\/view\/game\/index\.html/);
   });
 
-  test('games dropdown opens and contains game links', async ({ page }) => {
-    await page.goto('/view/dashboard.html');
-    const gamesButton = page.locator('button', { hasText: 'Games' });
-    await expect(gamesButton).toBeVisible();
-
-    await gamesButton.click();
-    const gameMenu = page.locator('#game-menu');
-    await expect(gameMenu).toBeVisible();
-    await expect(gameMenu.locator('a.dropdown-item')).toHaveCount(1);
-    await expect(gameMenu.locator('a.dropdown-item')).toContainText('Total War: Warhammer III');
+  test('game selector lists available games', async ({ page }) => {
+    await page.goto('/view/game/index.html');
+    const gameCards = page.locator('a.game-card');
+    await expect(gameCards.first()).toBeVisible();
+    await expect(gameCards.first()).toContainText('Total War: Warhammer III');
   });
 
   test('navbar shows account menu for dev user', async ({ page }) => {
-    await page.goto('/view/dashboard.html');
+    await page.goto('/view/game/index.html');
     await expect(page.locator('button[aria-label*="Account menu"]')).toBeVisible();
   });
 });

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,23 @@
+# Copy this file to deploy/.env on the target host and fill in real values.
+# deploy/.env is .gitignored; never commit real secrets.
+
+# Container image (pushed by .github/workflows/publish-image.yml).
+# Use a specific SHA or stable-* tag in prod; `latest` is fine for pre-prod.
+APP_IMAGE=ghcr.io/devereux-henley/com.devereux-henley:latest
+
+# Public domain pointing at the Droplet. Caddy obtains a Let's Encrypt cert
+# for this hostname automatically on first boot.
+APP_DOMAIN=rts.example.com
+
+# Base URL used by the app to build HATEOAS _links. Must match APP_DOMAIN.
+RTS_API_HOSTNAME=https://rts.example.com
+
+# Ory Cloud tenant — the API calls ${AUTH_HOSTNAME}/sessions/whoami to
+# validate the ory_session_${AUTH_SLUG} cookie on each request.
+AUTH_HOSTNAME=https://auth.example.com
+AUTH_SLUG=your-ory-slug
+
+# Host directory that persists the SQLite database. On a DO Droplet with a
+# Block Storage volume mounted at /mnt/rts-data, set this to /mnt/rts-data.
+# For local smoke tests, leave it at the default.
+DATA_DIR=./data

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,13 @@
+{$APP_DOMAIN} {
+    encode gzip zstd
+
+    reverse_proxy app:3001 {
+        header_up X-Forwarded-Proto {scheme}
+        header_up X-Forwarded-Host  {host}
+    }
+
+    log {
+        output stdout
+        format console
+    }
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,127 @@
+# DigitalOcean deployment
+
+Target: a single DigitalOcean Droplet running `docker compose`, fronted by Caddy for
+TLS, with SQLite persisted on an attached DO Block Storage volume.
+
+## Layout
+
+- `Dockerfile` — lives at `bases/rts-api/Dockerfile`, builds an uberjar from
+  `projects/api/` and ships it on a slim JRE. Built + pushed to GHCR by
+  `.github/workflows/publish-image.yml` on every push to `main` and every
+  `stable-*` tag.
+- `deploy/docker-compose.yml` — two services: `app` (the API container) and
+  `caddy` (TLS-terminating reverse proxy). SQLite is persisted in a host
+  directory mounted at `/data`.
+- `deploy/Caddyfile` — reverse-proxies `${APP_DOMAIN}` to the `app` container
+  and handles Let's Encrypt automatically.
+- `deploy/.env.example` — the full list of env vars the deploy needs. Copy to
+  `deploy/.env` on the host and fill in real values.
+
+## One-time Droplet bootstrap
+
+1. **Create a Droplet** — Ubuntu 24.04, `s-2vcpu-2gb` is plenty. SSH-key auth.
+2. **Create and attach a Block Storage volume** (e.g. 10 GB). DO's web console
+   writes fstab for you; confirm with `lsblk` and `mount | grep rts-data`.
+   Target mount: `/mnt/rts-data`. The container runs as UID 10001, so the
+   mount point needs to be writable by that UID:
+   ```bash
+   chown -R 10001:10001 /mnt/rts-data
+   ```
+3. **Install Docker + compose plugin**:
+   ```bash
+   apt-get update
+   apt-get install -y ca-certificates curl
+   install -m 0755 -d /etc/apt/keyrings
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+     -o /etc/apt/keyrings/docker.asc
+   chmod a+r /etc/apt/keyrings/docker.asc
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+     https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" \
+     > /etc/apt/sources.list.d/docker.list
+   apt-get update
+   apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+   ```
+4. **Put the deploy files on the host**:
+   ```bash
+   mkdir -p /opt/rts-api
+   scp deploy/docker-compose.yml deploy/Caddyfile deploy/.env.example \
+       root@<droplet-ip>:/opt/rts-api/
+   ssh root@<droplet-ip>
+   cd /opt/rts-api
+   cp .env.example .env
+   # edit .env: APP_IMAGE, APP_DOMAIN, RTS_API_HOSTNAME, AUTH_HOSTNAME,
+   # AUTH_SLUG, DATA_DIR=/mnt/rts-data
+   ```
+5. **Log in to GHCR** so the Droplet can pull the private image. Generate a
+   classic PAT with `read:packages` scope at github.com/settings/tokens:
+   ```bash
+   echo $GHCR_TOKEN | docker login ghcr.io -u <your-gh-username> --password-stdin
+   ```
+6. **Point DNS** — an A record for `${APP_DOMAIN}` → Droplet IPv4. Caddy obtains
+   the cert on first boot; this only works once DNS is live.
+7. **First deploy**:
+   ```bash
+   cd /opt/rts-api
+   docker compose pull
+   docker compose up -d
+   docker compose logs -f app
+   ```
+   Migrations run automatically on startup (see `::rts-data/migrate` in
+   `configuration.clj`). `GET /status` should return `{"status":"ok"}`.
+
+## Subsequent deploys
+
+```bash
+cd /opt/rts-api
+docker compose pull   # fetches the new image tag (update APP_IMAGE in .env
+                      # if pinning to a SHA/stable-* tag)
+docker compose up -d  # recreates the app container with zero-downtime-ish swap
+```
+
+Caddy stays up across deploys; only `app` is recreated.
+
+## Ory Cloud configuration
+
+Not a code change but easy to forget. In the Ory project dashboard:
+
+- Add `https://${APP_DOMAIN}` to **Allowed return URLs** for login + logout
+  flows so Ory redirects the user back after auth.
+- Either set up a **custom domain** on Ory (e.g. `auth.${APP_DOMAIN}`) so the
+  `ory_session_${AUTH_SLUG}` cookie is set on a domain the browser will
+  present back to this app, or accept that cross-site cookies require
+  `SameSite=None` + HTTPS on both ends.
+- `AUTH_HOSTNAME` in `.env` must point at the fully-qualified Ory endpoint
+  (the slug URL or the custom domain).
+
+## Backups
+
+SQLite on a volume survives container restarts but not data corruption. Set up
+a nightly cron on the Droplet:
+
+```cron
+0 3 * * * sqlite3 /mnt/rts-data/database.db ".backup /tmp/backup.db" \
+  && s3cmd put /tmp/backup.db s3://rts-backups/$(date -u +\%Y-\%m-\%d).db \
+  && rm /tmp/backup.db
+```
+
+DO Spaces is S3-compatible and cheap (~$5/mo). Configure `s3cmd` with the
+Spaces access key. Keep 30 days of backups via a lifecycle rule.
+
+## Local smoke test
+
+From the repo root (not the host):
+
+```bash
+docker build -f bases/rts-api/Dockerfile -t rts-api:test .
+
+mkdir -p tmp-data
+docker run --rm -p 3001:3001 \
+  -v $(pwd)/tmp-data:/data \
+  -e RTS_API_HOSTNAME=http://localhost:3001 \
+  -e AUTH_HOSTNAME=http://localhost:4000 \
+  -e AUTH_SLUG=eloquentyalowwhtijq6my4 \
+  rts-api:test
+
+# in another shell
+curl -s http://127.0.0.1:3001/status   # => {"status":"ok"}
+```

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,41 @@
+name: rts-api
+
+services:
+  app:
+    image: ${APP_IMAGE:?APP_IMAGE must be set in .env (e.g. ghcr.io/devereux-henley/com.devereux-henley:latest)}
+    restart: unless-stopped
+    environment:
+      RTS_API_PORT: "3001"
+      RTS_API_HOSTNAME: ${RTS_API_HOSTNAME:?set RTS_API_HOSTNAME in .env}
+      AUTH_HOSTNAME:    ${AUTH_HOSTNAME:?set AUTH_HOSTNAME in .env}
+      AUTH_SLUG:        ${AUTH_SLUG:?set AUTH_SLUG in .env}
+      RTS_DB_CONNECTION_URI: jdbc:sqlite:/data/database.db
+    volumes:
+      - ${DATA_DIR:-./data}:/data
+    expose:
+      - "3001"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3001/status || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      - app
+    environment:
+      APP_DOMAIN: ${APP_DOMAIN:?set APP_DOMAIN in .env}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/projects/api/deps.edn
+++ b/projects/api/deps.edn
@@ -12,5 +12,7 @@
         mono/e2e                     {:local/root "../../components/e2e"}
         mono/rts-api                 {:local/root "../../bases/rts-api"}}
  :aliases {:build {:extra-paths ["."]
-                   :extra-deps  {org.clojure/tools.build {:mvn/version "0.9.4"}}
+                   :extra-deps  {io.github.clojure/tools.build
+                                 {:git/tag "v0.10.13"
+                                  :git/sha "ae52edfedef4ca72e699e9c86abfe0940e97dc26"}}
                    :ns-default  build}}}

--- a/projects/deploy-data/deps.edn
+++ b/projects/deploy-data/deps.edn
@@ -2,5 +2,7 @@
         mono/rts-data        {:local/root "../../components/rts-data"}
         mono/rts-data-deploy {:local/root "../../bases/rts-data-deploy"}}
  :aliases {:build {:extra-paths ["."]
-                   :extra-deps  {org.clojure/tools.build {:mvn/version "0.9.4"}}
+                   :extra-deps  {io.github.clojure/tools.build
+                                 {:git/tag "v0.10.13"
+                                  :git/sha "ae52edfedef4ca72e699e9c86abfe0940e97dc26"}}
                    :ns-default  build}}}


### PR DESCRIPTION
## Summary

- Stands up a full **Droplet + docker-compose** deployment: Caddy fronts the API with automatic Let's Encrypt TLS, SQLite persists on a DO Block Storage volume, and `docker compose pull && up -d` is the whole deploy loop. Bootstrap instructions live in `deploy/README.md`.
- Wires a `publish-image` workflow that builds the image and pushes to GHCR on every push to `main` and every `stable-*` tag (existing `tag-stable` workflow provides the tags).
- Rewrites the stale `Dockerfile` as a multi-stage build from `projects/api/` — the old one copied 4 of 11 required components and `CMD`-ed `clojure -M:build`, which only compiles. Image runs as pinned UID 10001 on a slim Temurin 21 JRE (~400 MB).

## Fixes uncovered along the way

- `db.clj` now honors `RTS_DB_CONNECTION_URI` (matching the migrations CLI). Previously the path was hardcoded, so the container couldn't be pointed at a volume.
- Production `system.clj` now calls `integrant.core/expand` before `init`. Without it, `::configuration/openid-url` never materialised as a top-level key and the prod profile couldn't boot. The dev workspace already did this.
- `projects/api/deps.edn` + `projects/deploy-data/deps.edn` bumped `org.clojure/tools.build 0.9.4` (doesn't exist on Maven Central or Clojars) to git-based `io.github.clojure/tools.build v0.10.13`. `build.clj` couldn't resolve its own classpath before.

## Test plan

- [x] Uberjar builds (`clojure -T:build uber` from `projects/api/`) → 108 MB JAR
- [x] `java -jar rts-api.jar` boots, migrations apply, `GET /status` → `{"status":"ok"}`
- [x] `podman build -f bases/rts-api/Dockerfile .` succeeds → 404 MB image
- [x] Container runs with named volume, all 25 migrations land in SQLite, `/status` ok
- [x] Container process runs as UID 10001 (verified via `podman exec id`)
- [x] `clj-kondo --lint bases components development` → 0 errors, 0 warnings
- [x] `clojure -M:cljfmt check` on touched files → clean
- [ ] Full CI (PR Check + Tag Stable workflows) green
- [ ] First GHCR image published via `publish-image` workflow
- [ ] Droplet smoke: provision, `chown -R 10001:10001 /mnt/rts-data`, `docker compose up -d`, verify HTTPS + `/status` via `APP_DOMAIN`

## Follow-ups (not in this PR)

- Ory Cloud: add prod `APP_DOMAIN` to allowed return URLs (settings only, no code).
- Nightly SQLite backup to DO Spaces (documented in `deploy/README.md`, implementation deferred).
- GitHub Actions SSH deploy step once manual cut-over works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)