### PR TITLE
Split match-record review modal into Main Army / Reinforcements sections

### DIFF
--- a/components/e2e/tests/match-record.spec.js
+++ b/components/e2e/tests/match-record.spec.js
@@ -129,6 +129,19 @@ test.describe('Parse fragment endpoint', () => {
     // (or the placeholder fallback when the parser key didn't enrich against the DB).
     expect(html).toMatch(/<img class="pm-draft-unit-portrait"[^>]*src="\/card\/unit\/[^"]+\.png"/);
     expect(html).toMatch(/onerror="this\.src='\/card\/unit\/placeholder\.png'/);
+    // Each side splits its army into a Main Army and a Reinforcements section
+    // — both label headings must appear for both players (p1 and p2), with
+    // matching aria-labelledby ids so the section headings are screen-reader
+    // accessible.
+    for (const side of ['p1', 'p2']) {
+      expect(html).toMatch(new RegExp(`id="pm-section-0-${side}-main"[^>]*>Main Army</h4>`));
+      expect(html).toMatch(new RegExp(`id="pm-section-0-${side}-reinforcements"[^>]*>Reinforcements</h4>`));
+      expect(html).toContain(`aria-labelledby="pm-section-0-${side}-main"`);
+      expect(html).toContain(`aria-labelledby="pm-section-0-${side}-reinforcements"`);
+    }
+    // Aggregate "X units across N armies" footer is gone now that sections are
+    // explicit — only the commander remains in the per-side foot.
+    expect(html).not.toMatch(/units across \d+ arm/);
   });
 
   test('rejects empty submission with an inline error fragment', async ({ request }) => {

--- a/components/rts-web/resources/rts-web/asset/style/post-match.css
+++ b/components/rts-web/resources/rts-web/asset/style/post-match.css
@@ -859,6 +859,44 @@
   color: var(--color-neutral-800);
 }
 
+.pm-draft-section + .pm-draft-section {
+  border-top: 1px solid var(--color-border);
+}
+
+.pm-draft-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3) 0;
+}
+
+.pm-draft-section-label {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-neutral-800);
+}
+
+.pm-draft-section-meta {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  font-family: var(--font-family-heading);
+  font-size: 0.66rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.pm-draft-section-cost {
+  font-variant-numeric: tabular-nums;
+  color: var(--color-neutral-800);
+}
+
 .pm-vs-divider {
   display: flex;
   align-items: center;

--- a/components/rts-web/resources/rts-web/view/match-record-review-fragment.html
+++ b/components/rts-web/resources/rts-web/view/match-record-review-fragment.html
@@ -70,25 +70,40 @@
                         <span class="pm-draft-cost-unit">{{side.total-unit}}</span>
                     </div>
                 </div>
-                <div class="pm-draft-units">
-                    {% for unit in side.units %}
-                    <div class="pm-draft-unit{% if unit.is-lord %} pm-draft-unit--lord{% endif %}" title="{{unit.display}}">
-                        <img class="pm-draft-unit-portrait"
-                             src="/card/unit/{% if unit.unit-eid %}{{unit.unit-eid}}{% else %}placeholder{% endif %}.png"
-                             alt="{{unit.display}}"
-                             onerror="this.src='/card/unit/placeholder.png'; this.onerror=null;"/>
-                        {% if unit.cost %}<span class="pm-draft-unit-cost">{{unit.cost}}</span>{% endif %}
-                        <div class="pm-draft-unit-tooltip">
-                            <strong>{{unit.display}}</strong>
-                            <span>{{unit.tooltip}}</span>
+                {% for section in side.sections %}
+                <section class="pm-draft-section pm-draft-section--{{section.section}}"
+                         aria-labelledby="pm-section-{{game.game-index}}-{{side.side-key}}-{{section.section}}">
+                    <header class="pm-draft-section-head">
+                        <h4 id="pm-section-{{game.game-index}}-{{side.side-key}}-{{section.section}}"
+                            class="pm-draft-section-label">{{section.section-label}}</h4>
+                        <span class="pm-draft-section-meta">
+                            <span class="pm-draft-section-count">{{section.section-unit-count}} {% ifequal section.section-unit-count 1 %}unit{% else %}units{% endifequal %}</span>
+                            <span class="pm-draft-section-cost">{{section.section-num}} {{section.section-unit}}</span>
+                        </span>
+                    </header>
+                    <div class="pm-draft-units">
+                        {% for unit in section.section-units %}
+                        <div class="pm-draft-unit{% if unit.is-lord %} pm-draft-unit--lord{% endif %}" title="{{unit.display}}">
+                            <img class="pm-draft-unit-portrait"
+                                 src="/card/unit/{% if unit.unit-eid %}{{unit.unit-eid}}{% else %}placeholder{% endif %}.png"
+                                 alt="{{unit.display}}"
+                                 onerror="this.src='/card/unit/placeholder.png'; this.onerror=null;"/>
+                            {% if unit.cost %}<span class="pm-draft-unit-cost">{{unit.cost}}</span>{% endif %}
+                            <div class="pm-draft-unit-tooltip">
+                                <strong>{{unit.display}}</strong>
+                                <span>{{unit.tooltip}}</span>
+                            </div>
                         </div>
+                        {% endfor %}
                     </div>
-                    {% endfor %}
-                </div>
+                </section>
+                {% endfor %}
+                {% if side.commander-display %}
                 <div class="pm-draft-foot">
-                    <span>{{side.unit-count}} units across {{side.army-count}} {% ifequal side.army-count 1 %}army{% else %}armies{% endifequal %}</span>
+                    <span>Commander</span>
                     <strong>{{side.commander-display}}</strong>
                 </div>
+                {% endif %}
             </div>
             {% endwith %}
 
@@ -104,25 +119,40 @@
                         <span class="pm-draft-cost-unit">{{side.total-unit}}</span>
                     </div>
                 </div>
-                <div class="pm-draft-units">
-                    {% for unit in side.units %}
-                    <div class="pm-draft-unit{% if unit.is-lord %} pm-draft-unit--lord{% endif %}" title="{{unit.display}}">
-                        <img class="pm-draft-unit-portrait"
-                             src="/card/unit/{% if unit.unit-eid %}{{unit.unit-eid}}{% else %}placeholder{% endif %}.png"
-                             alt="{{unit.display}}"
-                             onerror="this.src='/card/unit/placeholder.png'; this.onerror=null;"/>
-                        {% if unit.cost %}<span class="pm-draft-unit-cost">{{unit.cost}}</span>{% endif %}
-                        <div class="pm-draft-unit-tooltip">
-                            <strong>{{unit.display}}</strong>
-                            <span>{{unit.tooltip}}</span>
+                {% for section in side.sections %}
+                <section class="pm-draft-section pm-draft-section--{{section.section}}"
+                         aria-labelledby="pm-section-{{game.game-index}}-{{side.side-key}}-{{section.section}}">
+                    <header class="pm-draft-section-head">
+                        <h4 id="pm-section-{{game.game-index}}-{{side.side-key}}-{{section.section}}"
+                            class="pm-draft-section-label">{{section.section-label}}</h4>
+                        <span class="pm-draft-section-meta">
+                            <span class="pm-draft-section-count">{{section.section-unit-count}} {% ifequal section.section-unit-count 1 %}unit{% else %}units{% endifequal %}</span>
+                            <span class="pm-draft-section-cost">{{section.section-num}} {{section.section-unit}}</span>
+                        </span>
+                    </header>
+                    <div class="pm-draft-units">
+                        {% for unit in section.section-units %}
+                        <div class="pm-draft-unit{% if unit.is-lord %} pm-draft-unit--lord{% endif %}" title="{{unit.display}}">
+                            <img class="pm-draft-unit-portrait"
+                                 src="/card/unit/{% if unit.unit-eid %}{{unit.unit-eid}}{% else %}placeholder{% endif %}.png"
+                                 alt="{{unit.display}}"
+                                 onerror="this.src='/card/unit/placeholder.png'; this.onerror=null;"/>
+                            {% if unit.cost %}<span class="pm-draft-unit-cost">{{unit.cost}}</span>{% endif %}
+                            <div class="pm-draft-unit-tooltip">
+                                <strong>{{unit.display}}</strong>
+                                <span>{{unit.tooltip}}</span>
+                            </div>
                         </div>
+                        {% endfor %}
                     </div>
-                    {% endfor %}
-                </div>
+                </section>
+                {% endfor %}
+                {% if side.commander-display %}
                 <div class="pm-draft-foot">
-                    <span>{{side.unit-count}} units across {{side.army-count}} {% ifequal side.army-count 1 %}army{% else %}armies{% endifequal %}</span>
+                    <span>Commander</span>
                     <strong>{{side.commander-display}}</strong>
                 </div>
+                {% endif %}
             </div>
             {% endwith %}
         </div>

--- a/components/rts-web/resources/rts-web/view/match-record-review-fragment.html
+++ b/components/rts-web/resources/rts-web/view/match-record-review-fragment.html
@@ -84,10 +84,13 @@
                     <div class="pm-draft-units">
                         {% for unit in section.section-units %}
                         <div class="pm-draft-unit{% if unit.is-lord %} pm-draft-unit--lord{% endif %}" title="{{unit.display}}">
+                            {# FALLBACK (#49): src ternary + onerror cover unresolved parser keys #}
+                            {# (no unit-eid) and missing PNGs — drop both once #45 closes. #}
                             <img class="pm-draft-unit-portrait"
                                  src="/card/unit/{% if unit.unit-eid %}{{unit.unit-eid}}{% else %}placeholder{% endif %}.png"
                                  alt="{{unit.display}}"
                                  onerror="this.src='/card/unit/placeholder.png'; this.onerror=null;"/>
+                            {# FALLBACK (#49): cost pip is hidden when the DB row is missing. #}
                             {% if unit.cost %}<span class="pm-draft-unit-cost">{{unit.cost}}</span>{% endif %}
                             <div class="pm-draft-unit-tooltip">
                                 <strong>{{unit.display}}</strong>
@@ -133,10 +136,13 @@
                     <div class="pm-draft-units">
                         {% for unit in section.section-units %}
                         <div class="pm-draft-unit{% if unit.is-lord %} pm-draft-unit--lord{% endif %}" title="{{unit.display}}">
+                            {# FALLBACK (#49): src ternary + onerror cover unresolved parser keys #}
+                            {# (no unit-eid) and missing PNGs — drop both once #45 closes. #}
                             <img class="pm-draft-unit-portrait"
                                  src="/card/unit/{% if unit.unit-eid %}{{unit.unit-eid}}{% else %}placeholder{% endif %}.png"
                                  alt="{{unit.display}}"
                                  onerror="this.src='/card/unit/placeholder.png'; this.onerror=null;"/>
+                            {# FALLBACK (#49): cost pip is hidden when the DB row is missing. #}
                             {% if unit.cost %}<span class="pm-draft-unit-cost">{{unit.cost}}</span>{% endif %}
                             <div class="pm-draft-unit-tooltip">
                                 <strong>{{unit.display}}</strong>

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
@@ -268,11 +268,18 @@
 
 (defn- army->units
   "Maps a single army's units into the per-unit shape the review template
-  expects (display name, cost when enriched, lord flag, tooltip)."
+  expects (display name, cost when enriched, lord flag, tooltip).
+
+  The `enriched?` branch and `or`/`if` fallbacks below cover parser keys
+  that don't resolve to a DB unit row. Once #45 lands and key resolution
+  is guaranteed, the fallbacks become dead code — see #49 for the
+  cleanup checklist."
   [army]
   (mapv (fn [{:keys [key name cost unit-category-name unit-type-name unit-eid]}]
           (let [enriched? (some? name)
+                ;; FALLBACK (#49): unresolved parser key shows the raw engine key.
                 display   (if enriched? name key)
+                ;; FALLBACK (#49): missing category data falls through to type, then em-dash.
                 category  (or unit-category-name unit-type-name "—")
                 is-lord?  (= "lord" (some-> unit-category-name str/lower-case))]
             {:key      key
@@ -280,6 +287,7 @@
              :display  display
              :cost     cost
              :is-lord  is-lord?
+             ;; FALLBACK (#49): tooltip omits cost when the DB row is missing.
              :tooltip  (if cost
                          (str category " · " cost " pts")
                          category)}))
@@ -288,7 +296,11 @@
 (defn- section-totals
   "Per-section count/cost pair mirroring `alliance-totals` at section
   scope: cost in pts when every unit in the section is enriched, otherwise
-  the section's army-level :force-value sum (model count)."
+  the section's army-level :force-value sum (model count).
+
+  The model-count branch is a FALLBACK (#49) for partial enrichment — once
+  #45 guarantees every parser key matches a DB unit row, this collapses
+  to just the pts branch."
   [armies units]
   (let [enriched-count (count (filter :cost units))]
     (if (and (pos? enriched-count) (= enriched-count (count units)))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
@@ -266,26 +266,64 @@
             (:year played-at) (:month played-at) (:day played-at)
             (:hour played-at) (:minute played-at))))
 
-(defn- alliance->units
-  "Flattens an alliance's armies → units into the per-unit shape the
-  review template expects (display name, cost when enriched, lord flag,
-  tooltip)."
+(defn- army->units
+  "Maps a single army's units into the per-unit shape the review template
+  expects (display name, cost when enriched, lord flag, tooltip)."
+  [army]
+  (mapv (fn [{:keys [key name cost unit-category-name unit-type-name unit-eid]}]
+          (let [enriched? (some? name)
+                display   (if enriched? name key)
+                category  (or unit-category-name unit-type-name "—")
+                is-lord?  (= "lord" (some-> unit-category-name str/lower-case))]
+            {:key      key
+             :unit-eid unit-eid
+             :display  display
+             :cost     cost
+             :is-lord  is-lord?
+             :tooltip  (if cost
+                         (str category " · " cost " pts")
+                         category)}))
+        (:units army)))
+
+(defn- section-totals
+  "Per-section count/cost pair mirroring `alliance-totals` at section
+  scope: cost in pts when every unit in the section is enriched, otherwise
+  the section's army-level :force-value sum (model count)."
+  [armies units]
+  (let [enriched-count (count (filter :cost units))]
+    (if (and (pos? enriched-count) (= enriched-count (count units)))
+      {:section-num  (reduce + 0 (keep :cost units))
+       :section-unit "pts"}
+      {:section-num  (reduce + 0 (keep :force-value armies))
+       :section-unit "models"})))
+
+(defn- build-section
+  "Composes a section context (label, units, count, cost/model-count)
+  for a contiguous group of armies that belong to either the Main Army
+  or the Reinforcements bucket."
+  [section-key armies]
+  (let [label (case section-key
+                "main"           "Main Army"
+                "reinforcements" "Reinforcements")
+        units (vec (mapcat army->units armies))]
+    (merge {:section            section-key
+            :section-label      label
+            :section-units      units
+            :section-unit-count (count units)}
+           (section-totals armies units))))
+
+(defn- alliance->sections
+  "Splits an alliance's armies into a Main Army section (the first
+  army) and a Reinforcements section (everything after). The Reinforcements
+  section is omitted when the alliance only carries one army; the Main
+  Army section is omitted when the alliance carries no armies at all."
   [alliance]
-  (->> (:armies alliance)
-       (mapcat :units)
-       (mapv (fn [{:keys [key name cost unit-category-name unit-type-name unit-eid]}]
-               (let [enriched? (some? name)
-                     display   (if enriched? name key)
-                     category  (or unit-category-name unit-type-name "—")
-                     is-lord?  (= "lord" (some-> unit-category-name str/lower-case))]
-                 {:key      key
-                  :unit-eid unit-eid
-                  :display  display
-                  :cost     cost
-                  :is-lord  is-lord?
-                  :tooltip  (if cost
-                              (str category " · " cost " pts")
-                              category)})))))
+  (let [armies (vec (:armies alliance))
+        main   (when (seq armies) [(first armies)])
+        reinf  (vec (rest armies))]
+    (cond-> []
+      main        (conj (build-section "main" main))
+      (seq reinf) (conj (build-section "reinforcements" reinf)))))
 
 (defn- alliance-totals
   "Returns the {:total-num … :total-unit …} pair shown in the draft head.
@@ -302,19 +340,22 @@
        :total-unit "models"})))
 
 (defn- side-context
-  "Builds the per-player side struct for one game (handle, faction-key,
-  unit list, totals, commander, army count)."
-  [handle alliance]
+  "Builds the per-player side struct for one game: handle, faction-key,
+  side-level totals, commander, and a vector of section contexts (Main
+  Army + optional Reinforcements). `side-key` (\"p1\" / \"p2\") is woven
+  into the struct so the template can build unique heading IDs for
+  `aria-labelledby` without a parent loop variable."
+  [side-key handle alliance]
   (let [armies    (vec (:armies alliance))
-        units     (alliance->units alliance)
-        totals    (alliance-totals alliance units)
+        sections  (alliance->sections alliance)
+        all-units (vec (mapcat :section-units sections))
+        totals    (alliance-totals alliance all-units)
         commander (:commander-display (first armies))]
     (merge totals
-           {:handle            handle
+           {:side-key          side-key
+            :handle            handle
             :faction-key       (:faction-key alliance)
-            :units             units
-            :unit-count        (count units)
-            :army-count        (count armies)
+            :sections          sections
             :commander-display (or commander "")})))
 
 (defn- build-game-context
@@ -343,8 +384,8 @@
      :parser-format  (:format parsed)
      :p1-model-count (:model-count p1-alliance)
      :p2-model-count (:model-count p2-alliance)
-     :p1             (side-context (:player-one-sub match) p1-alliance)
-     :p2             (side-context (:player-two-sub match) p2-alliance)}))
+     :p1             (side-context "p1" (:player-one-sub match) p1-alliance)
+     :p2             (side-context "p2" (:player-two-sub match) p2-alliance)}))
 
 (defn- error-fragment
   [message]


### PR DESCRIPTION
Closes #47.

## Summary
- `side-context` now emits `:sections` (Main Army + optional Reinforcements) instead of a flat unit list, so each player card mirrors the section split the draft editor already uses. Reinforcements is dropped when an alliance has only one army; both are dropped for an empty alliance.
- New helpers in `view.clj`: `army->units`, `section-totals`, `build-section`, `alliance->sections`. `:side-key` is woven into the side struct so the template can build unique heading IDs without a parent loop variable.
- `match-record-review-fragment.html` iterates `side.sections`, rendering each as a `<section>` with `aria-labelledby` pointing to its own heading. Per-section meta shows unit count + cost (or model count when not all units enriched). The legacy `"X units across N armies"` footer is replaced with a `Commander` block.
- Minimal CSS additions for `.pm-draft-section*` rules.
- `match-record.spec.js` asserts both `Main Army` and `Reinforcements` headings appear for both players with matching `aria-labelledby` ids, and that the legacy footer text is gone.

No change to the submit endpoint payload — this is a presentation-only refactor.

## Test plan
- [x] `clojure -M:poly check` passes
- [x] `clojure -M:poly test` (51 assertions, 0 failures)
- [x] `npx playwright test match-record.spec.js` (6/6 passing, including new section assertions)
- [x] REPL smoke-checked `side-context` against multi-army, single-army, and empty alliances
- [x] Live walkthrough on `sample-battle.replay`: 4 sections rendered (2 per side), correct labels, correct per-section meta, commanders shown, no leaked legacy text

🤖 Generated with [Claude Code](https://claude.com/claude-code)