### PR TITLE
Add custom-name nameplate to drafts

### DIFF
--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -68,7 +68,8 @@
             :com.devereux-henley.rts-web.web.draft/draft-add-unit
             :com.devereux-henley.rts-web.web.draft/draft-update-unit
             :com.devereux-henley.rts-web.web.draft/draft-remove-unit
-            :com.devereux-henley.rts-web.web.draft/create-draft))
+            :com.devereux-henley.rts-web.web.draft/create-draft
+            :com.devereux-henley.rts-web.web.draft/update-draft))
 
 (def social-media-configuration
   (handlers :com.devereux-henley.rts-web.web.social-media/get-platform))

--- a/components/e2e/tests/draft-name.spec.js
+++ b/components/e2e/tests/draft-name.spec.js
@@ -1,0 +1,79 @@
+const { test, expect } = require('@playwright/test');
+
+const GAME_EID = 'eea787d7-1065-45eb-a3f6-e26f32c294a1';
+const HIGH_ELVES_FACTION_EID = 'f000000a-0000-4000-8000-000000000000';
+const LAND_BATTLE_MODE_EID = 'a1b2c3d4-0001-4000-8000-000000000001';
+
+function addDevCookie(context) {
+  return context.addCookies([
+    {
+      name: 'dev_impersonation',
+      value: 'dev-admin',
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+async function createHighElvesDraft(page) {
+  await page.goto(`/view/game/${GAME_EID}/draft/create.html`);
+  await page.locator('#faction-eid').selectOption(HIGH_ELVES_FACTION_EID);
+  await page.locator('#game-mode-eid').selectOption(LAND_BATTLE_MODE_EID);
+  await page.locator('#create-draft-form button[type="submit"]').click();
+  await expect(page.locator('.draft-page')).toBeVisible({ timeout: 10000 });
+}
+
+test.describe.serial('Draft rename', () => {
+  test.beforeEach(async ({ context }) => {
+    await addDevCookie(context);
+  });
+
+  test('new draft shows faction-and-date placeholder, not a pre-filled name', async ({ page }) => {
+    await createHighElvesDraft(page);
+    const input = page.locator('#draft-name-input');
+    await expect(input).toBeVisible();
+    await expect(input).toHaveValue('');
+    await expect(input).toHaveAttribute('placeholder', /High Elves draft \d{2}\/\d{2}\/\d{4}/);
+    await expect(page).toHaveTitle(/High Elves draft \d{2}\/\d{2}\/\d{4}/);
+  });
+
+  test('typing a custom name persists, re-titles the page, and appears in the My Drafts list', async ({ page }) => {
+    await createHighElvesDraft(page);
+    const input = page.locator('#draft-name-input');
+    await input.fill('Teclis Expeditionary Force');
+    await input.dispatchEvent('input');
+
+    // HTMX PATCH is debounced 500ms. Wait for the "saved" affordance to fire.
+    await expect(page.locator('.draft-nameplate')).toHaveClass(/draft-nameplate--saved/, { timeout: 3000 });
+
+    await page.reload();
+    await expect(page.locator('#draft-name-input')).toHaveValue('Teclis Expeditionary Force');
+    await expect(page).toHaveTitle(/Teclis Expeditionary Force/);
+
+    // My Drafts list shows the custom name, not the default. The dev-admin
+    // DB may accumulate prior renamed drafts across runs — we just need
+    // at least one match.
+    await page.goto(`/view/game/${GAME_EID}/draft/me.html`);
+    await expect(page.locator('a', { hasText: 'Teclis Expeditionary Force' }).first()).toBeVisible();
+  });
+
+  test('clearing the field restores the faction-and-date default', async ({ page }) => {
+    await createHighElvesDraft(page);
+    const input = page.locator('#draft-name-input');
+    await input.fill('Throwaway');
+    await input.dispatchEvent('input');
+    await expect(page.locator('.draft-nameplate')).toHaveClass(/draft-nameplate--saved/, { timeout: 3000 });
+
+    // Clear — empty string should revert to the default on reload.
+    await page.locator('.draft-nameplate').evaluate((el) => el.classList.remove('draft-nameplate--saved'));
+    await input.fill('');
+    await input.dispatchEvent('input');
+    await expect(page.locator('.draft-nameplate')).toHaveClass(/draft-nameplate--saved/, { timeout: 3000 });
+
+    await page.reload();
+    await expect(page.locator('#draft-name-input')).toHaveValue('');
+    await expect(page).toHaveTitle(/High Elves draft \d{2}\/\d{2}\/\d{4}/);
+  });
+});

--- a/components/rts-data-access/resources/rts-data-access/sql/game/get-draft-by-eid.sql
+++ b/components/rts-data-access/resources/rts-data-access/sql/game/get-draft-by-eid.sql
@@ -1,8 +1,11 @@
 SELECT
   d.id,
   d.eid,
+  d.name,
   gm.eid AS game_mode_eid,
   f.eid AS faction_eid,
+  f.name AS faction_name,
+  strftime('%m/%d/%Y', d.created_at) AS created_at_display,
   d.player_sub,
   d.version,
   d.created_at,

--- a/components/rts-data-access/resources/rts-data-access/sql/game/get-drafts-for-player-by-game.sql
+++ b/components/rts-data-access/resources/rts-data-access/sql/game/get-drafts-for-player-by-game.sql
@@ -1,6 +1,7 @@
 SELECT
   d.id,
   d.eid,
+  d.name,
   gm.eid AS game_mode_eid,
   f.eid AS faction_eid,
   f.name AS faction_name,

--- a/components/rts-data-access/resources/rts-data-access/sql/game/get-drafts-for-player.sql
+++ b/components/rts-data-access/resources/rts-data-access/sql/game/get-drafts-for-player.sql
@@ -1,6 +1,7 @@
 SELECT
   d.id,
   d.eid,
+  d.name,
   gm.eid AS game_mode_eid,
   f.eid AS faction_eid,
   d.player_sub,

--- a/components/rts-data-access/resources/rts-data-access/sql/game/update-draft.sql
+++ b/components/rts-data-access/resources/rts-data-access/sql/game/update-draft.sql
@@ -1,0 +1,5 @@
+UPDATE draft
+SET name = ?,
+    updated_at = ?
+WHERE eid = ?
+  AND deleted_at IS NULL

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
@@ -34,6 +34,7 @@
 (def get-drafts-for-player-by-game query.game/get-drafts-for-player-by-game)
 
 (def create-draft query.game/create-draft)
+(def update-draft query.game/update-draft)
 
 (def get-game-mode-by-eid query.game/get-game-mode-by-eid)
 

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/game.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/game.clj
@@ -55,6 +55,7 @@
 (def get-mount-by-key-query (resource/load-query-resource "game" "get-mount-by-key.sql"))
 
 (def upsert-draft-state-query (resource/load-query-resource "game" "upsert-draft-state.sql"))
+(def update-draft-query (resource/load-query-resource "game" "update-draft.sql"))
 
 (defn get-game-by-eid
   {:malli/schema (schema.contract/to-schema
@@ -279,3 +280,13 @@
                                  (assoc :game-mode-id (:id game-mode))
                                  (assoc :faction-id (:id faction))))
       (get-draft-by-eid connection (:eid specification)))))
+
+(defn update-draft
+  "Applies a partial update to a draft. Currently the only mutable field
+  is :name (nil clears the custom name and lets the default render).
+  Returns the refreshed entity."
+  [connection draft-eid {:keys [name]}]
+  (jdbc.contract/execute-one!
+   connection
+   [update-draft-query name (str (Instant/now)) draft-eid])
+  (get-draft-by-eid connection draft-eid))

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema.clj
@@ -25,6 +25,7 @@
   (schema.contract/to-schema
    [:map
     [:eid :uuid]
+    [:name {:optional true} [:maybe :string]]
     [:game-mode-eid :uuid]
     [:faction-eid :uuid]
     [:player-sub :string]
@@ -38,8 +39,11 @@
    [:map
     [:id :int]
     [:eid :uuid]
+    [:name {:optional true} [:maybe :string]]
     [:game-mode-eid :uuid]
     [:faction-eid :uuid]
+    [:faction-name {:optional true} :string]
+    [:created-at-display {:optional true} :string]
     [:player-sub :string]
     [:version :int]
     [:created-at :instant]

--- a/components/rts-data/resources/rts-data/migrations/000009-create-draft-table.up.sql
+++ b/components/rts-data/resources/rts-data/migrations/000009-create-draft-table.up.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS draft (
   id INTEGER PRIMARY KEY ASC,
   eid TEXT NOT NULL,
+  name TEXT,
   game_mode_id INTEGER NOT NULL,
   faction_id INTEGER NOT NULL,
   player_sub TEXT NOT NULL,

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
@@ -17,6 +17,7 @@
 (def draft-resource schema/draft-resource)
 
 (def create-draft-specification       schema/create-draft-specification)
+(def update-draft-specification       schema/update-draft-specification)
 (def add-unit-to-draft-specification  schema/add-unit-to-draft-specification)
 
 (def draft-error-response schema/draft-error-response)
@@ -58,6 +59,7 @@
 (def get-drafts-for-player                      handlers.draft/get-drafts-for-player)
 (def get-drafts-for-player-by-game              handlers.draft/get-drafts-for-player-by-game)
 (def create-draft                               handlers.draft/create-draft)
+(def update-draft                               handlers.draft/update-draft)
 (def get-draft-state                            handlers.draft/get-draft-state)
 (def set-draft-state                            handlers.draft/set-draft-state)
 (def parse-unit-statistics                      handlers.draft/parse-unit-statistics)

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/draft.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/draft.clj
@@ -205,32 +205,63 @@
 
 ;; ─── Draft state ──────────────────────────────────────────────────────────────
 
+(defn- draft-default-name
+  "Fallback display name when a draft hasn't been renamed: 'Faction draft
+  mm/dd/yyyy'. Both inputs come from the SQL projection (faction-name +
+  created-at-display)."
+  [{:keys [faction-name created-at-display]}]
+  (when (and faction-name created-at-display)
+    (str faction-name " draft " created-at-display)))
+
+(defn- with-display-name
+  "Attaches :display-name — the custom :name (trimmed, ignored when
+  blank) when set, else the faction/date default. Templates read
+  :display-name so they never need to know which side of the OR they
+  got."
+  [draft]
+  (let [trimmed (some-> (:name draft) str/trim not-empty)]
+    (assoc draft :display-name (or trimmed (draft-default-name draft)))))
+
 (defn get-draft-by-eid
-  "Fetches a draft by eid and attaches :type :game/draft."
+  "Fetches a draft by eid and attaches :type :game/draft + :display-name."
   [dependencies eid]
-  (assoc (db/get-draft-by-eid (:connection dependencies) eid) :type :game/draft))
+  (-> (db/get-draft-by-eid (:connection dependencies) eid)
+      with-display-name
+      (assoc :type :game/draft)))
 
 (defn create-draft
   "Creates a new draft, stamping :created-at and :updated-at, and attaches :type :game/draft."
   [dependencies create-specification]
   (let [created-at (Instant/now)
         updated-at created-at]
-    (assoc (db/create-draft (:connection dependencies)
-                            (-> create-specification
-                                (assoc :created-at created-at)
-                                (assoc :updated-at updated-at)))
-           :type :game/draft)))
+    (-> (db/create-draft (:connection dependencies)
+                         (-> create-specification
+                             (assoc :created-at created-at)
+                             (assoc :updated-at updated-at)))
+        with-display-name
+        (assoc :type :game/draft))))
+
+(defn update-draft
+  "Applies a partial update to a draft. Currently only :name is
+  mutable — empty/whitespace-only clears the stored name so the default
+  (faction + date) renders again. Returns the refreshed draft with
+  :display-name recomputed."
+  [dependencies eid {:keys [name] :as _updates}]
+  (let [normalised (when name (not-empty (str/trim name)))]
+    (-> (db/update-draft (:connection dependencies) eid {:name normalised})
+        with-display-name
+        (assoc :type :game/draft))))
 
 (defn get-drafts-for-player
   "Returns all drafts for a player, each tagged with :type :game/draft."
   [dependencies player-sub]
-  (mapv (fn [draft] (assoc draft :type :game/draft))
+  (mapv (fn [draft] (-> draft with-display-name (assoc :type :game/draft)))
         (db/get-drafts-for-player (:connection dependencies) player-sub)))
 
 (defn get-drafts-for-player-by-game
   "Returns all drafts for a player scoped to a specific game, each tagged with :type :game/draft."
   [dependencies player-sub game-eid]
-  (mapv (fn [draft] (assoc draft :type :game/draft))
+  (mapv (fn [draft] (-> draft with-display-name (assoc :type :game/draft)))
         (db/get-drafts-for-player-by-game (:connection dependencies) player-sub game-eid)))
 
 (def ^:private state-entry-schema

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/schema.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/schema.clj
@@ -372,6 +372,8 @@
      [:type [:= :game/draft]]
      [:game-mode-eid {:model/link :game-mode/by-eid} :uuid]
      [:faction-eid {:model/link :game/faction-by-eid} :uuid]
+     [:name {:optional true} [:maybe :string]]
+     [:display-name {:optional true} :string]
      [:player-sub :string]])))
 
 (def create-draft-specification
@@ -379,7 +381,16 @@
    [:map
     [:game-eid :uuid]
     [:game-mode-eid :uuid]
-    [:faction-eid :uuid]]))
+    [:faction-eid :uuid]
+    [:name {:optional true} [:maybe [:string {:max 60}]]]]))
+
+(def update-draft-specification
+  "Partial update on a draft. Currently only the custom :name is mutable
+  — empty string clears the stored name so the default (faction + date)
+  renders again."
+  (schema.contract/to-schema
+   [:map
+    [:name {:optional true} [:maybe [:string {:max 60}]]]]))
 
 (def draft-error-response
   (schema.contract/to-schema

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/draft_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/draft_test.clj
@@ -185,6 +185,65 @@
       (handlers.draft/create-draft test-deps test-draft)
       (is (= (:created-at @captured) (:updated-at @captured))))))
 
