### PR TITLE
Migrate /api GET fragments to /components mirror endpoints

### DIFF
--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -130,6 +130,7 @@
    rts-web/status-route
    rts-web/icon-routes
    rts-web/view-routes
+   rts-web/components-routes
    rts-web/api-routes])
 
 ;;; ─── Assembled system maps ─────────────────────────────────────────────────

--- a/bases/rts-api/src/com/devereux_henley/rts_api/produces_enforcement.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/produces_enforcement.clj
@@ -1,0 +1,55 @@
+(ns com.devereux-henley.rts-api.produces-enforcement
+  "Reitit middleware that enforces the matched route's `:produces` against
+  the request's Accept header. Reitit's built-in `:produces` declaration
+  is informational only; muuntaja negotiates against globally-registered
+  formats, so without this middleware a route saying `:produces
+  [\"application/json\"]` will still happily serve any other registered
+  format if asked. This middleware closes the gap: a request whose Accept
+  header overlaps none of the produced types is rejected with 406."
+  (:require
+   [clojure.string :as string]
+   [reitit.ring :as ring]))
+
+(defn- accept-wildcard?
+  "True when the Accept header is missing, blank, or contains `*/*`."
+  [accept-header]
+  (or (string/blank? accept-header)
+      (string/includes? accept-header "*/*")))
+
+(defn- accept-allows?
+  "Does `accept-header` permit at least one of the `produces` media
+   types? Match is substring-based so `application/json;q=0.9` counts as
+   acceptable for `application/json`. Matches are case-insensitive."
+  [accept-header produces]
+  (or (accept-wildcard? accept-header)
+      (let [lc (string/lower-case accept-header)]
+        (some #(string/includes? lc (string/lower-case %)) produces))))
+
+(defn- route-produces
+  "Reads the matched route's `:produces` for the request method. Reitit
+   keeps method-specific data under method keys in `:data`, e.g.
+   `{:data {:get {:produces [...]}}}` — so we look it up by the request
+   method. Also accepts a top-level `:produces` for routes that declare
+   one verb only."
+  [request]
+  (when-let [match (ring/get-match request)]
+    (let [data (:data match)]
+      (or (get-in data [(:request-method request) :produces])
+          (:produces data)))))
+
+(defn wrap-enforce-produces
+  "Returns 406 Not Acceptable when the matched route declares `:produces`
+   and the request's Accept header does not include at least one of those
+   media types. No-op when the matched route has no `:produces` (route
+   accepts whatever muuntaja can negotiate globally)."
+  [handler]
+  (fn [request]
+    (let [produces (route-produces request)
+          accept   (get-in request [:headers "accept"])]
+      (if (or (nil? produces)
+              (empty? produces)
+              (accept-allows? accept produces))
+        (handler request)
+        {:status  406
+         :headers {"Content-Type" "text/plain; charset=utf-8"}
+         :body    "Not Acceptable"}))))

--- a/bases/rts-api/src/com/devereux_henley/rts_api/web.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/web.clj
@@ -6,6 +6,7 @@
    [com.devereux-henley.resourcekit.contract :as resourcekit]
    [com.devereux-henley.rts-api.extensions.clj-http] ;; Patches multimethod for clj-http
    [com.devereux-henley.rts-api.method-override :as method-override]
+   [com.devereux-henley.rts-api.produces-enforcement :as produces-enforcement]
    [com.devereux-henley.rts-web.contract :as rts-web]
    [integrant.core]
    [malli.util]
@@ -227,6 +228,9 @@
                               openapi/openapi-feature
                               ;; query-params & form-params
                               parameters/parameters-middleware
+                              ;; reject Accept that doesn't match the matched
+                              ;; route's :produces before muuntaja sees it
+                              produces-enforcement/wrap-enforce-produces
                               ;; content-negotiation
                               muuntaja/format-negotiate-middleware
                               ;; encoding response body

--- a/bases/rts-api/test/com/devereux_henley/rts_api/produces_enforcement_test.clj
+++ b/bases/rts-api/test/com/devereux_henley/rts_api/produces_enforcement_test.clj
@@ -1,0 +1,55 @@
+(ns com.devereux-henley.rts-api.produces-enforcement-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [com.devereux-henley.rts-api.produces-enforcement :as produces-enforcement]))
+
+(defn- ok-handler
+  [_request]
+  {:status 200 :body :handler-ran})
+
+(def ^:private wrapped
+  (produces-enforcement/wrap-enforce-produces ok-handler))
+
+(defn- request-with
+  "Builds a fake reitit-style request whose matched route declares the
+   given :produces (under the request's verb, mirroring reitit's method-
+   keyed shape) and whose Accept header is what the test asserts on."
+  [produces accept]
+  (cond-> {:request-method    :get
+           :reitit.core/match {:data {:get {:produces produces}}}}
+    accept (assoc :headers {"accept" accept})))
+
+(deftest accept-includes-a-produced-type
+  (testing "Accept header listing exactly the produced type → handler runs"
+    (is (= :handler-ran (:body (wrapped (request-with ["application/json"] "application/json"))))))
+  (testing "Accept header listing one of several produced types → handler runs"
+    (is (= :handler-ran (:body (wrapped (request-with ["application/json" "application/hal+json"]
+                                                      "application/hal+json"))))))
+  (testing "Accept header carrying q-values for a produced type → handler runs"
+    (is (= :handler-ran (:body (wrapped (request-with ["application/json"] "application/json;q=0.9")))))))
+
+(deftest accept-mismatches-produced-types
+  (testing "Accept asks for htmx+html but route only produces JSON → 406"
+    (is (= 406 (:status (wrapped (request-with ["application/json"] "application/htmx+html"))))))
+  (testing "Accept asks for text/html but route produces htmx+html only → 406"
+    (is (= 406 (:status (wrapped (request-with ["application/htmx+html"] "text/html")))))))
+
+(deftest accept-wildcards-pass
+  (testing "Accept: */* → handler runs"
+    (is (= :handler-ran (:body (wrapped (request-with ["application/htmx+html"] "*/*"))))))
+  (testing "missing Accept header → handler runs"
+    (is (= :handler-ran (:body (wrapped (request-with ["application/json"] nil))))))
+  (testing "blank Accept header → handler runs"
+    (is (= :handler-ran (:body (wrapped (request-with ["application/json"] "")))))))
+
+(deftest no-produces-on-route-passes
+  (testing "matched route without :produces → handler runs regardless of Accept"
+    (is (= :handler-ran (:body (wrapped (request-with nil "application/htmx+html"))))))
+  (testing "matched route with empty :produces → handler runs"
+    (is (= :handler-ran (:body (wrapped (request-with [] "application/htmx+html")))))))
+
+(deftest case-insensitive-matching
+  (testing "Accept header uppercase, produced lowercase → handler runs"
+    (is (= :handler-ran (:body (wrapped (request-with ["application/json"] "APPLICATION/JSON"))))))
+  (testing "Accept header lowercase, produced mixed-case → handler runs"
+    (is (= :handler-ran (:body (wrapped (request-with ["Application/JSON"] "application/json")))))))

--- a/components/e2e/tests/draft-mount.spec.js
+++ b/components/e2e/tests/draft-mount.spec.js
@@ -95,7 +95,7 @@ test.describe.serial('Mount-selection overrides', () => {
     // the /unit/:eid endpoint, not /entry/:eid.
     await expect(page.locator('.draft-editing-indicator')).not.toBeVisible();
     const formAction = await page.locator('#draft-unit-form').getAttribute('hx-get');
-    expect(formAction).toMatch(/\/api\/draft\/.+\/unit\//);
+    expect(formAction).toMatch(/\/components\/draft\/.+\/unit\//);
 
     const costCell = page.locator('#draft-unit .draft-stats-cost');
     const costBefore = await costCell.textContent();

--- a/components/e2e/tests/league.spec.js
+++ b/components/e2e/tests/league.spec.js
@@ -198,7 +198,7 @@ test.describe('Competitive view + legacy URL', () => {
 
   test('competitive landing renders both tabs', async ({ request }) => {
     const res = await request.get(`${BASE}/view/game/${GAME_EID}/competitive/index.html`, {
-      headers: { Accept: 'text/html', Cookie: 'dev_impersonation=dev-admin' },
+      headers: { Accept: 'application/htmx+html', Cookie: 'dev_impersonation=dev-admin' },
     });
     expect(res.status()).toBe(200);
     const body = await res.text();

--- a/components/e2e/tests/tournament.spec.js
+++ b/components/e2e/tests/tournament.spec.js
@@ -633,9 +633,9 @@ test.describe('Tournament Phase Details API', () => {
     expect((await res.json()).type).toBe('missing/resource');
   });
 
-  test('phase details renders an htmx fragment when accept is htmx+html', async ({ request }) => {
+  test('phase details renders an htmx fragment from the components endpoint', async ({ request }) => {
     const eid = await createActiveSwissTournament(request);
-    const res = await request.get(`${BASE}/api/tournament/${eid}/phase/0`, {
+    const res = await request.get(`${BASE}/components/tournament/${eid}/phase/0/panel/phase.html`, {
       headers: {
         Accept: 'application/htmx+html',
         Cookie: 'dev_impersonation=dev-admin',

--- a/components/e2e/tests/tournament.spec.js
+++ b/components/e2e/tests/tournament.spec.js
@@ -635,7 +635,7 @@ test.describe('Tournament Phase Details API', () => {
 
   test('phase details renders an htmx fragment from the components endpoint', async ({ request }) => {
     const eid = await createActiveSwissTournament(request);
-    const res = await request.get(`${BASE}/components/tournament/${eid}/phase/0/panel/phase.html`, {
+    const res = await request.get(`${BASE}/components/tournament/${eid}/phase/0/phase-panel.html`, {
       headers: {
         Accept: 'application/htmx+html',
         Cookie: 'dev_impersonation=dev-admin',

--- a/components/rts-web/resources/rts-web/resource/game.html
+++ b/components/rts-web/resources/rts-web/resource/game.html
@@ -37,7 +37,7 @@
             {% for faction in data._embedded.factions %}
             <a class="dropdown-item"
                role="menuitem"
-               hx-get="/components/faction/{{faction.eid}}/card/faction.html?embed=units-by-category"
+               hx-get="/components/faction/{{faction.eid}}/faction-card.html?embed=units-by-category"
                hx-target="#content"
                hx-push-url="/view/game/{{data.eid}}/faction/{{faction.eid}}/index.html"
                href="/view/game/{{data.eid}}/faction/{{faction.eid}}/index.html">

--- a/components/rts-web/resources/rts-web/resource/game.html
+++ b/components/rts-web/resources/rts-web/resource/game.html
@@ -37,7 +37,7 @@
             {% for faction in data._embedded.factions %}
             <a class="dropdown-item"
                role="menuitem"
-               hx-get="/api/game/faction/{{faction.eid}}?embed=units-by-category"
+               hx-get="/components/faction/{{faction.eid}}/card/faction.html?embed=units-by-category"
                hx-target="#content"
                hx-push-url="/view/game/{{data.eid}}/faction/{{faction.eid}}/index.html"
                href="/view/game/{{data.eid}}/faction/{{faction.eid}}/index.html">

--- a/components/rts-web/resources/rts-web/view/draft-index.html
+++ b/components/rts-web/resources/rts-web/view/draft-index.html
@@ -77,7 +77,7 @@
                             role="listitem"
                             aria-pressed="false"
                             aria-label="{{unit.name}}{% if unit.mark %}{% if unit.family-variant-count > 1 %} (Mark of {{unit.mark|capitalize}}){% endif %}{% endif %}, {{unit.unit-type-name}}, cost {{unit.cost}}"
-                            hx-get="/api/draft/{{draft-eid}}/unit/{{unit.eid}}"
+                            hx-get="/components/draft/{{draft-eid}}/unit/{{unit.eid}}/panel/unit.html"
                             hx-target="#draft-unit"
                             hx-swap="outerHTML">
                         <img src="/card/unit/{{unit.eid}}.png"

--- a/components/rts-web/resources/rts-web/view/draft-index.html
+++ b/components/rts-web/resources/rts-web/view/draft-index.html
@@ -77,7 +77,7 @@
                             role="listitem"
                             aria-pressed="false"
                             aria-label="{{unit.name}}{% if unit.mark %}{% if unit.family-variant-count > 1 %} (Mark of {{unit.mark|capitalize}}){% endif %}{% endif %}, {{unit.unit-type-name}}, cost {{unit.cost}}"
-                            hx-get="/components/draft/{{draft-eid}}/unit/{{unit.eid}}/panel/unit.html"
+                            hx-get="/components/draft/{{draft-eid}}/unit/{{unit.eid}}/unit-panel.html"
                             hx-target="#draft-unit"
                             hx-swap="outerHTML">
                         <img src="/card/unit/{{unit.eid}}.png"

--- a/components/rts-web/resources/rts-web/view/draft-slot-inner.html
+++ b/components/rts-web/resources/rts-web/view/draft-slot-inner.html
@@ -3,7 +3,7 @@
         hx-preserve="true"
         type="button"
         aria-labelledby="draft-slot-edit-label-{{unit.entry-eid}}"
-        hx-get="/components/draft/{{section.draft-eid}}/entry/{{unit.entry-eid}}/panel/entry.html?section={{section.section}}&amp;embed=unit"
+        hx-get="/components/draft/{{section.draft-eid}}/entry/{{unit.entry-eid}}/entry-panel.html?section={{section.section}}&amp;embed=unit"
         hx-target="#draft-unit"
         hx-swap="outerHTML">
     {# Accessible label lives in a child span rather than an inline

--- a/components/rts-web/resources/rts-web/view/draft-slot-inner.html
+++ b/components/rts-web/resources/rts-web/view/draft-slot-inner.html
@@ -3,7 +3,7 @@
         hx-preserve="true"
         type="button"
         aria-labelledby="draft-slot-edit-label-{{unit.entry-eid}}"
-        hx-get="/api/draft/{{section.draft-eid}}/entry/{{unit.entry-eid}}?section={{section.section}}&amp;embed=unit"
+        hx-get="/components/draft/{{section.draft-eid}}/entry/{{unit.entry-eid}}/panel/entry.html?section={{section.section}}&amp;embed=unit"
         hx-target="#draft-unit"
         hx-swap="outerHTML">
     {# Accessible label lives in a child span rather than an inline

--- a/components/rts-web/resources/rts-web/view/draft-unit-panel.html
+++ b/components/rts-web/resources/rts-web/view/draft-unit-panel.html
@@ -11,7 +11,7 @@
           hx-patch="/api/draft/{{data.draft-eid}}/entry/{{data.eid}}?section={{data.section}}"
           hx-ext="json-enc"
           {% else %}
-          hx-get="/api/draft/{{unit.draft-eid}}/unit/{{unit.eid}}"
+          hx-get="/components/draft/{{unit.draft-eid}}/unit/{{unit.eid}}/panel/unit.html"
           {% endif %}
           hx-trigger="change delay:300ms"
           hx-target="#draft-unit-body"
@@ -437,14 +437,14 @@
           hx-headers='{"Accept": "application/htmx+html"}'></form>
     {% else %}
     <form id="draft-mark-form"
-          hx-get="/api/draft/{{unit.draft-eid}}/unit"
+          hx-get="/components/draft/{{unit.draft-eid}}/panel/unit-preview.html"
           hx-trigger="patchFamily"
           hx-target="#draft-unit-body"
           hx-select="#draft-unit-body"
           hx-swap="outerHTML"
           hx-headers='{"Accept": "application/htmx+html"}'></form>
     <form id="draft-lore-form"
-          hx-get="/api/draft/{{unit.draft-eid}}/unit"
+          hx-get="/components/draft/{{unit.draft-eid}}/panel/unit-preview.html"
           hx-trigger="patchFamily"
           hx-target="#draft-unit-body"
           hx-select="#draft-unit-body"

--- a/components/rts-web/resources/rts-web/view/draft-unit-panel.html
+++ b/components/rts-web/resources/rts-web/view/draft-unit-panel.html
@@ -11,7 +11,7 @@
           hx-patch="/api/draft/{{data.draft-eid}}/entry/{{data.eid}}?section={{data.section}}"
           hx-ext="json-enc"
           {% else %}
-          hx-get="/components/draft/{{unit.draft-eid}}/unit/{{unit.eid}}/panel/unit.html"
+          hx-get="/components/draft/{{unit.draft-eid}}/unit/{{unit.eid}}/unit-panel.html"
           {% endif %}
           hx-trigger="change delay:300ms"
           hx-target="#draft-unit-body"
@@ -437,14 +437,14 @@
           hx-headers='{"Accept": "application/htmx+html"}'></form>
     {% else %}
     <form id="draft-mark-form"
-          hx-get="/components/draft/{{unit.draft-eid}}/panel/unit-preview.html"
+          hx-get="/components/draft/{{unit.draft-eid}}/unit-panel.html"
           hx-trigger="patchFamily"
           hx-target="#draft-unit-body"
           hx-select="#draft-unit-body"
           hx-swap="outerHTML"
           hx-headers='{"Accept": "application/htmx+html"}'></form>
     <form id="draft-lore-form"
-          hx-get="/components/draft/{{unit.draft-eid}}/panel/unit-preview.html"
+          hx-get="/components/draft/{{unit.draft-eid}}/unit-panel.html"
           hx-trigger="patchFamily"
           hx-target="#draft-unit-body"
           hx-select="#draft-unit-body"

--- a/components/rts-web/resources/rts-web/view/faction-list.html
+++ b/components/rts-web/resources/rts-web/view/faction-list.html
@@ -13,7 +13,7 @@
         {% if factions %}
         {% for faction in factions %}
         <a class="faction-card"
-           hx-get="/components/faction/{{faction.eid}}/card/faction.html?embed=units-by-category"
+           hx-get="/components/faction/{{faction.eid}}/faction-card.html?embed=units-by-category"
            hx-target="#content"
            hx-push-url="/view/game/{{game-eid}}/faction/{{faction.eid}}/index.html"
            href="/view/game/{{game-eid}}/faction/{{faction.eid}}/index.html"

--- a/components/rts-web/resources/rts-web/view/faction-list.html
+++ b/components/rts-web/resources/rts-web/view/faction-list.html
@@ -13,7 +13,7 @@
         {% if factions %}
         {% for faction in factions %}
         <a class="faction-card"
-           hx-get="/api/game/faction/{{faction.eid}}?embed=units-by-category"
+           hx-get="/components/faction/{{faction.eid}}/card/faction.html?embed=units-by-category"
            hx-target="#content"
            hx-push-url="/view/game/{{game-eid}}/faction/{{faction.eid}}/index.html"
            href="/view/game/{{game-eid}}/faction/{{faction.eid}}/index.html"

--- a/components/rts-web/resources/rts-web/view/tournament-index.html
+++ b/components/rts-web/resources/rts-web/view/tournament-index.html
@@ -178,7 +178,7 @@
                 <button type="button" role="tab" id="tab-phase-{{phase-group.phase}}"
                         aria-selected="false" aria-controls="panel-phase-{{phase-group.phase}}"
                         class="tourney-tab"
-                        hx-get="/api/tournament/{{data.eid}}/phase/{{phase-group.phase}}"
+                        hx-get="/components/tournament/{{data.eid}}/phase/{{phase-group.phase}}/panel/phase.html"
                         hx-target="#panel-phase-{{phase-group.phase}}"
                         hx-swap="innerHTML"
                         _="on click
@@ -218,7 +218,7 @@
                      aria-labelledby="tab-phase-{{phase-group.phase}}"
                      class="tourney-tab-panel"
                      hidden
-                     hx-get="/api/tournament/{{data.eid}}/phase/{{phase-group.phase}}"
+                     hx-get="/components/tournament/{{data.eid}}/phase/{{phase-group.phase}}/panel/phase.html"
                      hx-trigger="match-recorded from:body"
                      hx-swap="innerHTML"></section>
             {% endfor %}

--- a/components/rts-web/resources/rts-web/view/tournament-index.html
+++ b/components/rts-web/resources/rts-web/view/tournament-index.html
@@ -178,7 +178,7 @@
                 <button type="button" role="tab" id="tab-phase-{{phase-group.phase}}"
                         aria-selected="false" aria-controls="panel-phase-{{phase-group.phase}}"
                         class="tourney-tab"
-                        hx-get="/components/tournament/{{data.eid}}/phase/{{phase-group.phase}}/panel/phase.html"
+                        hx-get="/components/tournament/{{data.eid}}/phase/{{phase-group.phase}}/phase-panel.html"
                         hx-target="#panel-phase-{{phase-group.phase}}"
                         hx-swap="innerHTML"
                         _="on click
@@ -218,7 +218,7 @@
                      aria-labelledby="tab-phase-{{phase-group.phase}}"
                      class="tourney-tab-panel"
                      hidden
-                     hx-get="/components/tournament/{{data.eid}}/phase/{{phase-group.phase}}/panel/phase.html"
+                     hx-get="/components/tournament/{{data.eid}}/phase/{{phase-group.phase}}/phase-panel.html"
                      hx-trigger="match-recorded from:body"
                      hx-swap="innerHTML"></section>
             {% endfor %}

--- a/components/rts-web/resources/rts-web/view/tournament-phase-row.html
+++ b/components/rts-web/resources/rts-web/view/tournament-phase-row.html
@@ -17,7 +17,7 @@
         {% include "rts-web/view/tournament-round-row.html" %}
     </div>
     <button type="button" class="btn btn-ghost btn-sm"
-            hx-get="/api/tournament/{{tournament-eid}}/round"
+            hx-get="/components/tournament/{{tournament-eid}}/row/round.html"
             hx-target="previous .tournament-rounds-container"
             hx-swap="beforeend">+ Add Round</button>
 </div>

--- a/components/rts-web/resources/rts-web/view/tournament-phase-row.html
+++ b/components/rts-web/resources/rts-web/view/tournament-phase-row.html
@@ -17,7 +17,7 @@
         {% include "rts-web/view/tournament-round-row.html" %}
     </div>
     <button type="button" class="btn btn-ghost btn-sm"
-            hx-get="/components/tournament/{{tournament-eid}}/row/round.html"
+            hx-get="/components/tournament/{{tournament-eid}}/round-row.html"
             hx-target="previous .tournament-rounds-container"
             hx-swap="beforeend">+ Add Round</button>
 </div>

--- a/components/rts-web/src/com/devereux_henley/rts_web/contract.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/contract.clj
@@ -21,6 +21,7 @@
 (def shutdown-route web.routes/shutdown-route)
 (def icon-routes web.routes/icon-routes)
 (def view-routes web.routes/view-routes)
+(def components-routes web.routes/components-routes)
 (def api-routes web.routes/api-routes)
 
 (def render-view render/render)

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -354,10 +354,10 @@
             :responses  {200 {:body domain/draft-unit-resource}
                          500 {:body domain/draft-error-response}}
             :handler    (integrant.core/ref ::web.draft.api/get-draft-unit)}
-     :post {:produces   ["application/json" "application/htmx+html"]
+     :post {:produces   ["application/json" "application/hal+json" "application/htmx+html"]
             :openapi    {:summary      "Assigns a unit to the specified draft."
                          :tags         ["draft"]
-                         :produces     ["application/json" "application/htmx+html"]
+                         :produces     ["application/json" "application/hal+json" "application/htmx+html"]
                          :operation-id "draft-unit/create"}
             :parameters {:path  (schema.contract/to-schema
                                  [:map
@@ -396,10 +396,10 @@
                            404 {:body domain/draft-error-response}
                            500 {:body domain/draft-error-response}}
               :handler    (integrant.core/ref ::web.draft.api/get-draft-entry)}
-     :patch  {:produces   ["application/json" "application/htmx+html"]
+     :patch  {:produces   ["application/json" "application/hal+json" "application/htmx+html"]
               :openapi    {:summary      "Updates the selections of a placed draft entry."
                            :tags         ["draft"]
-                           :produces     ["application/json" "application/htmx+html"]
+                           :produces     ["application/json" "application/hal+json" "application/htmx+html"]
                            :operation-id "draft-entry/update"}
               :parameters {:path  (schema.contract/to-schema
                                    [:map
@@ -413,10 +413,10 @@
                            422 {:body domain/draft-error-response}
                            500 {:body domain/draft-error-response}}
               :handler    (integrant.core/ref ::web.draft.api/draft-update-unit)}
-     :delete {:produces   ["application/json" "application/htmx+html"]
+     :delete {:produces   ["application/json" "application/hal+json" "application/htmx+html"]
               :openapi    {:summary      "Removes a placed entry from the specified draft."
                            :tags         ["draft"]
-                           :produces     ["application/json" "application/htmx+html"]
+                           :produces     ["application/json" "application/hal+json" "application/htmx+html"]
                            :operation-id "draft-entry/delete"}
               :parameters {:path  (schema.contract/to-schema
                                    [:map
@@ -432,8 +432,9 @@
     {:name  :draft/by-eid
      :put   {:summary    "Creates a draft with the given eid and version."
              :openapi    {:tags         ["draft"]
-                          :produces     ["application/json" "application/htmx+html"]
+                          :produces     ["application/json" "application/hal+json" "application/htmx+html"]
                           :operation-id "draft/create"}
+             :produces   ["application/json" "application/hal+json" "application/htmx+html"]
              :parameters {:path  schema.contract/id-path-parameter
                           :query schema.contract/version-query-parameter
                           :body  domain/create-draft-specification}
@@ -441,8 +442,9 @@
              :handler    (integrant.core/ref ::web.draft.api/create-draft)}
      :patch {:summary    "Applies a partial update to a draft (currently only :name)."
              :openapi    {:tags         ["draft"]
-                          :produces     ["application/json" "application/htmx+html"]
+                          :produces     ["application/json" "application/hal+json" "application/htmx+html"]
                           :operation-id "draft/update"}
+             :produces   ["application/json" "application/hal+json" "application/htmx+html"]
              :parameters {:path schema.contract/id-path-parameter
                           :body domain/update-draft-specification}
              :responses  {200 {:body domain/draft-resource}

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -273,8 +273,9 @@
     {:name :collection/game
      :get  {:summary   "Fetches a list of games."
             :openapi   {:tags         ["game"]
-                        :produces     ["application/json"]
+                        :produces     ["application/json" "application/hal+json"]
                         :operation-id "game/all"}
+            :produces  ["application/json" "application/hal+json"]
             :responses {200 {:body domain/game-collection-resource}}
             :handler   (integrant.core/ref ::web.game.api/get-games)}}]
 
@@ -282,8 +283,9 @@
     {:name :game/by-eid
      :get  {:summary    "Fetches a game by eid."
             :openapi    {:tags         ["game"]
-                         :produces     ["application/json"]
+                         :produces     ["application/json" "application/hal+json"]
                          :operation-id "game/by-eid"}
+            :produces   ["application/json" "application/hal+json"]
             :parameters {:path  schema.contract/id-path-parameter
                          :query web.game.api/game-query-parameters}
             :responses  {200 {:body domain/game-resource}}
@@ -292,8 +294,9 @@
     {:name :game/social-by-eid
      :get  {:summary    "Fetches a link between social media and a game by eid."
             :openapi    {:tags         ["game"]
-                         :produces     ["application/json"]
+                         :produces     ["application/json" "application/hal+json"]
                          :operation-id "game/social-by-eid"}
+            :produces   ["application/json" "application/hal+json"]
             :parameters {:path  schema.contract/id-path-parameter
                          :query schema.contract/version-query-parameter}
             :responses  {200 {:body domain/game-social-link-resource}}
@@ -302,18 +305,19 @@
     {:name :game/faction-by-eid
      :get  {:summary    "Fetches a game faction by eid."
             :openapi    {:tags         ["game"]
-                         :produces     ["application/json"]
+                         :produces     ["application/json" "application/hal+json"]
                          :operation-id "game/faction-by-eid"}
+            :produces   ["application/json" "application/hal+json"]
             :parameters {:path  schema.contract/id-path-parameter
                          :query web.game.api/faction-query-parameters}
             :responses  {200 {:body domain/faction-resource}}
             :handler    (integrant.core/ref ::web.game.api/get-faction)}}]
    ["/draft/:draft-eid/unit"
     {:name :draft-unit/preview
-     :get  {:produces   ["application/json"]
+     :get  {:produces   ["application/json" "application/hal+json"]
             :openapi    {:summary      "Previews a unit variant within the draft context (variant via `unit-eid` query)."
                          :tags         ["draft"]
-                         :produces     ["application/json"]
+                         :produces     ["application/json" "application/hal+json"]
                          :operation-id "draft-unit/preview"}
             :parameters {:path  (schema.contract/to-schema
                                  [:map
@@ -331,10 +335,10 @@
             :handler    (integrant.core/ref ::web.draft.api/get-draft-unit)}}]
    ["/draft/:draft-eid/unit/:eid"
     {:name :draft-unit/by-eid
-     :get  {:produces   ["application/json"]
+     :get  {:produces   ["application/json" "application/hal+json"]
             :openapi    {:summary      "Gets details for a unit that can be assigned to the specific draft."
                          :tags         ["draft"]
-                         :produces     ["application/json"]
+                         :produces     ["application/json" "application/hal+json"]
                          :operation-id "draft-unit/get"}
             :parameters {:path  (schema.contract/to-schema
                                  [:map
@@ -369,10 +373,10 @@
             :handler    (integrant.core/ref ::web.draft.api/draft-add-unit)}}]
    ["/draft/:draft-eid/entry/:eid"
     {:name   :draft-entry/by-eid
-     :get    {:produces   ["application/json"]
+     :get    {:produces   ["application/json" "application/hal+json"]
               :openapi    {:summary      "Gets a placed draft entry with its unit details and selection state."
                            :tags         ["draft"]
-                           :produces     ["application/json"]
+                           :produces     ["application/json" "application/hal+json"]
                            :operation-id "draft-entry/get"}
               :parameters {:path  (schema.contract/to-schema
                                    [:map
@@ -603,8 +607,9 @@
       {:name :tournament/phase
        :get  {:summary    "Phase details (standings + bracket / rounds)."
               :openapi    {:tags         ["tournament"]
-                           :produces     ["application/json"]
+                           :produces     ["application/json" "application/hal+json"]
                            :operation-id "tournament-phase/get"}
+              :produces   ["application/json" "application/hal+json"]
               :parameters {:path (schema.contract/to-schema
                                   [:map
                                    [:eid :uuid]
@@ -615,8 +620,9 @@
       {:name :tournament/round
        :get  {:summary    "Form partial for a tournament round."
               :openapi    {:tags         ["tournament"]
-                           :produces     ["application/json"]
+                           :produces     ["application/json" "application/hal+json"]
                            :operation-id "tournament-round/get"}
+              :produces   ["application/json" "application/hal+json"]
               :parameters {:path schema.contract/id-path-parameter}
               :responses  {200 {:body domain/round-response}}
               :handler    (integrant.core/ref ::web.tournament.api/get-round)}
@@ -724,8 +730,9 @@
     {:name :social-media/by-eid
      :get  {:summary    "Fetches a social media platform by eid."
             :openapi    {:tags         ["social-media"]
-                         :produces     ["application/json"]
+                         :produces     ["application/json" "application/hal+json"]
                          :operation-id "social-media/by-eid"}
+            :produces   ["application/json" "application/hal+json"]
             :parameters {:path  schema.contract/id-path-parameter
                          :query schema.contract/version-query-parameter}
             :responses  {200 {:body domain/social-media-platform-resource}}

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -185,13 +185,13 @@
 (def components-routes
   ["/components"
    {:no-doc true}
-   ["/faction/:eid/card/faction.html"
+   ["/faction/:eid/faction-card.html"
     {:get {:produces   ["application/htmx+html"]
            :parameters {:path  schema.contract/id-path-parameter
                         :query web.game.api/faction-query-parameters}
            :responses  {200 {:body domain/faction-resource}}
            :handler    (integrant.core/ref ::web.game.api/get-faction)}}]
-   ["/draft/:draft-eid/panel/unit-preview.html"
+   ["/draft/:draft-eid/unit-panel.html"
     {:get {:produces   ["application/htmx+html"]
            :parameters {:path  (schema.contract/to-schema
                                 [:map
@@ -207,7 +207,7 @@
            :responses  {200 {:body domain/draft-unit-resource}
                         500 {:body domain/draft-error-response}}
            :handler    (integrant.core/ref ::web.draft.api/get-draft-unit)}}]
-   ["/draft/:draft-eid/unit/:eid/panel/unit.html"
+   ["/draft/:draft-eid/unit/:eid/unit-panel.html"
     {:get {:produces   ["application/htmx+html"]
            :parameters {:path  (schema.contract/to-schema
                                 [:map
@@ -223,7 +223,7 @@
            :responses  {200 {:body domain/draft-unit-resource}
                         500 {:body domain/draft-error-response}}
            :handler    (integrant.core/ref ::web.draft.api/get-draft-unit)}}]
-   ["/draft/:draft-eid/entry/:eid/panel/entry.html"
+   ["/draft/:draft-eid/entry/:eid/entry-panel.html"
     {:get {:produces   ["application/htmx+html"]
            :parameters {:path  (schema.contract/to-schema
                                 [:map
@@ -243,12 +243,12 @@
                         404 {:body domain/draft-error-response}
                         500 {:body domain/draft-error-response}}
            :handler    (integrant.core/ref ::web.draft.api/get-draft-entry)}}]
-   ["/tournament/:eid/row/round.html"
+   ["/tournament/:eid/round-row.html"
     {:get {:produces   ["application/htmx+html"]
            :parameters {:path schema.contract/id-path-parameter}
            :responses  {200 {:body domain/round-response}}
            :handler    (integrant.core/ref ::web.tournament.api/get-round)}}]
-   ["/tournament/:eid/phase/:phase-index/panel/phase.html"
+   ["/tournament/:eid/phase/:phase-index/phase-panel.html"
     {:get {:produces   ["application/htmx+html"]
            :parameters {:path (schema.contract/to-schema
                                [:map

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -182,6 +182,81 @@
                                    [:eid :uuid]])}
               :handler    (integrant.core/ref ::web.season.view/season-view)}}]]]]])
 
+(def components-routes
+  ["/components"
+   {:no-doc true}
+   ["/faction/:eid/card/faction.html"
+    {:get {:produces   ["application/htmx+html"]
+           :parameters {:path  schema.contract/id-path-parameter
+                        :query web.game.api/faction-query-parameters}
+           :responses  {200 {:body domain/faction-resource}}
+           :handler    (integrant.core/ref ::web.game.api/get-faction)}}]
+   ["/draft/:draft-eid/panel/unit-preview.html"
+    {:get {:produces   ["application/htmx+html"]
+           :parameters {:path  (schema.contract/to-schema
+                                [:map
+                                 [:draft-eid :uuid]])
+                        :query (schema.contract/to-schema
+                                [:map
+                                 [:unit-eid  :uuid]
+                                 [:mount     {:optional true} [:maybe :string]]
+                                 [:lore      {:optional true} [:maybe :string]]
+                                 [:items     {:optional true} [:or :string [:sequential :string]]]
+                                 [:spells    {:optional true} [:or :string [:sequential :string]]]
+                                 [:abilities {:optional true} [:or :string [:sequential :string]]]])}
+           :responses  {200 {:body domain/draft-unit-resource}
+                        500 {:body domain/draft-error-response}}
+           :handler    (integrant.core/ref ::web.draft.api/get-draft-unit)}}]
+   ["/draft/:draft-eid/unit/:eid/panel/unit.html"
+    {:get {:produces   ["application/htmx+html"]
+           :parameters {:path  (schema.contract/to-schema
+                                [:map
+                                 [:draft-eid :uuid]
+                                 [:eid :uuid]])
+                        :query (schema.contract/to-schema
+                                [:map
+                                 [:mount     {:optional true} [:maybe :string]]
+                                 [:level     {:optional true} [:int {:min 0 :max 9}]]
+                                 [:items     {:optional true} [:or :string [:sequential :string]]]
+                                 [:spells    {:optional true} [:or :string [:sequential :string]]]
+                                 [:abilities {:optional true} [:or :string [:sequential :string]]]])}
+           :responses  {200 {:body domain/draft-unit-resource}
+                        500 {:body domain/draft-error-response}}
+           :handler    (integrant.core/ref ::web.draft.api/get-draft-unit)}}]
+   ["/draft/:draft-eid/entry/:eid/panel/entry.html"
+    {:get {:produces   ["application/htmx+html"]
+           :parameters {:path  (schema.contract/to-schema
+                                [:map
+                                 [:draft-eid :uuid]
+                                 [:eid :uuid]])
+                        :query (schema.contract/to-schema
+                                [:map
+                                 [:section   [:enum "main" "reinforcements"]]
+                                 [:embed     {:optional true} [:or [:enum "unit"]
+                                                               [:sequential [:enum "unit"]]]]
+                                 [:mount     {:optional true} [:maybe :string]]
+                                 [:level     {:optional true} [:int {:min 0 :max 9}]]
+                                 [:items     {:optional true} [:or :string [:sequential :string]]]
+                                 [:spells    {:optional true} [:or :string [:sequential :string]]]
+                                 [:abilities {:optional true} [:or :string [:sequential :string]]]])}
+           :responses  {200 {:body domain/draft-entry-resource}
+                        404 {:body domain/draft-error-response}
+                        500 {:body domain/draft-error-response}}
+           :handler    (integrant.core/ref ::web.draft.api/get-draft-entry)}}]
+   ["/tournament/:eid/row/round.html"
+    {:get {:produces   ["application/htmx+html"]
+           :parameters {:path schema.contract/id-path-parameter}
+           :responses  {200 {:body domain/round-response}}
+           :handler    (integrant.core/ref ::web.tournament.api/get-round)}}]
+   ["/tournament/:eid/phase/:phase-index/panel/phase.html"
+    {:get {:produces   ["application/htmx+html"]
+           :parameters {:path (schema.contract/to-schema
+                               [:map
+                                [:eid :uuid]
+                                [:phase-index :int]])}
+           :responses  {200 {:body domain/phase-response}}
+           :handler    (integrant.core/ref ::web.tournament.api/get-phase)}}]])
+
 (def api-routes
   ["/api"
    {:openapi {:security [{"ory" ["openid"]}]}}
@@ -198,7 +273,7 @@
     {:name :collection/game
      :get  {:summary   "Fetches a list of games."
             :openapi   {:tags         ["game"]
-                        :produces     ["application/htmx+html" "application/json"]
+                        :produces     ["application/json"]
                         :operation-id "game/all"}
             :responses {200 {:body domain/game-collection-resource}}
             :handler   (integrant.core/ref ::web.game.api/get-games)}}]
@@ -207,7 +282,7 @@
     {:name :game/by-eid
      :get  {:summary    "Fetches a game by eid."
             :openapi    {:tags         ["game"]
-                         :produces     ["application/htmx+html" "application/json"]
+                         :produces     ["application/json"]
                          :operation-id "game/by-eid"}
             :parameters {:path  schema.contract/id-path-parameter
                          :query web.game.api/game-query-parameters}
@@ -217,7 +292,7 @@
     {:name :game/social-by-eid
      :get  {:summary    "Fetches a link between social media and a game by eid."
             :openapi    {:tags         ["game"]
-                         :produces     ["application/htmx+html" "application/json"]
+                         :produces     ["application/json"]
                          :operation-id "game/social-by-eid"}
             :parameters {:path  schema.contract/id-path-parameter
                          :query schema.contract/version-query-parameter}
@@ -227,7 +302,7 @@
     {:name :game/faction-by-eid
      :get  {:summary    "Fetches a game faction by eid."
             :openapi    {:tags         ["game"]
-                         :produces     ["application/htmx+html" "application/json"]
+                         :produces     ["application/json"]
                          :operation-id "game/faction-by-eid"}
             :parameters {:path  schema.contract/id-path-parameter
                          :query web.game.api/faction-query-parameters}
@@ -235,10 +310,10 @@
             :handler    (integrant.core/ref ::web.game.api/get-faction)}}]
    ["/draft/:draft-eid/unit"
     {:name :draft-unit/preview
-     :get  {:produces   ["application/json" "application/htmx+html"]
+     :get  {:produces   ["application/json"]
             :openapi    {:summary      "Previews a unit variant within the draft context (variant via `unit-eid` query)."
                          :tags         ["draft"]
-                         :produces     ["application/json" "application/htmx+html"]
+                         :produces     ["application/json"]
                          :operation-id "draft-unit/preview"}
             :parameters {:path  (schema.contract/to-schema
                                  [:map
@@ -256,10 +331,10 @@
             :handler    (integrant.core/ref ::web.draft.api/get-draft-unit)}}]
    ["/draft/:draft-eid/unit/:eid"
     {:name :draft-unit/by-eid
-     :get  {:produces   ["application/json" "application/htmx+html"]
+     :get  {:produces   ["application/json"]
             :openapi    {:summary      "Gets details for a unit that can be assigned to the specific draft."
                          :tags         ["draft"]
-                         :produces     ["application/json" "application/htmx+html"]
+                         :produces     ["application/json"]
                          :operation-id "draft-unit/get"}
             :parameters {:path  (schema.contract/to-schema
                                  [:map
@@ -294,10 +369,10 @@
             :handler    (integrant.core/ref ::web.draft.api/draft-add-unit)}}]
    ["/draft/:draft-eid/entry/:eid"
     {:name   :draft-entry/by-eid
-     :get    {:produces   ["application/json" "application/htmx+html"]
+     :get    {:produces   ["application/json"]
               :openapi    {:summary      "Gets a placed draft entry with its unit details and selection state."
                            :tags         ["draft"]
-                           :produces     ["application/json" "application/htmx+html"]
+                           :produces     ["application/json"]
                            :operation-id "draft-entry/get"}
               :parameters {:path  (schema.contract/to-schema
                                    [:map
@@ -528,7 +603,7 @@
       {:name :tournament/phase
        :get  {:summary    "Phase details (standings + bracket / rounds)."
               :openapi    {:tags         ["tournament"]
-                           :produces     ["application/json" "application/htmx+html"]
+                           :produces     ["application/json"]
                            :operation-id "tournament-phase/get"}
               :parameters {:path (schema.contract/to-schema
                                   [:map
@@ -540,7 +615,7 @@
       {:name :tournament/round
        :get  {:summary    "Form partial for a tournament round."
               :openapi    {:tags         ["tournament"]
-                           :produces     ["application/json" "application/htmx+html"]
+                           :produces     ["application/json"]
                            :operation-id "tournament-round/get"}
               :parameters {:path schema.contract/id-path-parameter}
               :responses  {200 {:body domain/round-response}}
@@ -649,7 +724,7 @@
     {:name :social-media/by-eid
      :get  {:summary    "Fetches a social media platform by eid."
             :openapi    {:tags         ["social-media"]
-                         :produces     ["application/htmx+html" "application/json"]
+                         :produces     ["application/json"]
                          :operation-id "social-media/by-eid"}
             :parameters {:path  schema.contract/id-path-parameter
                          :query schema.contract/version-query-parameter}


### PR DESCRIPTION
## Summary
First slice of the /api → hypermedia migration. Three pieces:

1. **Six `/components` mirror routes** for the /api GETs that templates currently `hx-get` against. Each is `application/htmx+html`-only and reuses the existing /api handler:
   - `/components/faction/:eid/faction-card.html`
   - `/components/draft/:draft-eid/unit-panel.html` *(preview-by-query)*
   - `/components/draft/:draft-eid/unit/:eid/unit-panel.html`
   - `/components/draft/:draft-eid/entry/:eid/entry-panel.html`
   - `/components/tournament/:eid/round-row.html`
   - `/components/tournament/:eid/phase/:phase-index/phase-panel.html`

   The two `unit-panel.html` paths share a filename — they render the same component, distinguished by URL shape.

2. **Per-route `:produces` enforcement.** Reitit's `:produces` is documentation-only in this stack (muuntaja negotiates against globally-registered formats), so dropping `application/htmx+html` from a route's `:produces` had no runtime effect. New `wrap-enforce-produces` middleware reads the matched route's method-keyed `:produces` and returns `406 Not Acceptable` when the request's `Accept` header overlaps none of them. Wildcard `Accept` (`*/*`, blank, missing) and routes without `:produces` pass through.

   Wired in between `parameters-middleware` and muuntaja's `format-negotiate-middleware`, so rejection happens before muuntaja considers the request. Every /api GET now declares `:produces ["application/json" "application/hal+json"]` (preserves HAL+JSON used by `draft-api.spec.js`).

3. **Templates repointed.** All `hx-get` attributes that pointed at /api fragment URLs now point at /components. Mutations on /api (POST/PATCH/DELETE/PUT) untouched — those move to /actions in PR D.

## Behavior after this PR

| URL prefix | Accept | Status |
|---|---|---|
| `/api/*` (GET) | `application/htmx+html` | **406** |
| `/api/*` (GET) | `application/json` | 200 |
| `/api/*` (GET) | `application/hal+json` | 200 |
| `/components/*` | `application/htmx+html` | 200 |
| `/components/*` | `application/json` | **406** |

## Test plan
- [x] `clojure -M:poly test` — method-override (16 assertions) + produces-enforcement (12 assertions) all green.
- [x] `cljfmt` clean on touched files.
- [x] `clj-kondo` 0 errors / 0 warnings.
- [x] `clojure -M:poly check` clean.
- [x] Live walkthrough via Playwright against a local dev server (toolbox nREPL on :7888 + Jetty on :3001): faction-list → click The Empire → units table renders via the `/components/faction/:eid/faction-card.html?embed=units-by-category` swap; browser URL updates via `hx-push-url`.
- [x] Curl spot-checks confirm 406 enforcement on both /api (htmx Accept) and /components (json Accept), and 200 on the expected combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)