### PR TITLE
Add ?_method= tunneling middleware for plain HTML forms

### DIFF
--- a/bases/rts-api/src/com/devereux_henley/rts_api/method_override.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/method_override.clj
@@ -1,0 +1,34 @@
+(ns com.devereux-henley.rts-api.method-override
+  "Outer ring middleware that unwraps `?_method=PUT|PATCH|DELETE` on POST
+  requests so plain HTML <form> elements can drive non-POST mutations
+  without JavaScript. HTMX-driven forms use real HTTP verbs and bypass
+  this entirely."
+  (:require
+   [clojure.string :as string]
+   [ring.util.codec :as codec]))
+
+(def ^:private overridable-verbs
+  #{"put" "patch" "delete"})
+
+(defn- read-method-override
+  "Returns the lower-cased `_method` query-parameter value, or nil when
+   the query string is absent or does not contain `_method`."
+  [query-string]
+  (when-not (string/blank? query-string)
+    (some (fn [pair]
+            (let [[k v] (string/split pair #"=" 2)]
+              (when (and v (= (codec/url-decode k) "_method"))
+                (string/lower-case (codec/url-decode v)))))
+          (string/split query-string #"&"))))
+
+(defn wrap-method-override
+  "Ring middleware. On POST requests with `?_method=PUT|PATCH|DELETE`,
+   rewrites `:request-method` to the overridden verb before delegating
+   to `handler`. Other requests pass through unchanged."
+  [handler]
+  (fn [{:keys [request-method query-string] :as request}]
+    (let [override (when (= :post request-method)
+                     (read-method-override query-string))]
+      (if (contains? overridable-verbs override)
+        (handler (assoc request :request-method (keyword override)))
+        (handler request)))))

--- a/bases/rts-api/src/com/devereux_henley/rts_api/web.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/web.clj
@@ -5,6 +5,7 @@
    [com.devereux-henley.content-negotiation.contract :as content-negotiation]
    [com.devereux-henley.resourcekit.contract :as resourcekit]
    [com.devereux-henley.rts-api.extensions.clj-http] ;; Patches multimethod for clj-http
+   [com.devereux-henley.rts-api.method-override :as method-override]
    [com.devereux-henley.rts-web.contract :as rts-web]
    [integrant.core]
    [malli.util]
@@ -258,6 +259,7 @@
                                             :body   "Oopsie"})})
     (ring/create-default-handler))
    {:middleware [ring.middleware.cookies/wrap-cookies
+                 method-override/wrap-method-override
                  auth-middleware]}))
 
 (defmethod integrant.core/init-key ::service

--- a/bases/rts-api/test/com/devereux_henley/rts_api/method_override_test.clj
+++ b/bases/rts-api/test/com/devereux_henley/rts_api/method_override_test.clj
@@ -1,0 +1,51 @@
+(ns com.devereux-henley.rts-api.method-override-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [com.devereux-henley.rts-api.method-override :as method-override]))
+
+(defn- echo-method-handler
+  [request]
+  {:status 200 :body (:request-method request)})
+
+(def ^:private wrapped
+  (method-override/wrap-method-override echo-method-handler))
+
+(deftest unwraps-overridable-verbs-on-post
+  (testing "POST + ?_method=DELETE → :delete"
+    (is (= :delete (:body (wrapped {:request-method :post :query-string "_method=DELETE"})))))
+  (testing "POST + ?_method=PATCH → :patch"
+    (is (= :patch (:body (wrapped {:request-method :post :query-string "_method=PATCH"})))))
+  (testing "POST + ?_method=PUT → :put"
+    (is (= :put (:body (wrapped {:request-method :post :query-string "_method=PUT"}))))))
+
+(deftest case-insensitive-override-values
+  (testing "lower-case override value works"
+    (is (= :delete (:body (wrapped {:request-method :post :query-string "_method=delete"})))))
+  (testing "mixed-case override value works"
+    (is (= :patch (:body (wrapped {:request-method :post :query-string "_method=PaTcH"}))))))
+
+(deftest leaves-other-requests-untouched
+  (testing "POST without _method query param stays :post"
+    (is (= :post (:body (wrapped {:request-method :post :query-string nil}))))
+    (is (= :post (:body (wrapped {:request-method :post :query-string ""}))))
+    (is (= :post (:body (wrapped {:request-method :post :query-string "version=1"})))))
+  (testing "GET + _method=DELETE stays :get (override only fires on POST)"
+    (is (= :get (:body (wrapped {:request-method :get :query-string "_method=DELETE"})))))
+  (testing "PUT + _method=DELETE stays :put"
+    (is (= :put (:body (wrapped {:request-method :put :query-string "_method=DELETE"}))))))
+
+(deftest unknown-override-value-ignored
+  (testing "POST + ?_method=GET stays :post — GET is not overridable"
+    (is (= :post (:body (wrapped {:request-method :post :query-string "_method=GET"})))))
+  (testing "POST + ?_method=POST stays :post — POST is not overridable"
+    (is (= :post (:body (wrapped {:request-method :post :query-string "_method=POST"})))))
+  (testing "POST + ?_method=FROBNICATE stays :post"
+    (is (= :post (:body (wrapped {:request-method :post :query-string "_method=FROBNICATE"}))))))
+
+(deftest mixed-with-other-query-params
+  (testing "_method works alongside other params (leading)"
+    (is (= :patch (:body (wrapped {:request-method :post :query-string "_method=PATCH&version=1"})))))
+  (testing "_method works alongside other params (trailing)"
+    (is (= :delete (:body (wrapped {:request-method :post :query-string "section=main&_method=DELETE"})))))
+  (testing "url-encoded _method value"
+    (is (= :delete (:body (wrapped {:request-method :post :query-string "_method=%44ELETE"}))))))


### PR DESCRIPTION
## Summary
- Adds `wrap-method-override` ring middleware that unwraps `?_method=PUT|PATCH|DELETE` on POST and rewrites `:request-method` before reitit route matching.
- First step toward an HTML-only hypermedia API where plain `<form>` elements can drive non-POST mutations on `/actions` without JS. HTMX continues to use real verbs and is unaffected.

## Test plan
- [x] `clojure -M:poly test` — 16 assertions across 5 deftests; covers overridable verbs, case-insensitivity, no-op on non-POST, ignored unknown overrides, mixed query strings, url-encoded values.
- [x] `cljfmt` clean on touched files.
- [x] `clj-kondo` 0 errors / 0 warnings on touched files.
- [x] `clojure -M:poly check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)