### PR TITLE
Style chrome: Competitive tab counts + navbar game-pill (design review pass 3)

### DIFF
--- a/components/rts-web/resources/rts-web/asset/style/app.css
+++ b/components/rts-web/resources/rts-web/asset/style/app.css
@@ -97,30 +97,54 @@ body,
   min-width: 28rem;
 }
 
-.navbar-game {
+/* Game-scope pill — promoted from a small dim label so it reads as a
+   control. The dot + caret signal "this opens a switcher"; the click
+   currently navigates to the game-selector page. */
+.navbar .game-pill {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
+  padding: 0.375rem 0.625rem 0.375rem 0.75rem;
+  background: color-mix(in srgb, var(--color-primary-600) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-primary-600) 35%, transparent);
+  border-left: 2px solid var(--color-primary-600);
+  border-radius: 1px;
+  font-family: var(--font-heading);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-strong);
   text-decoration: none;
-  color: var(--color-text-muted);
-  transition: color var(--transition-fast);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 
-.navbar-game:hover { color: var(--color-text-strong); }
-
-.navbar-game-logo {
-  width: 1.5rem;
-  height: 1.5rem;
-  object-fit: contain;
+.navbar .game-pill::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  background: var(--color-primary-600);
+  border-radius: 50%;
   flex-shrink: 0;
 }
 
