### PR TITLE
Style standings table, list rows, and My Drafts (design review pass 1)

### DIFF
--- a/components/rts-data-access/resources/rts-data-access/sql/game/get-drafts-for-player-by-game.sql
+++ b/components/rts-data-access/resources/rts-data-access/sql/game/get-drafts-for-player-by-game.sql
@@ -6,6 +6,7 @@ SELECT
   f.eid AS faction_eid,
   f.name AS faction_name,
   strftime('%m/%d/%Y', d.created_at) AS created_at_display,
+  strftime('%m/%d/%Y', d.updated_at) AS updated_at_display,
   d.player_sub,
   d.version,
   d.created_at,
@@ -18,4 +19,4 @@ FROM
   INNER JOIN faction f ON f.id = d.faction_id
 WHERE d.player_sub = ?
   AND g.eid = ?
-ORDER BY d.id
+ORDER BY d.updated_at DESC, d.id

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema.clj
@@ -44,6 +44,7 @@
     [:faction-eid :uuid]
     [:faction-name {:optional true} :string]
     [:created-at-display {:optional true} :string]
+    [:updated-at-display {:optional true} :string]
     [:player-sub :string]
     [:version :int]
     [:created-at :instant]

--- a/components/rts-web/resources/rts-web/asset/style/app.css
+++ b/components/rts-web/resources/rts-web/asset/style/app.css
@@ -2178,13 +2178,17 @@ h3.draft-category-header {
 
 .drafts-list li {
   display: grid;
-  grid-template-columns: 1.25rem 1fr 6rem auto;
+  grid-template-columns: 1.25rem 1fr auto auto;
   align-items: center;
-  gap: var(--space-4);
+  column-gap: var(--space-4);
   padding: var(--space-2) var(--space-4);
   border-bottom: 1px solid
     color-mix(in srgb, var(--color-border) 45%, transparent);
   transition: background 120ms;
+}
+
+.drafts-list li > .draft-faction {
+  margin-right: var(--space-6);
 }
 
 .drafts-list li:last-child {

--- a/components/rts-web/resources/rts-web/asset/style/app.css
+++ b/components/rts-web/resources/rts-web/asset/style/app.css
@@ -1864,3 +1864,376 @@ h3.draft-category-header {
   font-family: var(--font-family-mono);
   font-size: 0.625rem;
 }
+
+/* ── Standings table ─────────────────────────────────────────── */
+
+.standings-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+}
+
+.standings-table caption {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+
+.standings-table thead th {
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-align: left;
+  color: var(--color-text-muted);
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-primary-600) 6%, transparent),
+    transparent
+  );
+  white-space: nowrap;
+}
+
+.standings-table thead th[scope="col"]:not(:first-child) {
+  text-align: right;
+}
+
+.standings-table tbody td {
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--color-border) 50%, transparent);
+  font-family: var(--font-heading);
+  font-variant-numeric: tabular-nums lining-nums;
+  font-size: var(--text-sm);
+  letter-spacing: 0.04em;
+  vertical-align: middle;
+}
+
+.standings-table tbody td:first-child {
+  color: var(--color-text-strong);
+  font-weight: 500;
+}
+
+.standings-table tbody td:not(:first-child) {
+  text-align: right;
+  color: var(--color-text);
+}
+
+.standings-table tbody tr:nth-child(even) td {
+  background: color-mix(in srgb, var(--color-neutral-300) 18%, transparent);
+}
+
+.standings-table tbody tr:hover td {
+  background: color-mix(in srgb, var(--color-primary-600) 8%, transparent);
+}
+
+.standings-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.standings-table .rank {
+  color: var(--color-primary-700);
+  display: inline-block;
+  width: 1.5rem;
+  text-align: right;
+  margin-right: var(--space-2);
+  font-size: var(--text-xs);
+}
+
+.standings-table .winbar {
+  display: inline-block;
+  width: 4rem;
+  height: 4px;
+  background: var(--color-neutral-200);
+  border-radius: 1px;
+  overflow: hidden;
+  margin-right: var(--space-2);
+  vertical-align: middle;
+}
+
+.standings-table .winbar-fill {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg,
+    var(--color-primary-500),
+    var(--color-primary-700));
+}
+
+.standings-table .winpct {
+  color: var(--color-primary-700);
+  font-weight: 700;
+}
+
+.standings-table .winpct-low {
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+/* ── Resource list rows (seasons, tournaments-in-league/season) ── */
+
+.season-list,
+.tournament-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.season-list li,
+.tournament-list li {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--color-border) 50%, transparent);
+  transition: background 120ms;
+}
+
+.season-list li:last-child,
+.tournament-list li:last-child {
+  border-bottom: none;
+}
+
+.season-list li:hover,
+.tournament-list li:hover {
+  background: color-mix(in srgb, var(--color-primary-600) 6%, transparent);
+}
+
+.season-list a,
+.tournament-list a {
+  font-family: var(--font-heading);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-strong);
+  text-decoration: none;
+}
+
+.season-list a:hover,
+.tournament-list a:hover {
+  color: var(--color-primary-700);
+}
+
+.season-list .season-dates,
+.tournament-list .tournament-meta {
+  font-family: var(--font-heading);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  letter-spacing: 0.04em;
+}
+
+.season-list .season-status,
+.tournament-list .tournament-status {
+  font-family: var(--font-heading);
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.125rem 0.5rem;
+  border: 1px solid;
+  border-radius: 1px;
+}
+
+.season-status--active {
+  color: var(--color-success-500);
+  border-color: color-mix(in srgb, var(--color-success-500) 50%, transparent);
+  background: color-mix(in srgb, var(--color-success-500) 12%, transparent);
+}
+
+.season-status--past {
+  color: var(--color-text-muted);
+  border-color: var(--color-border);
+}
+
+/* ── Resource header text (description + meta lines) ────────── */
+
+.resource-description {
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  font-style: italic;
+  color: var(--color-text);
+  max-width: 60ch;
+  line-height: 1.5;
+  margin: var(--space-1) 0 0;
+}
+
+.resource-meta {
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: var(--space-3) 0 0;
+}
+
+.resource-meta strong {
+  color: var(--color-primary-700);
+  font-weight: 600;
+}
+
+.resource-meta a {
+  color: var(--color-primary-700);
+  text-decoration: none;
+  border-bottom: 1px dotted currentColor;
+}
+
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin: var(--space-8) 0 var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.section-heading h3 {
+  font-family: var(--font-heading);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.section-heading .meta {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+/* ── My Drafts list ───────────────────────────────────────── */
+
+.drafts-page {
+  max-width: 56rem;
+}
+
+.drafts-toolbar {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: var(--space-6);
+}
+
+.drafts-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--color-border) 50%, transparent);
+  padding-bottom: var(--space-3);
+}
+
+.drafts-filter {
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: var(--space-1) var(--space-3);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  border-radius: 1px;
+}
+
+.drafts-filter:hover {
+  border-color: var(--color-primary-500);
+}
+
+.drafts-filter[aria-pressed="true"] {
+  color: var(--color-text-strong);
+  border-color: var(--color-primary-500);
+  background: color-mix(in srgb, var(--color-primary-600) 10%, transparent);
+}
+
+.drafts-filter .count {
+  color: var(--color-primary-700);
+  margin-left: var(--space-1);
+}
+
+.drafts-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.drafts-list li {
+  display: grid;
+  grid-template-columns: 1.25rem 1fr 6rem auto;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--color-border) 45%, transparent);
+  transition: background 120ms;
+}
+
+.drafts-list li:last-child {
+  border-bottom: none;
+}
+
+.drafts-list li:hover {
+  background: color-mix(in srgb, var(--color-primary-600) 6%, transparent);
+}
+
+.drafts-list .draft-icon {
+  color: var(--color-primary-700);
+  display: inline-flex;
+}
+
+.drafts-list .draft-name {
+  font-family: var(--font-heading);
+  font-size: var(--text-sm);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-strong);
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drafts-list .draft-name:hover {
+  color: var(--color-primary-700);
+}
+
+.drafts-list .draft-faction {
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  padding: 0.125rem var(--space-2);
+  background: var(--color-neutral-200);
+  border-radius: 1px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.drafts-list .draft-date {
+  font-family: var(--font-heading);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  letter-spacing: 0.04em;
+  text-align: right;
+}

--- a/components/rts-web/resources/rts-web/view/_partial/faction-standings-table.html
+++ b/components/rts-web/resources/rts-web/view/_partial/faction-standings-table.html
@@ -13,11 +13,16 @@
         {% if standings.rows|not-empty? %}
         {% for row in standings.rows %}
         <tr>
-            <td>{{row.faction-name}}</td>
+            <td><span class="rank">{{forloop.counter}}</span>{{row.faction-name}}</td>
             <td>{{row.matches-played}}</td>
             <td>{{row.wins}}</td>
             <td>{{row.losses}}</td>
-            <td>{{row.win-percentage}}%</td>
+            <td>
+                <span class="winbar" aria-hidden="true">
+                    <span class="winbar-fill" style="width: {{row.win-percentage}}%"></span>
+                </span>
+                <span class="winpct">{{row.win-percentage}}%</span>
+            </td>
         </tr>
         {% endfor %}
         {% else %}

--- a/components/rts-web/resources/rts-web/view/league-index.html
+++ b/components/rts-web/resources/rts-web/view/league-index.html
@@ -51,9 +51,7 @@
                     {{tournament.name}}
                 </a>
                 {% if tournament.season-display-name %}
-                <span class="text-muted">— {{tournament.season-display-name}}</span>
-                {% else %}
-                <span class="text-muted">— (no season)</span>
+                <span class="tournament-meta">{{tournament.season-display-name}}</span>
                 {% endif %}
                 <span class="badge">{{tournament.status}}</span>
             </li>

--- a/components/rts-web/resources/rts-web/view/my-drafts.html
+++ b/components/rts-web/resources/rts-web/view/my-drafts.html
@@ -9,43 +9,51 @@
         <a class="btn btn-primary" href="/view/game/{{game-eid}}/draft/create.html">Create Draft</a>
     </header>
 
-    {% if drafts|not-empty? %}
-    {% if faction-counts|not-empty? %}
-    <div class="drafts-filters" role="group" aria-label="Filter drafts by faction">
-        <button type="button" class="drafts-filter"
-                aria-pressed="{% if active-faction %}false{% else %}true{% endif %}"
-                hx-get="/view/game/{{game-eid}}/draft/me.html"
-                hx-target=".drafts-list"
-                hx-select=".drafts-list">
-            All<span class="count">{{total-count}}</span>
-        </button>
-        {% for f in faction-counts %}
-        <button type="button" class="drafts-filter"
-                aria-pressed="{% ifequal active-faction f.name %}true{% else %}false{% endifequal %}"
-                hx-get="/view/game/{{game-eid}}/draft/me.html?faction={{f.name|url-encode}}"
-                hx-target=".drafts-list"
-                hx-select=".drafts-list">
-            {{f.name}}<span class="count">{{f.count}}</span>
-        </button>
-        {% endfor %}
-    </div>
-    {% endif %}
+    {% if total-count %}
+    <div class="drafts-content">
+        {% if faction-counts|not-empty? %}
+        <div class="drafts-filters" role="group" aria-label="Filter drafts by faction">
+            <button type="button" class="drafts-filter"
+                    aria-pressed="{% if active-faction %}false{% else %}true{% endif %}"
+                    hx-get="/view/game/{{game-eid}}/draft/me.html"
+                    hx-target=".drafts-content"
+                    hx-select=".drafts-content"
+                    hx-swap="outerHTML">
+                All<span class="count">{{total-count}}</span>
+            </button>
+            {% for f in faction-counts %}
+            <button type="button" class="drafts-filter"
+                    aria-pressed="{% ifequal active-faction f.name %}true{% else %}false{% endifequal %}"
+                    hx-get="/view/game/{{game-eid}}/draft/me.html?faction={{f.name|url-encode}}"
+                    hx-target=".drafts-content"
+                    hx-select=".drafts-content"
+                    hx-swap="outerHTML">
+                {{f.name}}<span class="count">{{f.count}}</span>
+            </button>
+            {% endfor %}
+        </div>
+        {% endif %}
 
-    <ul class="drafts-list" aria-label="Your drafts">
-        {% for draft in drafts %}
-        <li>
-            <span class="draft-icon" aria-hidden="true">
-                {% include "rts-web/view/icon/sword.html" %}
-            </span>
-            <a class="draft-name"
-               href="/view/game/{{game-eid}}/draft/{{draft.eid}}/index.html">
-                {{draft.display-name}}
-            </a>
-            <span class="draft-faction">{{draft.faction-name}}</span>
-            <span class="draft-date">{{draft.updated-at-display}}</span>
-        </li>
-        {% endfor %}
-    </ul>
+        {% if drafts|not-empty? %}
+        <ul class="drafts-list" aria-label="Your drafts">
+            {% for draft in drafts %}
+            <li>
+                <span class="draft-icon" aria-hidden="true">
+                    {% include "rts-web/view/icon/sword.html" %}
+                </span>
+                <a class="draft-name"
+                   href="/view/game/{{game-eid}}/draft/{{draft.eid}}/index.html">
+                    {{draft.display-name}}
+                </a>
+                <span class="draft-faction">{{draft.faction-name}}</span>
+                <span class="draft-date">{{draft.updated-at-display}}</span>
+            </li>
+            {% endfor %}
+        </ul>
+        {% else %}
+        <p class="drafts-empty">No drafts match this filter.</p>
+        {% endif %}
+    </div>
     {% else %}
     <p>No drafts found.</p>
     {% endif %}

--- a/components/rts-web/resources/rts-web/view/my-drafts.html
+++ b/components/rts-web/resources/rts-web/view/my-drafts.html
@@ -3,21 +3,49 @@
 {% block title %}My Drafts | {{game.name}} | RTS-UI{% endblock %}
 
 {% block content %}
-<section class="resource" aria-labelledby="my-drafts-heading">
-    <div class="cluster cluster-2" style="justify-content: space-between; align-items: baseline;">
+<section class="resource drafts-page" aria-labelledby="my-drafts-heading">
+    <header class="drafts-toolbar">
         <h2 id="my-drafts-heading">My Drafts</h2>
         <a class="btn btn-primary" href="/view/game/{{game-eid}}/draft/create.html">Create Draft</a>
+    </header>
+
+    {% if drafts|not-empty? %}
+    {% if faction-counts|not-empty? %}
+    <div class="drafts-filters" role="group" aria-label="Filter drafts by faction">
+        <button type="button" class="drafts-filter"
+                aria-pressed="{% if active-faction %}false{% else %}true{% endif %}"
+                hx-get="/view/game/{{game-eid}}/draft/me.html"
+                hx-target=".drafts-list"
+                hx-select=".drafts-list">
+            All<span class="count">{{total-count}}</span>
+        </button>
+        {% for f in faction-counts %}
+        <button type="button" class="drafts-filter"
+                aria-pressed="{% ifequal active-faction f.name %}true{% else %}false{% endifequal %}"
+                hx-get="/view/game/{{game-eid}}/draft/me.html?faction={{f.name|url-encode}}"
+                hx-target=".drafts-list"
+                hx-select=".drafts-list">
+            {{f.name}}<span class="count">{{f.count}}</span>
+        </button>
+        {% endfor %}
     </div>
-    {% if drafts %}
-    <nav aria-label="Your drafts">
-        <ul>
-            {% for draft in drafts %}
-            <li>
-                <a href="/view/game/{{game-eid}}/draft/{{draft.eid}}/index.html">{{draft.display-name}}</a>
-            </li>
-            {% endfor %}
-        </ul>
-    </nav>
+    {% endif %}
+
+    <ul class="drafts-list" aria-label="Your drafts">
+        {% for draft in drafts %}
+        <li>
+            <span class="draft-icon" aria-hidden="true">
+                {% include "rts-web/view/icon/sword.html" %}
+            </span>
+            <a class="draft-name"
+               href="/view/game/{{game-eid}}/draft/{{draft.eid}}/index.html">
+                {{draft.display-name}}
+            </a>
+            <span class="draft-faction">{{draft.faction-name}}</span>
+            <span class="draft-date">{{draft.updated-at-display}}</span>
+        </li>
+        {% endfor %}
+    </ul>
     {% else %}
     <p>No drafts found.</p>
     {% endif %}

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -95,7 +95,10 @@
              :handler    (integrant.core/ref ::web.view/create-draft-view)}}]
      ["/me.html"
       {:get {:produces   ["application/htmx+html"]
-             :parameters {:path schema.contract/game-id-path-parameter}
+             :parameters {:path  schema.contract/game-id-path-parameter
+                          :query (schema.contract/to-schema
+                                  [:map
+                                   [:faction {:optional true} :string]])}
              :handler    (integrant.core/ref ::web.view/my-drafts-view)}}]
      ["/:eid/index.html"
       {:get {:produces   ["application/htmx+html"]

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
@@ -34,6 +34,10 @@
 
 (selmer.filters/add-filter! :not-empty? (comp boolean seq))
 
+(selmer.filters/add-filter! :url-encode
+                            (fn [s]
+                              (java.net.URLEncoder/encode (str s) "UTF-8")))
+
 (defn standard-view-handler
   [view-name request]
   {:status 200
@@ -204,12 +208,25 @@
 (defmethod integrant.core/init-key ::my-drafts-view
   [_init-key dependencies]
   (fn [{session :ory-session :as request}]
-    (let [player-sub (get-in session [:identity :id])
-          game-eid   (:game-eid (:game-context request))]
+    (let [player-sub     (get-in session [:identity :id])
+          game-eid       (:game-eid (:game-context request))
+          active-faction (not-empty (get-in request [:parameters :query :faction]))
+          all-drafts     (domain/get-drafts-for-player-by-game dependencies player-sub game-eid)
+          faction-counts (->> all-drafts
+                              (group-by :faction-name)
+                              (mapv (fn [[name drafts]] {:name name :count (count drafts)}))
+                              (sort-by (juxt (comp - :count) :name))
+                              vec)
+          drafts         (if active-faction
+                           (filterv #(= active-faction (:faction-name %)) all-drafts)
+                           all-drafts)]
       {:status 200
        :body   (render/render "my-drafts.html"
                               (assoc (base-context request)
-                                     :drafts (domain/get-drafts-for-player-by-game dependencies player-sub game-eid)))})))
+                                     :drafts drafts
+                                     :faction-counts faction-counts
+                                     :active-faction active-faction
+                                     :total-count (count all-drafts)))})))
 
 (defmethod integrant.core/init-key ::faction-list-view
   [_init-key _dependencies]

--- a/docs/rts-api/flows/competitive.md
+++ b/docs/rts-api/flows/competitive.md
@@ -34,7 +34,7 @@ The legacy `/view/game/:game-eid/tournament/index.html` URL is removed (404). Al
 
 1. **Header** — name, description, organizer; only the league owner sees the **Create Season** CTA.
 2. **Seasons list** — every season in ordinal order, linking to season detail pages.
-3. **Faction Standings** — `GET /api/stats/league/:eid/faction` results rendered as an accessible `<table>` (`<th scope="col">`, `<caption class="sr-only">`). Aggregates wins, losses, and win % across every completed match in every season-attached and season-less tournament under the league. Draws are not tracked — they are vanishingly rare in Warhammer matches and are typically replayed or omitted rather than recorded.
+3. **Faction Standings** — `GET /api/stats/league/:eid/faction` results rendered as an accessible `<table>` (`<th scope="col">`, `<caption class="sr-only">`). Aggregates wins, losses, and win % across every completed match in every season-attached and season-less tournament under the league. The first column carries a `.rank` ordinal prefix; the win-% column renders a thin `.winbar` proportional to the row's percentage so ladder shape scans at a glance. Draws are not tracked — they are vanishingly rare in Warhammer matches and are typically replayed or omitted rather than recorded.
 4. **Tournaments in this League** — flat list grouped visually by season (or `(no season)` for league-but-no-season tournaments).
 
 ![League detail with faction standings](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/flows/rts-api/views-league-detail.png)

--- a/docs/rts-api/flows/draft-operations.md
+++ b/docs/rts-api/flows/draft-operations.md
@@ -4,7 +4,7 @@ Covers the full draft lifecycle — creation, unit selection, adding/removing un
 
 ## My Drafts
 
-The "My Drafts" page lists all drafts for the authenticated user within the current game. A "Create Draft" button navigates to the creation form.
+The "My Drafts" page lists all drafts for the authenticated user within the current game, sorted by `updated-at` descending so recently-edited drafts surface first. Each row carries an icon, the draft display-name, a faction pill, and the last-edited date. A faction filter strip above the list (rendered when at least one draft exists) lets the user narrow the list to a single faction; the count chips reflect the unfiltered totals so the surface stays stable as filters toggle. The strip uses `hx-get` against the same `/draft/me.html` route with a `?faction=<name>` query param, swapping only the `.drafts-list` element. A "Create Draft" button in the header navigates to the creation form.
 
 ![My Drafts](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/flows/rts-api/draft-my-drafts.png)
 


### PR DESCRIPTION
## Summary

PR 1 of three from the [Competitive section polish](https://github.com/Devereux-Henley/com.devereux-henley/pulls?q=design-review-pass) design-review handoff. Covers issues 1, 3, and 5: the **lists**.

- **Standings table** — appended `.standings-table` rules to `app.css` and emit a rank ordinal prefix + a `.winbar` proportional to `row.win-percentage` so ladder shape scans at a glance.
- **Season + tournament list rows** — unified `.season-list` / `.tournament-list` into one row-grid component (name / status / dates / arrow), added `.resource-description` / `.resource-meta` / `.section-heading`, and dropped the inline em-dashes from league-index tournament rows in favor of grid spacing.
- **My Drafts** — replaced the plain `<ul><li><a>` list with a toolbar + faction filter chips (HTMX swap, count chips derived from the unfiltered set) + rows carrying icon, display-name, faction badge, and last-edited date. Listing SQL now projects `updated_at_display` and orders by `updated_at DESC`; the schema picks up an optional `:updated-at-display`; the route declares `?faction=<name>` as a query param; the view handler derives `faction-counts` / `active-faction` / `total-count`. Per-row point counts intentionally omitted (would require per-row state lookups).

Adds a `:url-encode` Selmer filter for the filter-chip query strings. No design-token changes.

Flow docs (`competitive.md`, `draft-operations.md`) updated alongside refreshed screenshots in `images.com.devereux-henley/flows/rts-api/`.

## Screenshots

### My Drafts (default)
![My Drafts](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/design-review-pass-1/my-drafts.png)

### My Drafts (faction filter applied)
![My Drafts filtered](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/design-review-pass-1/my-drafts-filtered.png)

### League detail (rank prefix + winbar + season/tournament rows)
![League detail](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/design-review-pass-1/league-detail.png)

### Season detail
![Season detail](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/design-review-pass-1/season-detail.png)

## Test plan

- [x] `clojure -M:poly check` — OK
- [x] `clojure -M:poly test` — all green
- [x] `cd components/e2e && npx playwright test` — 99/99 passing
- [x] `clj-kondo --lint components/rts-web/src components/rts-data-access/src` — 0 errors, 0 warnings
- [x] `clojure -M:cljfmt fix` applied
- [x] Walked the three views via Playwright as `dev-admin` against the running dev server: My Drafts default, My Drafts filtered to "The Empire", League detail (`172fd864-…` populated league), Season detail.

## Out of scope (future PRs)

- PR 2 — League cards & semantic status badges (Issues 2, 7)
- PR 3 — Competitive tabs & navbar game-pill (Issues 4, 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)