+;; --- display name ---
+
+(def ^:private named-draft
+  (assoc test-draft
+         :name               "Teclis Expeditionary Force"
+         :faction-name       "High Elves"
+         :created-at-display "04/21/2026"))
+
+(def ^:private unnamed-draft
+  (assoc test-draft
+         :name               nil
+         :faction-name       "High Elves"
+         :created-at-display "04/21/2026"))
+
+(deftest get-draft-by-eid-uses-custom-name-for-display
+  (with-redefs [data-access.contract/get-draft-by-eid (fn [_ _] named-draft)]
+    (is (= "Teclis Expeditionary Force"
+           (:display-name (handlers.draft/get-draft-by-eid test-deps test-draft-eid))))))
+
+(deftest get-draft-by-eid-falls-back-to-faction-date-default
+  (with-redefs [data-access.contract/get-draft-by-eid (fn [_ _] unnamed-draft)]
+    (is (= "High Elves draft 04/21/2026"
+           (:display-name (handlers.draft/get-draft-by-eid test-deps test-draft-eid))))))
+
+(deftest get-draft-by-eid-treats-blank-name-as-default
+  (with-redefs [data-access.contract/get-draft-by-eid (fn [_ _] (assoc unnamed-draft :name "   "))]
+    (is (= "High Elves draft 04/21/2026"
+           (:display-name (handlers.draft/get-draft-by-eid test-deps test-draft-eid))))))
+
+(deftest get-drafts-for-player-by-game-attaches-display-name-to-each
+  (with-redefs [data-access.contract/get-drafts-for-player-by-game
+                (fn [_ _ _] [named-draft unnamed-draft])]
+    (let [results (handlers.draft/get-drafts-for-player-by-game test-deps test-player-sub (UUID/randomUUID))]
+      (is (= ["Teclis Expeditionary Force" "High Elves draft 04/21/2026"]
+             (mapv :display-name results))))))
+
+;; --- update-draft ---
+
+(deftest update-draft-persists-trimmed-name-and-recomputes-display
+  (let [captured (atom nil)]
+    (with-redefs [data-access.contract/update-draft
+                  (fn [_ _eid updates]
+                    (reset! captured updates)
+                    (assoc unnamed-draft :name (:name updates)))]
+      (let [result (handlers.draft/update-draft test-deps test-draft-eid {:name "  Avelorn Corps  "})]
+        (is (= "Avelorn Corps" (:name @captured)))
+        (is (= "Avelorn Corps" (:display-name result)))
+        (is (= :game/draft (:type result)))))))
+
+(deftest update-draft-with-empty-name-clears-the-column
+  (let [captured (atom :sentinel)]
+    (with-redefs [data-access.contract/update-draft
+                  (fn [_ _eid updates]
+                    (reset! captured updates)
+                    (assoc unnamed-draft :name nil))]
+      (let [result (handlers.draft/update-draft test-deps test-draft-eid {:name "   "})]
+        (is (nil? (:name @captured)))
+        (is (= "High Elves draft 04/21/2026" (:display-name result)))))))
+
 ;; --- get-drafts-for-player ---
 
 (deftest get-drafts-for-player-assigns-type-to-each-draft

--- a/components/rts-web/resources/rts-web/asset/style/themes/warhammer3-app.css
+++ b/components/rts-web/resources/rts-web/asset/style/themes/warhammer3-app.css
@@ -429,7 +429,8 @@ a:hover:has(img) {
 /* Page layout: army builder (fixed top) + roster/panel (scrollable bottom) */
 .draft-page {
   display: grid;
-  grid-template-rows: auto 1fr;
+  /* Campaign nameplate + Army Builder + scrollable roster/stats column. */
+  grid-template-rows: auto auto 1fr;
   /* Fill the full scroll height app-content offers us. app-content owns
      the viewport-minus-navbar sizing now, so taking 100% here prevents a
      4px overflow (which would otherwise show a hairline app-content
@@ -437,6 +438,143 @@ a:hover:has(img) {
   height: 100%;
   overflow: hidden;
   background-color: #0a0806;
+}
+
+/* ─── Campaign nameplate ────────────────────────────────────────────────
+   Single-row bronze plaque above the Army Builder. The draft's identity
+   is the first thing the eye lands on after the navbar. Input reads as
+   a heading; the entire surface stays restrained so it doesn't fight
+   the red-gradient section banners below it. */
+
+.draft-nameplate {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  min-height: 2.75rem;
+  padding: 0 var(--space-6);
+  background:
+    linear-gradient(180deg,
+                    color-mix(in srgb, var(--color-neutral-200) 65%, transparent) 0%,
+                    color-mix(in srgb, var(--color-neutral-100) 90%, transparent) 100%);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-primary-500) 30%, var(--color-border));
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-primary-700) 12%, transparent);
+}
+
+.draft-nameplate::before,
+.draft-nameplate::after {
+  /* Top + bottom hairlines — a drafted double rule that echoes the
+     navbar's own ::after treatment elsewhere in the shell. */
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+  pointer-events: none;
+}
+.draft-nameplate::before {
+  top: 0;
+  background: linear-gradient(90deg,
+                              transparent 0%,
+                              color-mix(in srgb, var(--color-primary-600) 55%, transparent) 40%,
+                              color-mix(in srgb, var(--color-primary-600) 55%, transparent) 60%,
+                              transparent 100%);
+}
+.draft-nameplate::after {
+  bottom: -3px;
+  background: color-mix(in srgb, var(--color-primary-500) 18%, transparent);
+}
+
+.draft-nameplate-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding-left: var(--space-4);
+}
+
+.draft-nameplate-field::before {
+  /* Heraldic gold bookmark — matches .lore-select-field::before so the
+     two themed controls feel like siblings. */
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 10px;
+  bottom: 10px;
+  width: 2px;
+  background: linear-gradient(180deg,
+                              color-mix(in srgb, var(--color-primary-700) 90%, transparent),
+                              color-mix(in srgb, var(--color-primary-500) 45%, transparent));
+}
+
+.draft-nameplate-input {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  padding: var(--space-2) 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  font-family: var(--font-family-heading);
+  font-size: 1rem;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-primary-800) 85%, var(--color-neutral-900));
+  line-height: 1.3;
+  caret-color: var(--color-primary-600);
+  outline: none;
+  /* Gold underline that grows in on focus. */
+  background-image: linear-gradient(90deg,
+                                    color-mix(in srgb, var(--color-primary-600) 80%, transparent),
+                                    color-mix(in srgb, var(--color-primary-500) 30%, transparent));
+  background-repeat: no-repeat;
+  background-position: 0 100%;
+  background-size: 0 1px;
+  transition: background-size 180ms ease-out, color 140ms ease;
+}
+
+.draft-nameplate-input::placeholder {
+  font-family: var(--font-family-base);
+  font-style: italic;
+  font-weight: var(--font-weight-normal);
+  letter-spacing: 0.04em;
+  text-transform: none;
+  color: color-mix(in srgb, var(--color-text-muted) 80%, var(--color-neutral-900));
+  opacity: 1;
+}
+
+.draft-nameplate-input:hover {
+  color: var(--color-primary-800);
+}
+
+.draft-nameplate-input:focus-visible {
+  color: var(--color-primary-800);
+  background-size: 100% 1px;
+}
+
+.draft-nameplate-saved {
+  flex-shrink: 0;
+  font-family: var(--font-family-heading);
+  font-size: 0.7rem;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-success-600) 85%, var(--color-neutral-900));
+  opacity: 0;
+  transform: translateY(0);
+  pointer-events: none;
+}
+
+.draft-nameplate--saved .draft-nameplate-saved {
+  animation: draft-nameplate-saved-pulse 1.4s ease forwards;
+}
+
+@keyframes draft-nameplate-saved-pulse {
+  0%   { opacity: 0;   transform: translateY(2px); }
+  18%  { opacity: 1;   transform: translateY(0); }
+  70%  { opacity: 1;   transform: translateY(0); }
+  100% { opacity: 0;   transform: translateY(-2px); }
 }
 
 /* ─── Army Builder ───────────────────────────────────────────────────────── */