-.navbar-game-name {
-  font-family: var(--font-family-heading);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  letter-spacing: 0.02em;
-  white-space: nowrap;
+.navbar .game-pill::after {
+  content: "▾";
+  font-size: 0.625rem;
+  color: var(--color-primary-600);
+  margin-left: var(--space-1);
+}
+
+.navbar .game-pill:hover {
+  background: color-mix(in srgb, var(--color-primary-600) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-primary-600) 55%, transparent);
+}
+
+.navbar .game-pill:focus-visible {
+  outline: 2px solid var(--color-primary-600);
+  outline-offset: 2px;
 }
 
 /* Reserve width for conditional nav slots so navigating between pages with or

--- a/components/rts-web/resources/rts-web/asset/style/themes/warhammer3-app.css
+++ b/components/rts-web/resources/rts-web/asset/style/themes/warhammer3-app.css
@@ -2414,6 +2414,26 @@ a:hover:has(img) {
   outline: none;
 }
 
+/* Per-tab count chip — small tabular-nums badge nestled to the right of
+   the label so the user can see how many tournaments / leagues each tab
+   holds before clicking through. */
+.competitive-tab .count {
+  font-family: var(--font-family-heading);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--font-size-xs);
+  margin-left: var(--space-2);
+  padding: 0.125rem 0.4rem;
+  background: color-mix(in srgb, var(--color-primary-600) 18%, transparent);
+  color: var(--color-primary-700);
+  border-radius: 1px;
+  letter-spacing: 0.04em;
+}
+
+.competitive-tab[aria-selected="false"] .count {
+  background: var(--color-neutral-200);
+  color: var(--color-text-muted);
+}
+
 /* ─── League cards — heraldic standards ──────────────────────────────── */
 
 .league-list-header {

--- a/components/rts-web/resources/rts-web/template/entrypoint.html
+++ b/components/rts-web/resources/rts-web/template/entrypoint.html
@@ -25,11 +25,11 @@
                     <img src="/image/rts-hub-wordmark.svg" class="navbar-brand-mark" alt="RTS-Hub"/>
                 </a>
                 {% if game-eid %}
-                <a class="navbar-game" href="/view/game/{{game-eid}}/index.html" aria-label="Go to {{game.name}} home">
-                    {% if game.logo %}
-                    <img class="navbar-game-logo" src="/image/{{game.logo}}" alt=""/>
-                    {% endif %}
-                    <span class="navbar-game-name">{{game.name}}</span>
+                <a class="game-pill"
+                   href="/view/game/index.html"
+                   aria-haspopup="listbox"
+                   aria-label="Switch game (currently {{game.name}})">
+                    {{game.name}}
                 </a>
                 {% endif %}
             </div>

--- a/components/rts-web/resources/rts-web/view/competitive.html
+++ b/components/rts-web/resources/rts-web/view/competitive.html
@@ -13,7 +13,7 @@
                    then remove @hidden from #panel-tournaments
                    then set @aria-selected of <[role=tab]/> in my parentElement to 'false'
                    then set my @aria-selected to 'true'">
-            Tournaments
+            Tournaments<span class="count">{{tournaments|length}}</span>
         </button>
         <button type="button" role="tab" id="tab-leagues"
                 aria-selected="false" aria-controls="panel-leagues"
@@ -23,7 +23,7 @@
                    then remove @hidden from #panel-leagues
                    then set @aria-selected of <[role=tab]/> in my parentElement to 'false'
                    then set my @aria-selected to 'true'">
-            Leagues
+            Leagues<span class="count">{{leagues|length}}</span>
         </button>
     </div>
 

--- a/docs/rts-api/flows/competitive.md
+++ b/docs/rts-api/flows/competitive.md
@@ -11,7 +11,7 @@ Covers the per-game **Competitive** landing, league/season organization above to
 
 ## Competitive landing
 
-Every game has a single Competitive page at `/view/game/:game-eid/competitive/index.html`. It hosts two side-by-side tabs (WCAG-AA `role="tablist"`, Hyperscript-driven panel toggling — no HTMX swap needed):
+Every game has a single Competitive page at `/view/game/:game-eid/competitive/index.html`. It hosts two side-by-side tabs (WCAG-AA `role="tablist"`, Hyperscript-driven panel toggling — no HTMX swap needed). Each tab carries a small count chip (`<span class="count">{{tournaments|length}}</span>`) so users can see how many tournaments and leagues live behind each tab before switching:
 
 - **Tournaments** — every tournament for the game, league-affiliated or standalone. League-affiliated cards carry a "League · Season N" badge that links to the league. The status pill in the card header is one of `registration` (gold), `active` (green), `complete` (neutral grey — a finished tournament is success, not failure), or `cancelled` (red — the only true failure mode); the colour is keyed off the status string via `status-badge--*` classes rather than a generic `badge-danger` palette family.
 - **Leagues** — every league for the game. Each card carries a small heraldic corner pin in the top-left so leagues read as siblings of tournament cards under the Warhammer III skin, plus the league name, description, current-season subline, and tournament count.

--- a/docs/rts-api/flows/navigation.md
+++ b/docs/rts-api/flows/navigation.md
@@ -12,7 +12,7 @@ The root URL (`/`) redirects to `/view/game/index.html`. The game selector is th
 
 The navbar is emitted by `rts-web/template/entrypoint.html` and has three regions:
 
-1. **Brand cluster** (`.navbar-brand-cluster`) — the RTS-Hub wordmark + an optional game indicator (the active game's logo and name), separated by a hairline divider. Clicking the wordmark returns to `/`. Clicking the game indicator navigates to that game's home.
+1. **Brand cluster** (`.navbar-brand-cluster`) — the RTS-Hub wordmark + an optional **game-scope pill** showing the active game's name, separated by a hairline divider. The pill (`.game-pill`) renders with a 2px gold left rule, a leading dot, and a trailing caret so it reads as a switcher control rather than passive metadata; `aria-haspopup="listbox"` flags the affordance to assistive tech. Clicking the wordmark returns to `/`. Clicking the pill navigates to the game selector at `/view/game/index.html`.
 2. **Main nav** — Atlas (dropdown), My Drafts (game-scoped), Competitive (game-scoped). The per-slot widths are pinned in CSS so the row doesn't reflow when a game enters or leaves context.
 3. **Account menu** — game socials cluster + the signed-in user's name with a logout affordance.
 


### PR DESCRIPTION
## Summary

PR 3 of three from the design-review handoff — **the chrome** (Issues 4 + 6). Closes out the polish series.

- **Issue 4 — Competitive tabs:** the tabs already had the WH3 theme's gold underline + diamond separator, but no count chip. Add a small tabular-nums chip after each tab label — gold-tinted on the selected tab, neutral when deselected. The label data is `{{tournaments|length}}` / `{{leagues|length}}` from the existing render context — no domain or handler changes.
- **Issue 6 — Navbar game-scope pill:** the active game's name was rendering inline as a small dim label that read like metadata, not a control. Promote it to a `.game-pill` (gold-tinted background, 2px gold left rule, leading dot, trailing caret, Cinzel 11px — the system's stated minimum). Click navigates to `/view/game/index.html` (the game selector), so the affordance is honest. Drops the now-unused `.navbar-game` / `.navbar-game-logo` / `.navbar-game-name` rules and the in-pill logo so the pill's own visual treatment is the identity, not a redundant icon.

No design-token changes. Flow docs (`navigation.md`, `competitive.md`) updated alongside refreshed flow images.

## Screenshots

### Competitive landing — Tournaments tab (selected count chip on tab; game pill in nav)
![Tournaments](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/design-review-pass-3/competitive-tournaments.png)

### Competitive landing — Leagues tab (deselected chip styling)
![Leagues](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/design-review-pass-3/competitive-leagues.png)

### Navbar closeup — game pill replaces the small dim label
![Navbar](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/design-review-pass-3/navbar-pill.png)

### Full navbar in context (game pill + active competitive tab)
![Nav competitive](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/design-review-pass-3/nav-competitive.png)

## Test plan

- [x] `clojure -M:poly check` — OK
- [x] `clojure -M:poly test` — all green
- [x] `cd components/e2e && npx playwright test` — 99/99 passing
- [x] `clj-kondo --lint components/rts-web/src` — 0 errors, 0 warnings
- [x] `clojure -M:cljfmt fix` applied
- [x] Walked the Competitive landing (both tabs) and several game-scoped pages via Playwright. `getComputedStyle` reports the pill at 11px Cinzel with the 2px gold left border and the dot/caret pseudo-elements; tab counts render distinct gold (selected) vs neutral (deselected) chips.

## Out of scope / future polish

The `aria-haspopup="listbox"` markup contract on `.game-pill` flags a switcher affordance, but the click currently navigates to the game-selector page rather than opening an inline listbox popup. Wiring up the popup would be a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)