### PR TITLE
Drop paren-repair hooks; document clojure-mcp in README

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,39 +6,5 @@
     "rpfm": {
       "url": "http://127.0.0.1:45127/mcp"
     }
-  },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "clj-paren-repair-claude-hook --cljfmt"
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "clj-paren-repair-claude-hook --cljfmt"
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "clj-paren-repair-claude-hook --cljfmt"
-          }
-        ]
-      }
-    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -62,13 +62,17 @@ Components are shared units of behaviour consumed by one or more bases.
 
 ### Toolbox
 
-[`dev-env/`](dev-env) packages a [Fedora Toolbx](https://containertoolbx.org/) image with the full development toolchain (Emacs, JDK 21, Clojure CLI, clj-kondo, cljfmt, gh, sqlite, Node/npm + Playwright deps, Claude Code, clojure-mcp). From `dev-env/`:
+[`dev-env/`](dev-env) packages a [Fedora Toolbx](https://containertoolbx.org/) image with the full development toolchain (Emacs, JDK 21, Clojure CLI, clj-kondo, cljfmt, gh, sqlite, Node/npm + Playwright deps, Claude Code, [clojure-mcp](https://github.com/bhauman/clojure-mcp)). From `dev-env/`:
 
 ```
 make build && make create && make enter
 ```
 
 First interactive enter installs Claude Code and clojure-mcp into the shared home directory and starts the Emacs daemon. See [`CLAUDE.md`](CLAUDE.md#toolbox-dev-environment) for details.
+
+### Claude Code + clojure-mcp
+
+The Toolbox installs [`clojure-mcp`](https://github.com/bhauman/clojure-mcp) and registers it as an MCP server for Claude Code, so Claude drives the running nREPL through structured tools (`clojure_eval`, `clojure_edit`, `paren_repair`, etc.) rather than shelling out. Edits are delimiter-checked and auto-repaired before evaluation, which is why this repo has no separate paren-repair hook configured in `.claude/settings.json`. The canonical Claude workflow — start nREPL on `:7888`, then `(claude-workspace/go!)` over MCP — is described in [`CLAUDE.md`](CLAUDE.md#commands).
 
 ### REPL
 


### PR DESCRIPTION
## Summary

- Remove the `PreToolUse`/`PostToolUse`/`SessionEnd` hooks from `.claude/settings.json` that shelled out to `clj-paren-repair-claude-hook --cljfmt`. clojure-mcp's edit/eval tools already delimiter-check and auto-repair before running, so the hooks were duplicate work (and required a host-side babashka + bbin install).
- Update README's Development section to link to [clojure-mcp](https://github.com/bhauman/clojure-mcp) where it's already mentioned in the Toolbox bullet, and add a short subsection explaining how Claude Code uses it and why no paren-repair hook is configured.

## Test plan

- [x] `jq . .claude/settings.json` parses cleanly
- [x] README renders correctly on GitHub (link to clojure-mcp resolves)
- [x] Confirm no remaining references to `clj-paren-repair-claude-hook` in checked-in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)