--- a/components/rts-web/resources/rts-web/view/draft-index.html
+++ b/components/rts-web/resources/rts-web/view/draft-index.html
@@ -1,11 +1,37 @@
 {% extends "rts-web/template/entrypoint.html" %}
 
-{% block title %}{{faction.name}} Draft | {{game.name}} | RTS-UI{% endblock %}
+{% block title %}{{data.display-name}} | {{game.name}} | RTS-UI{% endblock %}
 
 {% block content %}
-<title id="page-title" hx-swap-oob="true">{{faction.name}} Draft | {{game.name}} | RTS-UI</title>
+<title id="page-title" hx-swap-oob="true">{{data.display-name}} | {{game.name}} | RTS-UI</title>
 
 <div class="draft-page">
+
+    <!-- ═══════════════════════════════════════════════════════════ -->
+    <!-- Campaign nameplate — renames the draft                      -->
+    <!-- ═══════════════════════════════════════════════════════════ -->
+    <header class="draft-nameplate" aria-label="Draft name">
+        <label class="draft-nameplate-field" for="draft-name-input">
+            <span class="sr-only">Draft name</span>
+            <input id="draft-name-input"
+                   class="draft-nameplate-input"
+                   type="text"
+                   name="name"
+                   maxlength="60"
+                   value="{{data.name}}"
+                   placeholder="{{data.faction-name}} draft {{data.created-at-display}}"
+                   autocomplete="off"
+                   spellcheck="false"
+                   aria-describedby="draft-nameplate-hint"
+                   hx-patch="/api/draft/{{data.eid}}"
+                   hx-ext="json-enc"
+                   hx-trigger="input changed delay:500ms, blur changed"
+                   hx-swap="none"
+                   hx-on::after-request="this.closest('.draft-nameplate').classList.toggle('draft-nameplate--saved', event.detail.successful)">
+            <span id="draft-nameplate-hint" class="sr-only">Up to 60 characters. Leave blank to restore the default name.</span>
+            <span class="draft-nameplate-saved" role="status" aria-live="polite">Saved</span>
+        </label>
+    </header>
 
     <!-- ═══════════════════════════════════════════════════════════ -->
     <!-- Army Builder                                               -->

