### PR TITLE
Strip nil :model/link values in the transformer

### DIFF
--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -9,26 +9,13 @@
 
 (def ^:private json-mapper (jsonista/object-mapper {:decode-key-fn keyword}))
 
-(defn- dissoc-nil-keys
-  "Removes keys whose values are nil. The model-transformer's :model/link
-   resolution can't handle nil eids; absent keys are skipped, but nil-valued
-   keys would crash route lookup."
-  [m & ks]
-  (reduce (fn [acc k] (if (nil? (get acc k)) (dissoc acc k) acc)) m ks))
-
 (defn- tag-tournament
   [tournament]
-  (when tournament
-    (-> tournament
-        (assoc :type :tournament/tournament)
-        (dissoc-nil-keys :league-eid :season-eid))))
+  (some-> tournament (assoc :type :tournament/tournament)))
 
 (defn- tag-match
   [match]
-  (when match
-    (-> match
-        (assoc :type :tournament/match)
-        (dissoc-nil-keys :player-one-draft-eid :player-two-draft-eid))))
+  (some-> match (assoc :type :tournament/match)))
 
 (defn get-tournament-by-eid
   "Fetches a tournament by eid and attaches :type :tournament/tournament."

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
@@ -341,17 +341,12 @@
                    :created-by-sub         "dev-admin"                                              :version     1})]
       (is (= :tournament/create-error (:type result))))))
 
-;; ─── tag-tournament strips nil league/season-eid ────────────────────────────
+;; ─── tag-tournament passes nil league/season-eid through ──────────────────
+;; Stripping happens in the schema model-transformer at the response boundary
+;; (see com.devereux-henley.schema.contract/handle-model-transform); the
+;; handler just preserves whatever the data layer hands it.
 
