### PR TITLE
Style cards: league heraldic corner pin + semantic tournament status badges (design review pass 2)

### DIFF
--- a/components/rts-web/resources/rts-web/asset/style/app.css
+++ b/components/rts-web/resources/rts-web/asset/style/app.css
@@ -302,6 +302,61 @@ table.table tbody tr:hover td { background: color-mix(in srgb, var(--color-accen
 .badge-warning { color: var(--color-warning-600); }
 .badge-danger  { color: var(--color-danger-400); }
 
+/* Semantic status pills.
+   The colour carries the meaning, not just the palette family — `complete`
+   is a successful end state and so renders neutral, while `cancelled` is
+   the only true failure mode and keeps the danger red. Pair with the
+   tournament-card-status positioning rule in the WH3 theme. */
+.status-badge {
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 0.125rem 0.5rem;
+  border: 1px solid;
+  border-radius: 1px;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  white-space: nowrap;
+}
+
+.status-badge::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.status-badge--registration {
+  color: var(--color-primary-700);
+  border-color: color-mix(in srgb, var(--color-primary-600) 50%, transparent);
+  background: color-mix(in srgb, var(--color-primary-600) 14%, transparent);
+}
+
+.status-badge--active {
+  color: #7fb58f;
+  border-color: color-mix(in srgb, var(--color-success-500) 60%, transparent);
+  background: color-mix(in srgb, var(--color-success-500) 16%, transparent);
+}
+
+.status-badge--complete {
+  color: var(--color-text-muted);
+  border-color: var(--color-border-strong);
+  background: var(--color-neutral-200);
+}
+
+.status-badge--complete::before { background: var(--color-text-muted); }
+
+.status-badge--cancelled {
+  color: var(--color-danger-400);
+  border-color: color-mix(in srgb, var(--color-danger-500) 60%, transparent);
+  background: color-mix(in srgb, var(--color-danger-500) 14%, transparent);
+}
+
 /* ════════════════════════════════════════════════════════════════════════ */
 /* Faction / game browser                                                   */
 /* ════════════════════════════════════════════════════════════════════════ */

--- a/components/rts-web/resources/rts-web/asset/style/themes/warhammer3-app.css
+++ b/components/rts-web/resources/rts-web/asset/style/themes/warhammer3-app.css
@@ -2442,17 +2442,16 @@ a:hover:has(img) {
 }
 
 .league-card::before {
-  /* Vertical gold stripe down the left side — heraldic standard pole. */
+  /* Heraldic corner pin in the top-left — leagues read as siblings of
+     tournament cards under the same skin. SVG inlined as a data URL so
+     no asset file is needed. */
   content: "";
   position: absolute;
-  left: 0;
   top: 0;
-  bottom: 0;
-  width: 3px;
-  background: linear-gradient(180deg,
-    color-mix(in srgb, var(--color-primary-500) 60%, transparent) 0%,
-    color-mix(in srgb, var(--color-primary-500) 30%, transparent) 50%,
-    color-mix(in srgb, var(--color-primary-500) 10%, transparent) 100%);
+  left: 0;
+  width: 14px;
+  height: 14px;
+  background: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 40'%3E%3Cg fill='none' stroke='%23d6ab58' stroke-linecap='round'%3E%3Cpath d='M0 1.5 L 38 1.5' stroke-width='1.8'/%3E%3Cpath d='M1.5 0 L 1.5 38' stroke-width='1.8'/%3E%3Cpath d='M4.5 5.5 L 28 5.5' stroke-width='1.3' opacity='0.85'/%3E%3Cpath d='M5.5 4.5 L 5.5 28' stroke-width='1.3' opacity='0.85'/%3E%3Ccircle cx='2.8' cy='2.8' r='1.3' fill='%23d6ab58' stroke='none'/%3E%3C/g%3E%3C/svg%3E") no-repeat top left/contain;
   pointer-events: none;
 }
 

--- a/components/rts-web/resources/rts-web/view/_partial/tournament-list-section.html
+++ b/components/rts-web/resources/rts-web/view/_partial/tournament-list-section.html
@@ -12,12 +12,7 @@
        href="/view/game/{{game-eid}}/tournament/{{tournament.eid}}/index.html"
        aria-label="{{tournament.name}}">
         <div class="tournament-card-header">
-            <span class="tournament-card-status badge
-                {% ifequal tournament.status "registration" %}badge-primary{% endifequal %}
-                {% ifequal tournament.status "active" %}badge-success{% endifequal %}
-                {% ifequal tournament.status "complete" %}badge-danger{% endifequal %}
-                {% ifequal tournament.status "cancelled" %}badge-danger{% endifequal %}
-            ">{{tournament.status}}</span>
+            <span class="tournament-card-status status-badge status-badge--{{tournament.status}}">{{tournament.status}}</span>
             {% if tournament.league-eid %}
             <span class="badge badge-league" title="Part of league {{tournament.league-name}}">
                 {{tournament.league-name}}{% if tournament.season-display-name %} · {{tournament.season-display-name}}{% endif %}

--- a/components/rts-web/resources/rts-web/view/league-index.html
+++ b/components/rts-web/resources/rts-web/view/league-index.html
@@ -53,7 +53,7 @@
                 {% if tournament.season-display-name %}
                 <span class="tournament-meta">{{tournament.season-display-name}}</span>
                 {% endif %}
-                <span class="badge">{{tournament.status}}</span>
+                <span class="status-badge status-badge--{{tournament.status}}">{{tournament.status}}</span>
             </li>
             {% endfor %}
         </ul>

--- a/components/rts-web/resources/rts-web/view/season-index.html
+++ b/components/rts-web/resources/rts-web/view/season-index.html
@@ -26,7 +26,7 @@
                 <a href="/view/game/{{game-eid}}/tournament/{{tournament.eid}}/index.html">
                     {{tournament.name}}
                 </a>
-                <span class="badge">{{tournament.status}}</span>
+                <span class="status-badge status-badge--{{tournament.status}}">{{tournament.status}}</span>
             </li>
             {% endfor %}
         </ul>

--- a/components/rts-web/resources/rts-web/view/tournament-list.html
+++ b/components/rts-web/resources/rts-web/view/tournament-list.html
@@ -18,12 +18,7 @@
            href="/view/game/{{game-eid}}/tournament/{{tournament.eid}}/index.html"
            aria-label="{{tournament.name}}">
             <div class="tournament-card-header">
-                <span class="tournament-card-status badge
-                    {% ifequal tournament.status "registration" %}badge-primary{% endifequal %}
-                    {% ifequal tournament.status "active" %}badge-success{% endifequal %}
-                    {% ifequal tournament.status "complete" %}badge-danger{% endifequal %}
-                    {% ifequal tournament.status "cancelled" %}badge-danger{% endifequal %}
-                ">{{tournament.status}}</span>
+                <span class="tournament-card-status status-badge status-badge--{{tournament.status}}">{{tournament.status}}</span>
             </div>
             <div class="tournament-card-body">
                 <h3 class="tournament-card-name">{{tournament.name}}</h3>

--- a/docs/rts-api/flows/competitive.md
+++ b/docs/rts-api/flows/competitive.md
@@ -13,8 +13,8 @@ Covers the per-game **Competitive** landing, league/season organization above to
 
 Every game has a single Competitive page at `/view/game/:game-eid/competitive/index.html`. It hosts two side-by-side tabs (WCAG-AA `role="tablist"`, Hyperscript-driven panel toggling — no HTMX swap needed):
 
-- **Tournaments** — every tournament for the game, league-affiliated or standalone. League-affiliated cards carry a "League · Season N" badge that links to the league.
-- **Leagues** — every league for the game. Each card shows the league name, description, current-season subline, and tournament count.
+- **Tournaments** — every tournament for the game, league-affiliated or standalone. League-affiliated cards carry a "League · Season N" badge that links to the league. The status pill in the card header is one of `registration` (gold), `active` (green), `complete` (neutral grey — a finished tournament is success, not failure), or `cancelled` (red — the only true failure mode); the colour is keyed off the status string via `status-badge--*` classes rather than a generic `badge-danger` palette family.
+- **Leagues** — every league for the game. Each card carries a small heraldic corner pin in the top-left so leagues read as siblings of tournament cards under the Warhammer III skin, plus the league name, description, current-season subline, and tournament count.
 
 The legacy `/view/game/:game-eid/tournament/index.html` URL is removed (404). All tournament-related navigation now flows through the Competitive landing.
 


### PR DESCRIPTION
## Summary

PR 2 of three from the design-review handoff — **the cards** (Issues 2 + 7).

- **Issue 2 — League cards:** swap the WH3 theme's vertical gold stripe on `.league-card::before` for a heraldic corner pin SVG (inlined as a data URL — no asset file needed) so leagues read as siblings of tournament cards instead of plainer variants. Markup was already in place; CSS-only change.
- **Issue 7 — Tournament status badges:** drop the `badge-*` colour primitives in favour of semantic `.status-badge--{registration,active,complete,cancelled}` classes. The biggest behavioural shift: `complete` no longer maps to red — a finished tournament is success, not failure. `cancelled` keeps the danger red as the only true failure mode. The `ifequal` ladder collapses to a single class interpolated from `{{tournament.status}}`. Templates touched: `_partial/tournament-list-section.html`, `tournament-list.html`, `league-index.html`, `season-index.html`.

Each badge picks up a small leading dot via `::before` so the chip reads as a status pill at a glance even at small sizes. The `.tournament-card-status { margin-right: auto }` positioning rule in the WH3 theme still anchors the chip on the left side of the card header alongside the league badge on the right.

No design-token changes. Flow doc (`competitive.md`) refreshed alongside the screenshots in `images.com.devereux-henley/flows/rts-api/`.

## Screenshots

### Competitive landing — Tournaments tab
![Tournaments](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/design-review-pass-2/competitive-tournaments.png)

### Competitive landing — Leagues tab (note the corner pin top-left of every card)
![Leagues](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/design-review-pass-2/competitive-leagues.png)

### League detail (registration status pill on a tournament row)
![League detail](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/design-review-pass-2/league-detail.png)

## Test plan

- [x] `clojure -M:poly check` — OK
- [x] `clojure -M:poly test` — all green
- [x] `cd components/e2e && npx playwright test` — 99/99 passing
- [x] `clj-kondo --lint components/rts-web/src` — 0 errors, 0 warnings
- [x] `clojure -M:cljfmt fix` applied
- [x] Walked the Competitive landing (both tabs) and the League detail page via Playwright — verified `getComputedStyle` reports the corner pin SVG (`14×14` data URL) on `.league-card::before`, and that the four tournament statuses render with distinct semantic colours (`complete` muted grey, `cancelled` red, `active` green, `registration` gold).

## Out of scope (PR 3)

- Issue 4 — Competitive tabs styling
- Issue 6 — Navbar game-pill switcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)