--- a/components/rts-web/resources/rts-web/view/my-drafts.html
+++ b/components/rts-web/resources/rts-web/view/my-drafts.html
@@ -13,7 +13,7 @@
         <ul>
             {% for draft in drafts %}
             <li>
-                <a href="/view/game/{{game-eid}}/draft/{{draft.eid}}/index.html">{{draft.faction-name}} draft {{draft.created-at-display}}</a>
+                <a href="/view/game/{{game-eid}}/draft/{{draft.eid}}/index.html">{{draft.display-name}}</a>
             </li>
             {% endfor %}
         </ul>

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/draft.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/draft.clj
@@ -31,12 +31,12 @@
 
 (defmethod integrant.core/init-key ::create-draft
   [_init-key dependencies]
-  (fn [{{{:keys [faction-eid game-mode-eid game-eid]} :body
-         {:keys [version]}                            :query
-         {:keys [eid]}                                :path} :parameters
-        router                                               :reitit.core/router
-        session                                              :ory-session
-        :as                                                  _request}]
+  (fn [{{{:keys [faction-eid game-mode-eid game-eid name]} :body
+         {:keys [version]}                                 :query
+         {:keys [eid]}                                     :path} :parameters
+        router                                                    :reitit.core/router
+        session                                                   :ory-session
+        :as                                                       _request}]
     (let [response (web.core/handle-create-response
                     domain/draft-resource
                     {:hostname (:hostname dependencies) :router router}
@@ -44,11 +44,23 @@
                       dependencies
                       {:faction-eid    faction-eid
                        :game-mode-eid  game-mode-eid
+                       :name           name
                        :player-sub     (get-in session [:identity :id])
                        :created-by-sub (get-in session [:identity :id])
                        :eid            eid
                        :version        version}))]
       (assoc-in response [:headers "HX-Redirect"] (str "/view/game/" game-eid "/draft/" eid "/index.html")))))
