### PR TITLE
Install playwright-cli in the dev-env toolbox on first enter

### DIFF
--- a/dev-env/Containerfile
+++ b/dev-env/Containerfile
@@ -87,4 +87,21 @@ if [ -f /run/.toolboxenv ] && [ -t 1 ] && command -v claude >/dev/null 2>&1; the
 fi
 EOF
 
+# Installs @playwright/cli (the agent-friendly browser-automation CLI used
+# by the /playwright-cli skill) into ~/.local on first interactive enter,
+# then seeds the Chromium browser the CLI drives. The dnf install above
+# already pulls the Chromium runtime libs (alsa-lib, atk, libdrm, libxcb,
+# libxkbcommon, nss, pango, …), so the browser install itself only needs
+# to download the browser bundle.
+RUN cat >/etc/profile.d/playwright-cli-install.sh <<'EOF'
+if [ -f /run/.toolboxenv ] && [ -t 1 ] && ! command -v playwright-cli >/dev/null 2>&1; then
+    echo "Installing playwright-cli (first run)..."
+    mkdir -p "$HOME/.local"
+    npm config set prefix "$HOME/.local"
+    npm install -g @playwright/cli@latest
+    echo "Installing Chromium browser bundle..."
+    npx --yes playwright install chromium
+fi
+EOF
+
 ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk


### PR DESCRIPTION
## Summary

Adds a `/etc/profile.d` hook to the toolbox image that installs `@playwright/cli` (the agent-friendly browser-automation CLI driven by the `/playwright-cli` skill) into the user's `~/.local` prefix on first interactive enter, then runs `npx playwright install chromium` to seed the browser bundle the CLI drives.

The Chromium runtime libs (alsa-lib, atk, libdrm, libxcb, libxkbcommon, nss, pango, …) are already on the image from the dnf block above, so the per-user step is just the npm package + the browser download — no new system packages.

The hook mirrors the existing claude-install / clojure-mcp-install pattern so the toolbox stays consistent: lean at build time, opt-in on first run.

## Test plan

- [ ] `cd dev-env && make build` succeeds
- [ ] `make rm && make create && make enter` (existing toolbox, re-created)
- [ ] First enter prints "Installing playwright-cli (first run)..." and "Installing Chromium browser bundle..."; subsequent enters are silent
- [ ] `command -v playwright-cli` resolves
- [ ] `playwright-cli open http://example.com && playwright-cli close` round-trip works
- [ ] Confirm the `/playwright-cli` skill can drive a real browser inside the toolbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)