### PR TITLE
Dedupe reitit dep; declare 0.10.1 once on rts-web

### DIFF
--- a/bases/rts-api/deps.edn
+++ b/bases/rts-api/deps.edn
@@ -1,7 +1,6 @@
 {:paths ["src" "resources"]
  :deps {com.taoensso/timbre {:mvn/version "6.0.4"}
         integrant/integrant {:mvn/version "1.0.1"}
-        metosin/reitit {:mvn/version "0.10.1"}
         metosin/malli {:mvn/version "0.9.2"}
         metosin/muuntaja {:mvn/version "0.6.8"}
         metosin/muuntaja-form {:mvn/version "0.6.8"}

--- a/components/rts-web/deps.edn
+++ b/components/rts-web/deps.edn
@@ -2,6 +2,6 @@
  :deps {camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
         integrant/integrant   {:mvn/version "1.0.1"}
         metosin/jsonista      {:mvn/version "0.3.5"}
-        metosin/reitit        {:mvn/version "0.5.18"}
+        metosin/reitit        {:mvn/version "0.10.1"}
         com.taoensso/timbre   {:mvn/version "6.0.4"}
         selmer/selmer         {:mvn/version "1.12.55"}}}


### PR DESCRIPTION
## Summary

The api project was pulling reitit twice with conflicting versions: `metosin/reitit 0.5.18` from `components/rts-web/deps.edn` and `metosin/reitit 0.10.1` from `bases/rts-api/deps.edn`. deps.edn's resolution algorithm was silently picking one. rts-web is the primary consumer (every route + the `_links` model-transformer), so the canonical declaration belongs there.

This bumps rts-web's reitit to `0.10.1` and drops the redundant entry from the api base. The base still uses reitit (routing + middleware in `web.clj`) but resolves it transitively via rts-web on the project classpath.

## Test plan

- [x] `clojure -M:poly check` is clean
- [x] `clojure -M:poly test :all` passes (rts-api method-override + every other brick's existing tests)
- [x] `clojure -Stree` from `projects/api/` shows a single `metosin/reitit 0.10.1` entry under `mono/rts-web` with no other reitit branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)