+
+(defmethod integrant.core/init-key ::update-draft
+  [_init-key dependencies]
+  (fn [{{{:keys [eid]} :path
+         body          :body} :parameters
+        router                :reitit.core/router
+        :as                   _request}]
+    (web.core/handle-fetch-response
+     domain/draft-resource
+     {:hostname (:hostname dependencies) :router router}
+     #(domain/update-draft dependencies eid (select-keys (or body {}) [:name])))))
 
 (defmethod integrant.core/init-key ::get-draft-unit
   [_init-key dependencies]

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -263,16 +263,25 @@
                            500 {:body domain/draft-error-response}}
               :handler    (integrant.core/ref ::web.draft/draft-remove-unit)}}]
    ["/draft/:eid"
-    {:name :draft/by-eid
-     :put  {:summary    "Creates a draft with the given eid and version."
-            :openapi    {:tags         ["draft"]
-                         :produces     ["application/json" "application/htmx+html"]
-                         :operation-id "draft/create"}
-            :parameters {:path  schema.contract/id-path-parameter
-                         :query schema.contract/version-query-parameter
-                         :body  domain/create-draft-specification}
-            :responses  {201 {:body domain/draft-resource}}
-            :handler    (integrant.core/ref ::web.draft/create-draft)}}]
+    {:name  :draft/by-eid
+     :put   {:summary    "Creates a draft with the given eid and version."
+             :openapi    {:tags         ["draft"]
+                          :produces     ["application/json" "application/htmx+html"]
+                          :operation-id "draft/create"}
+             :parameters {:path  schema.contract/id-path-parameter
+                          :query schema.contract/version-query-parameter
+                          :body  domain/create-draft-specification}
+             :responses  {201 {:body domain/draft-resource}}
+             :handler    (integrant.core/ref ::web.draft/create-draft)}
+     :patch {:summary    "Applies a partial update to a draft (currently only :name)."
+             :openapi    {:tags         ["draft"]
+                          :produces     ["application/json" "application/htmx+html"]
+                          :operation-id "draft/update"}
+             :parameters {:path schema.contract/id-path-parameter
+                          :body domain/update-draft-specification}
+             :responses  {200 {:body domain/draft-resource}
+                          500 {:body domain/draft-error-response}}
+             :handler    (integrant.core/ref ::web.draft/update-draft)}}]
 
    ["/tournament"
     [""


### PR DESCRIPTION
## Summary

- **Data**: `draft.name` added to the original migration (no new migration — drop DB and reseed). SQL projections return the name alongside `faction_name` + `created_at_display` so the domain can compute `:display-name` uniformly.
- **API**: `PATCH /api/draft/:eid` with `{name: string}` body; empty/whitespace clears back to default. PUT also accepts optional `:name` on create. Exposed as a generic `update-draft` (one-field today, extensible tomorrow) rather than name-specific.
- **UI**: new "Campaign nameplate" above the Army Builder — always-editable input styled as a heading, bronze hairline border, gold left bookmark matching `.lore-select-field`, Cinzel caps on closed state, Crimson italic placeholder showing the faction + date default. HTMX debounced 500ms, "SAVED" pulse fires on success.
- **List**: My Drafts shows the custom name when set, default when not.

![Nameplate in edit state](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/naming-drafts/draft-nameplate.png)

## Test plan

- [x] 68 domain tests (6 new) covering default-name fallback, blank-name-treated-as-default, trimmed persistence, and clear-to-null
- [x] `components/e2e/tests/draft-name.spec.js` (4 scenarios): placeholder on fresh draft, type → persist → re-title → appears in list, clear → default returns
- [x] All 88 Playwright e2e tests pass end-to-end (draft-operations, draft-lore, draft-mount, draft-api, draft-name, tournament, navigation, game-browsing)
- [x] `clojure -M:cljfmt check`, `clj-kondo`, `clojure -M:poly check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)