-(deftest get-tournament-omits-nil-league-season-eids
-  (with-redefs [data-access.contract/get-tournament-by-eid
-                (fn [_ _] (assoc test-tournament :league-eid nil :season-eid nil))]
-    (let [result (handlers.tournament/get-tournament-by-eid test-deps test-tournament-eid)]
-      (is (not (contains? result :league-eid))
-          "nil :league-eid must be dissoc'd so the model-transformer doesn't crash on link resolution")
-      (is (not (contains? result :season-eid))))))
-
-(deftest get-tournament-keeps-non-nil-league-season-eids
+(deftest get-tournament-passes-non-nil-league-season-eids-through
   (with-redefs [data-access.contract/get-tournament-by-eid
                 (fn [_ _] (assoc test-tournament :league-eid test-league-eid :season-eid test-season-eid))]
     (let [result (handlers.tournament/get-tournament-by-eid test-deps test-tournament-eid)]

--- a/components/schema/src/com/devereux_henley/schema/contract.clj
+++ b/components/schema/src/com/devereux_henley/schema/contract.clj
@@ -303,14 +303,16 @@
                                                  (ZoneId/of tz-string)))}}))
 
 (defn- parent-eid-params
-  "Collects every `*-eid` keyed field from the map into a path-params map
-   keyed by field name. Enables nested resources to self-link via routes
+  "Collects every non-nil `*-eid` keyed field from the map into a path-params
+   map keyed by field name. Enables nested resources to self-link via routes
    whose path requires more than one eid (e.g. `/draft/:draft-eid/entry/:eid`).
    Reitit silently drops extras, so passing this set alongside `{:eid v}` is
-   safe for single-param routes as well."
+   safe for single-param routes as well. Nil values are skipped so optional
+   foreign-key eids don't poison link resolution."
   [value]
   (reduce-kv (fn [acc k v]
                (if (and (keyword? k)
+                        (some? v)
                         (clojure.string/ends-with? (name k) "-eid"))
                  (assoc acc k v)
                  acc))
@@ -324,7 +326,15 @@
       (let [parent-params (parent-eid-params value)]
         (reduce-kv
          (fn [acc k v]
-           (if-let [link (get mapping k)]
+           (cond
+             ;; Linked key with a nil value (e.g. an optional foreign-key eid
+             ;; that wasn't set): skip both the field and its link entry so
+             ;; the response stays clean and reitit.core/match->path doesn't
+             ;; receive a nil :eid.
+             (and (contains? mapping k) (nil? v))
+             acc
+
+             (contains? mapping k)
              (-> acc
                  (assoc k v)
                  (assoc-in [:_links
@@ -334,8 +344,10 @@
                                (clojure.string/replace (name k) #"-eid" "")))]
                            (to-resource-link
                             route-data
-                            link
+                            (get mapping k)
                             (assoc parent-params :eid v))))
+
+             :else
              (assoc acc k v)))
          (vary-meta {}
                     assoc

--- a/components/schema/test/com/devereux_henley/schema/contract_test.clj
+++ b/components/schema/test/com/devereux_henley/schema/contract_test.clj
@@ -1,5 +1,71 @@
 (ns com.devereux-henley.schema.contract-test
-  (:require [clojure.test :refer [deftest is]]))
+  (:require
+   [clojure.test :refer [deftest is]]
+   [com.devereux-henley.schema.contract :as schema.contract]
+   [malli.core :as m]
+   [malli.util]
+   [reitit.core :as reitit]))
 
 (deftest dummy-test
   (is (= 1 1)))
+
+(def ^:private tournament-resource
+  (malli.util/merge
+   schema.contract/base-resource
+   (schema.contract/to-schema
+    [:map
+     [:eid {:model/link :tournament/by-eid} :uuid]
+     [:type [:= :tournament/tournament]]
+     [:name :string]
+     [:league-eid {:optional true :model/link :league/by-eid} :uuid]
+     [:season-eid {:optional true :model/link :season/by-eid} :uuid]
+     [:_links
+      [:map
+       [:self :url]
+       [:league {:optional true} :url]
+       [:season {:optional true} :url]]]])))
+
+(def ^:private router
+  (reitit/router
+   [["/api/tournament/:eid" {:name :tournament/by-eid}]
+    ["/api/league/:eid"     {:name :league/by-eid}]
+    ["/api/season/:eid"     {:name :season/by-eid}]]))
+
+(def ^:private route-data
+  {:hostname "http://localhost:3001" :router router})
+
+(defn- encode
+  [value]
+  (m/encode tournament-resource value (schema.contract/model-transformer route-data)))
+
+(deftest model-transformer-strips-nil-linked-eids
+  (let [eid    #uuid "11111111-1111-1111-1111-111111111111"
+        result (encode {:type       :tournament/tournament
+                        :eid        eid
+                        :name       "Standalone"
+                        :league-eid nil
+                        :season-eid nil})]
+    (is (not (contains? result :league-eid))
+        "nil :league-eid should be dropped from the encoded resource")
+    (is (not (contains? result :season-eid)))
+    (is (not (contains? (:_links result) :league))
+        "no :league link should be emitted when :league-eid is nil")
+    (is (not (contains? (:_links result) :season)))
+    (is (= (str "http://localhost:3001/api/tournament/" eid)
+           (get-in result [:_links :self])))))
+
+(deftest model-transformer-builds-links-for-non-nil-eids
+  (let [eid        #uuid "11111111-1111-1111-1111-111111111111"
+        league-eid #uuid "22222222-2222-2222-2222-222222222222"
+        season-eid #uuid "33333333-3333-3333-3333-333333333333"
+        result     (encode {:type       :tournament/tournament
+                            :eid        eid
+                            :name       "Attached"
+                            :league-eid league-eid
+                            :season-eid season-eid})]
+    (is (= league-eid (:league-eid result)))
+    (is (= season-eid (:season-eid result)))
+    (is (= (str "http://localhost:3001/api/league/" league-eid)
+           (get-in result [:_links :league])))
+    (is (= (str "http://localhost:3001/api/season/" season-eid)
+           (get-in result [:_links :season])))))


### PR DESCRIPTION
## Summary

- Move nil handling for `:model/link`-annotated fields into `schema.contract/handle-model-transform`. When the value is `nil`, skip both the field and its `_links` entry so optional foreign-key eids (e.g. a standalone tournament's `:league-eid`) don't crash `reitit.core/match->path`. Also filter nil `*-eid` values out of `parent-eid-params` so optional parent eids can't poison nested-route lookups.
- Drop `dissoc-nil-keys` from `handlers/tournament.clj` — `tag-tournament` and `tag-match` collapse to one-line `(some-> x (assoc :type ...))`.
- Replace the two stale handler-level `omits-nil` tests with a transformer-level pair in `schema/contract_test.clj` that exercises both nil-stripping and happy-path link generation against a minimal reitit router.

Wire shape on the JSON response is unchanged — no `"foo-eid": null` ever surfaces.

## Test plan

- [x] `clojure -M:poly check` — OK
- [x] 42 affected unit tests pass (`tournament-test` + new `schema.contract-test`)
- [x] Live API smoke: standalone tournament returns no `league-eid`/`season-eid`/`_links.league`/`_links.season`; attached tournament returns all four
- [x] Live league + tournament HTML views still render 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)