### PR TITLE
Fix tag-stable workflow: build replay parser before tests

### DIFF
--- a/.github/workflows/tag-stable.yml
+++ b/.github/workflows/tag-stable.yml
@@ -45,6 +45,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cljdeps-
 
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            tools/replay-parser/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('tools/replay-parser/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build replay parser
+        working-directory: tools/replay-parser
+        run: cargo build --release
+
       - name: Install Playwright
         working-directory: components/e2e
         run: |
@@ -52,6 +72,8 @@ jobs:
           npx playwright install --with-deps chromium
 
       - name: Start dev server
+        env:
+          REPLAY_PARSER_BIN: ${{ github.workspace }}/tools/replay-parser/target/release/tw-replay-parser
         run: |
           mkdir -p db
           clojure -M:dev -i components/e2e/resources/e2e/start_dev_server.clj &


### PR DESCRIPTION
## Summary
- `tag-stable.yml` runs `clojure -M:poly test`, which depends on the `tw-replay-parser` binary at `REPLAY_PARSER_BIN`. The workflow was missing the Rust setup, parser build, and env var, so the post-merge tag job would fail on any test that exercises the replay parser path.
- Mirror the Rust steps from `pr-check.yml`: install the stable toolchain, cache `~/.cargo` + `tools/replay-parser/target`, `cargo build --release` the parser, and pass `REPLAY_PARSER_BIN` to the dev server.

## Test plan
- [ ] Merge a PR and confirm the `Tag Stable` workflow reaches the tag step (no failure on parser-dependent tests)
- [ ] Confirm the stable tag is created and pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)