### PR TITLE
Move htmx-driven mutations from /api to /actions

### DIFF
--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -106,6 +106,21 @@
             :com.devereux-henley.rts-web.web.tournament.view/parse-replays-fragment
             :com.devereux-henley.rts-web.web.tournament.view/record-match-fragment))
 
+(def actions-configuration
+  (handlers :com.devereux-henley.rts-web.web.actions.draft/add-unit
+            :com.devereux-henley.rts-web.web.actions.draft/update-entry
+            :com.devereux-henley.rts-web.web.actions.draft/remove-entry
+            :com.devereux-henley.rts-web.web.actions.draft/create-draft
+            :com.devereux-henley.rts-web.web.actions.draft/update-draft
+            :com.devereux-henley.rts-web.web.actions.tournament/create-tournament
+            :com.devereux-henley.rts-web.web.actions.tournament/create-entry
+            :com.devereux-henley.rts-web.web.actions.tournament/delete-entry
+            :com.devereux-henley.rts-web.web.actions.tournament/update-status
+            :com.devereux-henley.rts-web.web.actions.tournament/update-registration
+            :com.devereux-henley.rts-web.web.actions.tournament/create-round
+            :com.devereux-henley.rts-web.web.actions.league/create-league
+            :com.devereux-henley.rts-web.web.actions.season/create-season))
+
 (def league-configuration
   (handlers :com.devereux-henley.rts-web.web.league.api/get-league
             :com.devereux-henley.rts-web.web.league.api/get-leagues
@@ -131,6 +146,7 @@
    rts-web/icon-routes
    rts-web/view-routes
    rts-web/components-routes
+   rts-web/actions-routes
    rts-web/api-routes])
 
 ;;; ─── Assembled system maps ─────────────────────────────────────────────────
@@ -146,7 +162,8 @@
          social-media-configuration
          tournament-configuration
          league-configuration
-         match-record-configuration))
+         match-record-configuration
+         actions-configuration))
 
 (def core-configuration
   "Production profile. Uses Ory for authentication."

--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -8,6 +8,9 @@
    [com.devereux-henley.rts-api.web :as web]
    [com.devereux-henley.rts-data.contract :as rts-data]
    [com.devereux-henley.rts-web.contract :as rts-web]
+   [com.devereux-henley.rts-web.orchestration :as orchestration]
+   [com.devereux-henley.rts-web.web.actions.draft :as web.actions.draft]
+   [com.devereux-henley.rts-web.web.actions.tournament :as web.actions.tournament]
    [integrant.core]))
 
 (def port
@@ -121,6 +124,19 @@
             :com.devereux-henley.rts-web.web.actions.league/create-league
             :com.devereux-henley.rts-web.web.actions.season/create-season))
 
+(def orchestration-configuration
+  "Wires the HX-Trigger registry. Each `::web-triggers` key contributes its
+   `{event-id [event …]}` map; the registry init-key gathers them via
+   `refset` (each contributing key derives from
+   `::orchestration/web-trigger-source` in its own namespace) and compiles
+   them into HTMX trigger strings. The middleware then assocs the
+   assembled registry onto every request that flows through view /
+   components routes."
+  {::web.actions.draft/web-triggers      {}
+   ::web.actions.tournament/web-triggers {}
+   ::orchestration/registry              {:sources (integrant.core/refset ::orchestration/web-trigger-source)}
+   ::orchestration/middleware            {:registry (integrant.core/ref ::orchestration/registry)}})
+
 (def league-configuration
   (handlers :com.devereux-henley.rts-web.web.league.api/get-league
             :com.devereux-henley.rts-web.web.league.api/get-leagues
@@ -163,7 +179,8 @@
          tournament-configuration
          league-configuration
          match-record-configuration
-         actions-configuration))
+         actions-configuration
+         orchestration-configuration))
 
 (def core-configuration
   "Production profile. Uses Ory for authentication."

--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -8,9 +8,6 @@
    [com.devereux-henley.rts-api.web :as web]
    [com.devereux-henley.rts-data.contract :as rts-data]
    [com.devereux-henley.rts-web.contract :as rts-web]
-   [com.devereux-henley.rts-web.orchestration :as orchestration]
-   [com.devereux-henley.rts-web.web.actions.draft :as web.actions.draft]
-   [com.devereux-henley.rts-web.web.actions.tournament :as web.actions.tournament]
    [integrant.core]))
 
 (def port
@@ -128,14 +125,16 @@
   "Wires the HX-Trigger registry. Each `::web-triggers` key contributes its
    `{event-id [event …]}` map; the registry init-key gathers them via
    `refset` (each contributing key derives from
-   `::orchestration/web-trigger-source` in its own namespace) and compiles
-   them into HTMX trigger strings. The middleware then assocs the
-   assembled registry onto every request that flows through view /
-   components routes."
-  {::web.actions.draft/web-triggers      {}
-   ::web.actions.tournament/web-triggers {}
-   ::orchestration/registry              {:sources (integrant.core/refset ::orchestration/web-trigger-source)}
-   ::orchestration/middleware            {:registry (integrant.core/ref ::orchestration/registry)}})
+   `:com.devereux-henley.rts-web.orchestration/web-trigger-source` in its
+   own namespace) and compiles them into HTMX trigger strings. The
+   middleware then assocs the assembled registry onto every request that
+   flows through view / components routes. `rts-web/contract` requires
+   the orchestration namespace, so its defmethods register transitively
+   when this configuration is loaded."
+  {:com.devereux-henley.rts-web.web.actions.draft/web-triggers      {}
+   :com.devereux-henley.rts-web.web.actions.tournament/web-triggers {}
+   :com.devereux-henley.rts-web.orchestration/registry              {:sources (integrant.core/refset :com.devereux-henley.rts-web.orchestration/web-trigger-source)}
+   :com.devereux-henley.rts-web.orchestration/middleware            {:registry (integrant.core/ref :com.devereux-henley.rts-web.orchestration/registry)}})
 
 (def league-configuration
   (handlers :com.devereux-henley.rts-web.web.league.api/get-league

--- a/bases/rts-api/src/com/devereux_henley/rts_api/produces_enforcement.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/produces_enforcement.clj
@@ -1,11 +1,12 @@
 (ns com.devereux-henley.rts-api.produces-enforcement
-  "Reitit middleware that enforces the matched route's `:produces` against
-  the request's Accept header. Reitit's built-in `:produces` declaration
-  is informational only; muuntaja negotiates against globally-registered
-  formats, so without this middleware a route saying `:produces
-  [\"application/json\"]` will still happily serve any other registered
-  format if asked. This middleware closes the gap: a request whose Accept
-  header overlaps none of the produced types is rejected with 406."
+  "Reitit middleware that reconciles the matched route's `:produces`
+  with the request's Accept header. Reitit's built-in `:produces` is
+  documentation-only — muuntaja negotiates against globally-registered
+  formats and can pick a format the route never declared. This middleware
+  closes the gap two ways: it 406s requests whose Accept overlaps nothing
+  the route produces, and it rewrites wildcard-only Accept headers to the
+  route's first produced type so muuntaja picks that type rather than
+  whichever globally-registered format happens to share the wildcard."
   (:require
    [clojure.string :as string]
    [reitit.ring :as ring]))
@@ -16,14 +17,14 @@
   (or (string/blank? accept-header)
       (string/includes? accept-header "*/*")))
 
-(defn- accept-allows?
-  "Does `accept-header` permit at least one of the `produces` media
-   types? Match is substring-based so `application/json;q=0.9` counts as
-   acceptable for `application/json`. Matches are case-insensitive."
+(defn- accept-includes-produced?
+  "True when the Accept header literally names one of the produced
+   media types. Match is substring-based so `application/json;q=0.9`
+   counts as `application/json`. Case-insensitive."
   [accept-header produces]
-  (or (accept-wildcard? accept-header)
-      (let [lc (string/lower-case accept-header)]
-        (some #(string/includes? lc (string/lower-case %)) produces))))
+  (when accept-header
+    (let [lc (string/lower-case accept-header)]
+      (some #(string/includes? lc (string/lower-case %)) produces))))
 
 (defn- route-produces
   "Reads the matched route's `:produces` for the request method. Reitit
@@ -38,18 +39,33 @@
           (:produces data)))))
 
 (defn wrap-enforce-produces
-  "Returns 406 Not Acceptable when the matched route declares `:produces`
-   and the request's Accept header does not include at least one of those
-   media types. No-op when the matched route has no `:produces` (route
-   accepts whatever muuntaja can negotiate globally)."
+  "Three cases when the matched route declares `:produces`:
+
+   1. Accept literally names one of the produced types → pass through.
+      Muuntaja will negotiate to that type.
+   2. Accept is wildcard (missing, blank, or contains `*/*`) but does
+      not literally name a produced type → rewrite `:headers \"accept\"`
+      to the first produced type so muuntaja picks the route's own
+      type rather than another globally-registered type that happens
+      to be listed in the Accept alongside the wildcard.
+   3. Neither — 406 Not Acceptable.
+
+   No-op when the route has no `:produces` declaration."
   [handler]
   (fn [request]
     (let [produces (route-produces request)
           accept   (get-in request [:headers "accept"])]
-      (if (or (nil? produces)
-              (empty? produces)
-              (accept-allows? accept produces))
+      (cond
+        (or (nil? produces) (empty? produces))
         (handler request)
+
+        (accept-includes-produced? accept produces)
+        (handler request)
+
+        (accept-wildcard? accept)
+        (handler (assoc-in request [:headers "accept"] (first produces)))
+
+        :else
         {:status  406
          :headers {"Content-Type" "text/plain; charset=utf-8"}
          :body    "Not Acceptable"}))))

--- a/bases/rts-api/test/com/devereux_henley/rts_api/produces_enforcement_test.clj
+++ b/bases/rts-api/test/com/devereux_henley/rts_api/produces_enforcement_test.clj
@@ -19,6 +19,18 @@
            :reitit.core/match {:data {:get {:produces produces}}}}
     accept (assoc :headers {"accept" accept})))
 
+(defn- accept-after
+  "Returns the Accept header the handler observed — used to confirm the
+   middleware rewrote Accept to the route's first produced type."
+  [request]
+  (get-in request [:headers "accept"]))
+
+(def ^:private capture-handler
+  "Echoes the Accept header back so wildcard-rewrite tests can assert on it."
+  (produces-enforcement/wrap-enforce-produces
+   (fn [request]
+     {:status 200 :body (accept-after request)})))
+
 (deftest accept-includes-a-produced-type
   (testing "Accept header listing exactly the produced type → handler runs"
     (is (= :handler-ran (:body (wrapped (request-with ["application/json"] "application/json"))))))
@@ -34,13 +46,21 @@
   (testing "Accept asks for text/html but route produces htmx+html only → 406"
     (is (= 406 (:status (wrapped (request-with ["application/htmx+html"] "text/html")))))))
 
-(deftest accept-wildcards-pass
-  (testing "Accept: */* → handler runs"
-    (is (= :handler-ran (:body (wrapped (request-with ["application/htmx+html"] "*/*"))))))
-  (testing "missing Accept header → handler runs"
-    (is (= :handler-ran (:body (wrapped (request-with ["application/json"] nil))))))
-  (testing "blank Accept header → handler runs"
-    (is (= :handler-ran (:body (wrapped (request-with ["application/json"] "")))))))
+(deftest accept-wildcards-rewritten-to-first-produced
+  (testing "Accept: */* → handler runs; Accept rewritten to route's first produced type"
+    (is (= "application/htmx+html"
+           (:body (capture-handler (request-with ["application/htmx+html"] "*/*"))))))
+  (testing "missing Accept header → handler runs; Accept rewritten"
+    (is (= "application/json"
+           (:body (capture-handler (request-with ["application/json"] nil))))))
+  (testing "blank Accept header → handler runs; Accept rewritten"
+    (is (= "application/json"
+           (:body (capture-handler (request-with ["application/json"] ""))))))
+  (testing "browser Accept (text/html, */* fallback, no produced type listed) → rewritten to produces[0]"
+    (is (= "application/htmx+html"
+           (:body (capture-handler
+                   (request-with ["application/htmx+html"]
+                                 "text/html,application/xhtml+xml,*/*;q=0.8")))))))
 
 (deftest no-produces-on-route-passes
   (testing "matched route without :produces → handler runs regardless of Accept"

--- a/components/e2e/tests/draft-mount.spec.js
+++ b/components/e2e/tests/draft-mount.spec.js
@@ -144,9 +144,10 @@ test.describe.serial('Mount-selection overrides', () => {
     const entryPatch = await page.locator('#draft-unit-form').getAttribute('hx-patch');
     expect(entryPatch).toBeTruthy();
 
-    // Build the GET equivalent from the same path (the form PATCHes to persist;
-    // the GET version accepts ?mount= as an override for preview renders).
-    const baseEntryUrl = new URL(entryPatch, page.url());
+    // The form's hx-patch points at /actions/ (mutation surface); the GET
+    // counterpart that returns the entry resource still lives on /api/.
+    // Build the GET URL from the same path with the prefix swapped.
+    const baseEntryUrl = new URL(entryPatch.replace('/actions/', '/api/'), page.url());
     baseEntryUrl.searchParams.set('embed', 'unit');
     const previewUrl = new URL(baseEntryUrl);
     previewUrl.searchParams.set('mount', mountKey);

--- a/components/rts-web/resources/rts-web/view/create-draft.html
+++ b/components/rts-web/resources/rts-web/view/create-draft.html
@@ -8,10 +8,9 @@
     <form id="create-draft-form"
           class="form"
           aria-labelledby="create-draft-heading"
-          hx-put="/api/draft/{{draft-eid}}?version=1"
+          hx-put="/actions/draft/{{draft-eid}}?version=1"
           hx-ext="json-enc"
-          hx-target="#content"
-          hx-swap="innerHTML">
+          hx-swap="none">
         <input type="hidden" name="game-eid" value="{{game-eid}}"/>
         <div class="form-group">
             <label class="form-label required" for="faction-eid">Faction</label>

--- a/components/rts-web/resources/rts-web/view/create-league.html
+++ b/components/rts-web/resources/rts-web/view/create-league.html
@@ -10,10 +10,9 @@
         <form id="create-league-form"
               class="form league-form"
               aria-labelledby="create-league-heading"
-              hx-put="/api/league/{{league-eid}}?version=1"
+              hx-put="/actions/league/{{league-eid}}?version=1"
               hx-ext="json-enc"
-              hx-target="#content"
-              hx-swap="innerHTML">
+              hx-swap="none">
             <input type="hidden" name="game-eid" value="{{game-eid}}"/>
 
             <fieldset class="league-fieldset">

--- a/components/rts-web/resources/rts-web/view/create-season.html
+++ b/components/rts-web/resources/rts-web/view/create-season.html
@@ -10,10 +10,9 @@
         <form id="create-season-form"
               class="form season-form"
               aria-labelledby="create-season-heading"
-              hx-put="/api/season/{{league-eid}}/{{season-eid}}"
+              hx-put="/actions/season/{{league-eid}}/{{season-eid}}"
               hx-ext="json-enc"
-              hx-target="#content"
-              hx-swap="innerHTML">
+              hx-swap="none">
 
             <fieldset class="season-fieldset">
                 <legend class="season-fieldset-legend">Season Details</legend>

--- a/components/rts-web/resources/rts-web/view/create-tournament.html
+++ b/components/rts-web/resources/rts-web/view/create-tournament.html
@@ -10,10 +10,9 @@
         <form id="create-tournament-form"
               class="form tournament-form"
               aria-labelledby="create-tournament-heading"
-              hx-put="/api/tournament/{{tournament-eid}}?version=1"
+              hx-put="/actions/tournament/{{tournament-eid}}?version=1"
               hx-ext="json-enc"
-              hx-target="#content"
-              hx-swap="innerHTML">
+              hx-swap="none">
             <input type="hidden" name="game-eid" value="{{game-eid}}"/>
 
             <!-- ─── Basic Info ─────────────────────────────────────── -->

--- a/components/rts-web/resources/rts-web/view/draft-index.html
+++ b/components/rts-web/resources/rts-web/view/draft-index.html
@@ -5,7 +5,8 @@
 {% block content %}
 <title id="page-title" hx-swap-oob="true">{{data.display-name}} | {{game.name}} | RTS-UI</title>
 
-<div class="draft-page{% if locked? %} draft-page--locked{% endif %}">
+<div id="draft-stage"
+     class="draft-page{% if locked? %} draft-page--locked{% endif %}">
 
     {% if locked? %}
     <aside class="draft-locked-banner" role="status">
@@ -32,7 +33,7 @@
                    autocomplete="off"
                    spellcheck="false"
                    aria-describedby="draft-nameplate-hint"
-                   {% if locked? %}readonly aria-readonly="true"{% else %}hx-patch="/api/draft/{{data.eid}}"
+                   {% if locked? %}readonly aria-readonly="true"{% else %}hx-patch="/actions/draft/{{data.eid}}"
                    hx-ext="json-enc"
                    hx-trigger="input changed delay:500ms, blur changed"
                    hx-swap="none"

--- a/components/rts-web/resources/rts-web/view/draft-slot-inner.html
+++ b/components/rts-web/resources/rts-web/view/draft-slot-inner.html
@@ -43,7 +43,7 @@
 {% endif %}
 <button class="draft-slot-remove"
         aria-labelledby="draft-slot-remove-label-{{unit.entry-eid}}"
-        hx-delete="/api/draft/{{section.draft-eid}}/entry/{{unit.entry-eid}}?section={{section.section}}"
+        hx-delete="/actions/draft/{{section.draft-eid}}/entry/{{unit.entry-eid}}?section={{section.section}}"
         hx-swap="none">
     <span class="sr-only" id="draft-slot-remove-label-{{unit.entry-eid}}">Remove {{unit.name}} from {{section.section-label}}</span>
     &#10005;

--- a/components/rts-web/resources/rts-web/view/draft-unit-panel.html
+++ b/components/rts-web/resources/rts-web/view/draft-unit-panel.html
@@ -8,7 +8,7 @@
              panel shows mark/lore/mount/abilities/spells as chosen, but
              no hx-* triggers fire and every input is `disabled` below. #}
           {% else %}{% if data.section %}
-          hx-patch="/api/draft/{{data.draft-eid}}/entry/{{data.eid}}?section={{data.section}}"
+          hx-patch="/actions/draft/{{data.draft-eid}}/entry/{{data.eid}}?section={{data.section}}"
           hx-ext="json-enc"
           {% else %}
           hx-get="/components/draft/{{unit.draft-eid}}/unit/{{unit.eid}}/unit-panel.html"
@@ -63,7 +63,7 @@
             {% else %}{% if not data.locked? %}
             <button class="btn btn-primary draft-add-btn"
                     type="button"
-                    hx-post="/api/draft/{{unit.draft-eid}}/unit/{{unit.eid}}?section=main"
+                    hx-post="/actions/draft/{{unit.draft-eid}}/unit/{{unit.eid}}?section=main"
                     hx-include="#draft-unit-form"
                     hx-ext="json-enc"
                     hx-swap="none">
@@ -74,7 +74,7 @@
             {% ifunequal unit.unit-category-name "Lord" %}
             <button class="btn btn-primary draft-add-btn draft-add-btn--reinf"
                     type="button"
-                    hx-post="/api/draft/{{unit.draft-eid}}/unit/{{unit.eid}}?section=reinforcements"
+                    hx-post="/actions/draft/{{unit.draft-eid}}/unit/{{unit.eid}}?section=reinforcements"
                     hx-include="#draft-unit-form"
                     hx-ext="json-enc"
                     hx-swap="none">
@@ -420,7 +420,7 @@
        query param. #}
     {% if data.section %}
     <form id="draft-mark-form"
-          hx-patch="/api/draft/{{data.draft-eid}}/entry/{{data.eid}}?section={{data.section}}"
+          hx-patch="/actions/draft/{{data.draft-eid}}/entry/{{data.eid}}?section={{data.section}}"
           hx-ext="json-enc"
           hx-trigger="patchFamily"
           hx-target="#draft-unit-body"
@@ -428,7 +428,7 @@
           hx-swap="outerHTML"
           hx-headers='{"Accept": "application/htmx+html"}'></form>
     <form id="draft-lore-form"
-          hx-patch="/api/draft/{{data.draft-eid}}/entry/{{data.eid}}?section={{data.section}}"
+          hx-patch="/actions/draft/{{data.draft-eid}}/entry/{{data.eid}}?section={{data.section}}"
           hx-ext="json-enc"
           hx-trigger="patchFamily"
           hx-target="#draft-unit-body"

--- a/components/rts-web/resources/rts-web/view/tournament-index.html
+++ b/components/rts-web/resources/rts-web/view/tournament-index.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="tourney-page">
+<div id="tournament-stage" class="tourney-page">
 
     <!-- ═══════════════════════════════════════════════════════════════ -->
     <!-- Hero                                                           -->
@@ -77,11 +77,11 @@
                 <div class="tourney-info-card-body">
                     {% if has-entry %}
                     <p style="margin-bottom: var(--space-3);">You are registered.</p>
-                    <form hx-delete="/api/tournament/{{data.eid}}/entry/me" hx-swap="none">
+                    <form hx-delete="/actions/tournament/{{data.eid}}/entry/me" hx-swap="none">
                         <button type="submit" class="btn btn-danger btn-sm" style="width:100%;">Withdraw</button>
                     </form>
                     {% elif registration-open %}
-                    <form hx-post="/api/tournament/{{data.eid}}/entry/me" hx-swap="none">
+                    <form hx-post="/actions/tournament/{{data.eid}}/entry/me" hx-swap="none">
                         <button type="submit" class="btn btn-primary" style="width:100%;">Enter Tournament</button>
                     </form>
                     {% else %}
@@ -117,38 +117,38 @@
                 <div class="tourney-info-card-header">Organizer Controls</div>
                 <div class="tourney-info-card-body stack stack-2">
                     {% ifequal tournament-state.status "registration" %}
-                    <form hx-patch="/api/tournament/{{data.eid}}/registration"
-                          hx-ext="json-enc" hx-target="#content" hx-swap="innerHTML">
+                    <form hx-patch="/actions/tournament/{{data.eid}}/registration"
+                          hx-ext="json-enc" hx-swap="none">
                         <input type="hidden" name="closed-early" value="true"/>
                         <button type="submit" class="btn btn-secondary btn-sm" style="width:100%;">Close Registration</button>
                     </form>
-                    <form hx-put="/api/tournament/{{data.eid}}/status"
-                          hx-ext="json-enc" hx-target="#content" hx-swap="innerHTML">
+                    <form hx-put="/actions/tournament/{{data.eid}}/status"
+                          hx-ext="json-enc" hx-swap="none">
                         <input type="hidden" name="status" value="active"/>
                         <button type="submit" class="btn btn-primary btn-sm" style="width:100%;">Start Tournament</button>
                     </form>
                     {% endifequal %}
                     {% ifequal tournament-state.status "active" %}
-                    <form hx-post="/api/tournament/{{data.eid}}/round"
-                          hx-target="#content" hx-swap="innerHTML">
+                    <form hx-post="/actions/tournament/{{data.eid}}/round"
+                          hx-swap="none">
                         <button type="submit" class="btn btn-primary btn-sm" style="width:100%;">Generate Next Round</button>
                     </form>
-                    <form hx-put="/api/tournament/{{data.eid}}/status"
-                          hx-ext="json-enc" hx-target="#content" hx-swap="innerHTML">
+                    <form hx-put="/actions/tournament/{{data.eid}}/status"
+                          hx-ext="json-enc" hx-swap="none">
                         <input type="hidden" name="status" value="complete"/>
                         <button type="submit" class="btn btn-secondary btn-sm" style="width:100%;">Complete Tournament</button>
                     </form>
                     {% endifequal %}
                     {% ifequal tournament-state.status "registration" %}
-                    <form hx-put="/api/tournament/{{data.eid}}/status"
-                          hx-ext="json-enc" hx-target="#content" hx-swap="innerHTML">
+                    <form hx-put="/actions/tournament/{{data.eid}}/status"
+                          hx-ext="json-enc" hx-swap="none">
                         <input type="hidden" name="status" value="cancelled"/>
                         <button type="submit" class="btn btn-danger btn-sm" style="width:100%;">Cancel Tournament</button>
                     </form>
                     {% endifequal %}
                     {% ifequal tournament-state.status "active" %}
-                    <form hx-put="/api/tournament/{{data.eid}}/status"
-                          hx-ext="json-enc" hx-target="#content" hx-swap="innerHTML">
+                    <form hx-put="/actions/tournament/{{data.eid}}/status"
+                          hx-ext="json-enc" hx-swap="none">
                         <input type="hidden" name="status" value="cancelled"/>
                         <button type="submit" class="btn btn-danger btn-sm" style="width:100%;">Cancel Tournament</button>
                     </form>

--- a/components/rts-web/src/com/devereux_henley/rts_web/contract.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/contract.clj
@@ -1,5 +1,6 @@
 (ns com.devereux-henley.rts-web.contract
   (:require
+   [com.devereux-henley.rts-web.orchestration]
    [com.devereux-henley.rts-web.render :as render]
    [com.devereux-henley.rts-web.web.actions.draft]
    [com.devereux-henley.rts-web.web.actions.league]

--- a/components/rts-web/src/com/devereux_henley/rts_web/contract.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/contract.clj
@@ -1,6 +1,10 @@
 (ns com.devereux-henley.rts-web.contract
   (:require
    [com.devereux-henley.rts-web.render :as render]
+   [com.devereux-henley.rts-web.web.actions.draft]
+   [com.devereux-henley.rts-web.web.actions.league]
+   [com.devereux-henley.rts-web.web.actions.season]
+   [com.devereux-henley.rts-web.web.actions.tournament]
    [com.devereux-henley.rts-web.web.draft.api]
    [com.devereux-henley.rts-web.web.draft.view]
    [com.devereux-henley.rts-web.web.game.api]
@@ -22,6 +26,7 @@
 (def icon-routes web.routes/icon-routes)
 (def view-routes web.routes/view-routes)
 (def components-routes web.routes/components-routes)
+(def actions-routes web.routes/actions-routes)
 (def api-routes web.routes/api-routes)
 
 (def render-view render/render)

--- a/components/rts-web/src/com/devereux_henley/rts_web/orchestration.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/orchestration.clj
@@ -1,45 +1,59 @@
 (ns com.devereux-henley.rts-web.orchestration
-  "Backend registry mapping /components fragment ids to the HX-Trigger
-  event names they should listen for. /actions mutations emit one of
-  these events on success; the named fragments subscribe to the events
-  via `hx-trigger=\"{{ listeners.<fragment-id> }} from:body\"` and refetch
-  themselves to reflect the new state.
+  "Assembles a backend registry that maps event ids to the HX-Trigger
+  event names they should listen for. Each namespace that owns mutating
+  endpoints contributes its own slice of the registry by deriving an
+  integrant key from `::web-trigger-source`; this namespace gathers
+  them via `integrant.core/refset` and exposes the merged result.
+
+  Wiring overview:
+
+    contributing ns    integrant
+    ──────────────     ─────────
+    ::web-triggers ─┐ derive
+    {:foo [...]}    │ ::web-trigger-source
+                    │ refset
+    contributing ns │
+    ──────────────  │
+    ::web-triggers ─┴──► ::registry ──► ::middleware ──► request
+    {:bar [...]}                                          :web-triggers
+
+  Templates read the result via the `:triggers` key in the Selmer
+  context (set by `web.view/base-context`) as
+  `hx-trigger=\"{{ triggers.<event-id> }}\"`. The `from:body` clause
+  is baked into the assembled string.
 
   Adding a new mutation:
     1. Pick a kebab-case `<resource>-<crud-verb>` past-tense event name.
     2. Decide which fragments display state that the mutation affects.
-    3. Add (or extend) entries here so each listening fragment names the
-       new event in its space-joined value.
+    3. In the owning namespace, declare (or extend) a
+       `::web-triggers` init-key returning `{event-id [event…]}`
+       and derive it from `::web-trigger-source`.
     4. Wire the event into the mutation handler via HX-Trigger.
-    5. Make sure each listening fragment's template uses
-       `hx-trigger=\"{{ listeners.<fragment-id> }} from:body\"`."
+    5. Each listening fragment's template uses
+       `hx-trigger=\"{{ triggers.<event-id> }}\"`."
   (:require
-   [clojure.string :as string]))
+   [clojure.string :as string]
+   [integrant.core]))
 
-(def ^:private fragment-events
-  "fragment-id (keyword) → vector of HX-Trigger event names the fragment
-   wants to listen for."
-  {:unit-panel       ["draft-entry-created" "draft-entry-updated" "draft-entry-deleted"]
-   :draft-stage      ["draft-entry-created" "draft-entry-updated" "draft-entry-deleted" "draft-updated"]
-   :tournament-stage ["tournament-status-updated" "tournament-entry-created"
-                      "tournament-entry-deleted" "tournament-registration-updated"
-                      "tournament-round-created"]})
-
-(def fragment-listeners
-  "fragment-id (keyword) → HTMX-ready hx-trigger value.
-
-   Each event is a comma-separated trigger spec with `from:body` so the
-   fragment can listen to events fired anywhere in the document body —
-   HX-Trigger headers fire events on the body element."
+(defn- compile-triggers
+  "Turn `{event-id [event…]}` into `{event-id \"event from:body, …\"}` —
+   the comma-joined trigger spec HTMX templates can drop straight into
+   `hx-trigger`. `from:body` is appended to every event because HX-Trigger
+   headers fire events on the document body."
+  [web-events]
   (into {}
-        (map (fn [[k events]]
-               [k (->> events
-                       (map #(str % " from:body"))
-                       (string/join ", "))]))
-        fragment-events))
+        (map (fn [[event-id events]]
+               [event-id (->> events
+                              (map #(str % " from:body"))
+                              (string/join ", "))]))
+        web-events))
 
-(defn assoc-listeners
-  "Adds the registry under `:listeners` on the given Selmer context so
-   templates can resolve event names via `{{ listeners.<fragment-id> }}`."
-  [context]
-  (assoc context :listeners fragment-listeners))
+(defmethod integrant.core/init-key ::registry
+  [_init-key {:keys [sources]}]
+  (compile-triggers (reduce merge {} sources)))
+
+(defmethod integrant.core/init-key ::middleware
+  [_init-key {:keys [registry]}]
+  (fn [handler]
+    (fn [request]
+      (handler (assoc request :web-triggers registry)))))

--- a/components/rts-web/src/com/devereux_henley/rts_web/orchestration.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/orchestration.clj
@@ -1,0 +1,45 @@
+(ns com.devereux-henley.rts-web.orchestration
+  "Backend registry mapping /components fragment ids to the HX-Trigger
+  event names they should listen for. /actions mutations emit one of
+  these events on success; the named fragments subscribe to the events
+  via `hx-trigger=\"{{ listeners.<fragment-id> }} from:body\"` and refetch
+  themselves to reflect the new state.
+
+  Adding a new mutation:
+    1. Pick a kebab-case `<resource>-<crud-verb>` past-tense event name.
+    2. Decide which fragments display state that the mutation affects.
+    3. Add (or extend) entries here so each listening fragment names the
+       new event in its space-joined value.
+    4. Wire the event into the mutation handler via HX-Trigger.
+    5. Make sure each listening fragment's template uses
+       `hx-trigger=\"{{ listeners.<fragment-id> }} from:body\"`."
+  (:require
+   [clojure.string :as string]))
+
+(def ^:private fragment-events
+  "fragment-id (keyword) → vector of HX-Trigger event names the fragment
+   wants to listen for."
+  {:unit-panel       ["draft-entry-created" "draft-entry-updated" "draft-entry-deleted"]
+   :draft-stage      ["draft-entry-created" "draft-entry-updated" "draft-entry-deleted" "draft-updated"]
+   :tournament-stage ["tournament-status-updated" "tournament-entry-created"
+                      "tournament-entry-deleted" "tournament-registration-updated"
+                      "tournament-round-created"]})
+
+(def fragment-listeners
+  "fragment-id (keyword) → HTMX-ready hx-trigger value.
+
+   Each event is a comma-separated trigger spec with `from:body` so the
+   fragment can listen to events fired anywhere in the document body —
+   HX-Trigger headers fire events on the body element."
+  (into {}
+        (map (fn [[k events]]
+               [k (->> events
+                       (map #(str % " from:body"))
+                       (string/join ", "))]))
+        fragment-events))
+
+(defn assoc-listeners
+  "Adds the registry under `:listeners` on the given Selmer context so
+   templates can resolve event names via `{{ listeners.<fragment-id> }}`."
+  [context]
+  (assoc context :listeners fragment-listeners))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/actions/common.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/actions/common.clj
@@ -1,0 +1,55 @@
+(ns com.devereux-henley.rts-web.web.actions.common
+  "Shared response builders for /actions handlers.
+
+  Every /actions endpoint follows one of three shapes:
+    1. Mutation success → status + body (htmx+html via view-by-type;
+       templates may include OOB swaps that update sidebar/budget
+       in-place) plus an HX-Trigger header naming the kebab-case event.
+       The Trigger header is the channel future listener-bound
+       /components fragments will react to.
+    2. Mutation creates a resource users navigate to → 200 + HX-Redirect.
+       HTMX issues a client-side navigation. A 3xx response would make
+       the fetch auto-follow before HTMX could see the header.
+    3. Mutation failed → HTML error fragment (role=alert) with the
+       relevant 4xx status."
+  (:require
+   [clojure.string :as string]))
+
+(defn trigger-response
+  "Mutation success with a 200 status. `body` will be encoded as
+   htmx+html by muuntaja via the view-by-type dispatch."
+  [event-name body]
+  {:status  200
+   :headers {"HX-Trigger" event-name}
+   :body    body})
+
+(defn trigger-status-response
+  "Same as `trigger-response` but with an explicit status code, for
+   creation flows that return 201."
+  [status event-name body]
+  {:status  status
+   :headers {"HX-Trigger" event-name}
+   :body    body})
+
+(defn redirect-response
+  "Created-and-go-somewhere. Returns 200 with HX-Redirect so HTMX
+   navigates client-side. A 3xx status would make the browser auto-
+   follow the redirect inside the fetch — HTMX would never see the
+   header, and `window.location` would not change."
+  [location]
+  {:status  200
+   :headers {"HX-Redirect" location}})
+
+(defn error-fragment
+  "Failure: 4xx with an HTML alert fragment. Templates' hx-target swaps
+   this where appropriate; without an explicit hx-target HTMX puts it
+   in the form itself, which is acceptable for inline form errors."
+  [status message]
+  {:status  status
+   :headers {"Content-Type" "application/htmx+html; charset=utf-8"}
+   :body    (str "<section class=\"resource\" role=\"alert\">"
+                 "<p>" (some-> message
+                               (string/replace "&" "&amp;")
+                               (string/replace "<" "&lt;")
+                               (string/replace ">" "&gt;")) "</p>"
+                 "</section>")})

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/actions/draft.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/actions/draft.clj
@@ -6,8 +6,17 @@
   so future listener-bound /components fragments can react granularly."
   (:require
    [com.devereux-henley.rts-domain.contract :as domain]
+   [com.devereux-henley.rts-web.orchestration :as orchestration]
    [com.devereux-henley.rts-web.web.actions.common :as common]
    [integrant.core]))
+
+(derive ::web-triggers ::orchestration/web-trigger-source)
+
+(defmethod integrant.core/init-key ::web-triggers
+  [_init-key _config]
+  {:unit-panel  ["draft-entry-created" "draft-entry-updated" "draft-entry-deleted"]
+   :draft-stage ["draft-entry-created" "draft-entry-updated" "draft-entry-deleted"
+                 "draft-updated"]})
 
 (defmethod integrant.core/init-key ::add-unit
   [_init-key dependencies]

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/actions/draft.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/actions/draft.clj
@@ -1,0 +1,86 @@
+(ns com.devereux-henley.rts-web.web.actions.draft
+  "/actions handlers for draft mutations. Each delegates the domain
+  work to rts-domain, returns the same typed-map response body the /api
+  variants returned (so view-by-type rendering and the existing OOB
+  swap templates keep working in-place), and adds an HX-Trigger header
+  so future listener-bound /components fragments can react granularly."
+  (:require
+   [com.devereux-henley.rts-domain.contract :as domain]
+   [com.devereux-henley.rts-web.web.actions.common :as common]
+   [integrant.core]))
+
+(defmethod integrant.core/init-key ::add-unit
+  [_init-key dependencies]
+  (fn [{{{:keys [draft-eid eid]} :path
+         {:keys [section]}       :query
+         body                    :body} :parameters
+        :as                             _request}]
+    (let [selections (select-keys (or body {}) [:mount :level :abilities :spells :items])
+          result     (domain/add-unit-to-draft dependencies draft-eid eid section selections)]
+      (case (:type result)
+        :draft/add-success (common/trigger-response "draft-entry-created" result)
+        :draft/locked      {:status 409 :body result}
+        {:status 422 :body result}))))
+
+(defmethod integrant.core/init-key ::update-entry
+  [_init-key dependencies]
+  (fn [{{{:keys [draft-eid eid]} :path
+         {:keys [section]}       :query
+         body                    :body} :parameters
+        :as                             _request}]
+    (let [selections (select-keys (or body {}) [:unit-eid :mount :level :abilities :spells :items])
+          result     (domain/update-unit-in-draft dependencies draft-eid eid section selections)]
+      (case (:type result)
+        :draft/update-success
+        ;; Reuse the same shape the /api endpoint returned: include the
+        ;; freshly-persisted entry + embedded unit so the OOB swaps in
+        ;; draft-update-success.html refresh sidebar slot + budget.
+        (let [entry (some->> (domain/get-draft-entry-details dependencies draft-eid eid section)
+                             (domain/embed-unit-for-entry dependencies))]
+          (common/trigger-response "draft-entry-updated" (assoc result :entry entry)))
+
+        :draft/locked {:status 409 :body result}
+        {:status 422 :body result}))))
+
+(defmethod integrant.core/init-key ::remove-entry
+  [_init-key dependencies]
+  (fn [{{{:keys [draft-eid eid]} :path
+         {:keys [section]}       :query} :parameters
+        :as                              _request}]
+    (let [result (domain/remove-unit-from-draft dependencies draft-eid eid section)]
+      (case (:type result)
+        :draft/remove-success (common/trigger-response "draft-entry-deleted" result)
+        :draft/locked         {:status 409 :body result}
+        {:status 422 :body result}))))
+
+(defmethod integrant.core/init-key ::create-draft
+  [_init-key dependencies]
+  (fn [{{{:keys [faction-eid game-mode-eid game-eid name]} :body
+         {:keys [version]}                                 :query
+         {:keys [eid]}                                     :path} :parameters
+        session                                                   :ory-session
+        :as                                                       _request}]
+    (let [result (domain/create-draft
+                  dependencies
+                  {:faction-eid    faction-eid
+                   :game-mode-eid  game-mode-eid
+                   :name           name
+                   :player-sub     (get-in session [:identity :id])
+                   :created-by-sub (get-in session [:identity :id])
+                   :eid            eid
+                   :version        version})]
+      (if (= :game/draft (:type result))
+        (common/redirect-response
+         (str "/view/game/" game-eid "/draft/" eid "/index.html"))
+        (common/error-fragment 422 (:message result))))))
+
+(defmethod integrant.core/init-key ::update-draft
+  [_init-key dependencies]
+  (fn [{{{:keys [eid]} :path
+         body          :body} :parameters
+        :as                   _request}]
+    (let [result (domain/update-draft dependencies eid (select-keys (or body {}) [:name]))]
+      (case (:type result)
+        :game/draft   (common/trigger-response "draft-updated" result)
+        :draft/locked {:status 409 :body result}
+        {:status 500 :body result}))))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/actions/league.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/actions/league.clj
@@ -1,0 +1,27 @@
+(ns com.devereux-henley.rts-web.web.actions.league
+  "/actions handler for league creation. PUT redirects via 303 to the
+   new league page; failures return an inline error fragment."
+  (:require
+   [com.devereux-henley.rts-domain.contract :as domain]
+   [com.devereux-henley.rts-web.web.actions.common :as common]
+   [integrant.core]))
+
+(defmethod integrant.core/init-key ::create-league
+  [_init-key dependencies]
+  (fn [{{{:keys [name description game-eid]} :body
+         {:keys [version]}                   :query
+         {:keys [eid]}                       :path} :parameters
+        session                                     :ory-session
+        :as                                         _request}]
+    (let [result (domain/create-league
+                  dependencies
+                  {:eid            eid
+                   :game-eid       game-eid
+                   :name           name
+                   :description    description
+                   :created-by-sub (get-in session [:identity :id])
+                   :version        (or version 1)})]
+      (if (= :game/league (:type result))
+        (common/redirect-response
+         (str "/view/game/" game-eid "/league/" eid "/index.html"))
+        (common/error-fragment 422 (:message result))))))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/actions/season.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/actions/season.clj
@@ -1,0 +1,32 @@
+(ns com.devereux-henley.rts-web.web.actions.season
+  "/actions handler for season creation. Looks up the parent league to
+   derive the game-eid for the redirect URL (the create-season form
+   doesn't carry game-eid)."
+  (:require
+   [com.devereux-henley.rts-domain.contract :as domain]
+   [com.devereux-henley.rts-web.web.actions.common :as common]
+   [integrant.core]))
+
+(defmethod integrant.core/init-key ::create-season
+  [_init-key dependencies]
+  (fn [{{{:keys [name timezone start-at end-at]} :body
+         {:keys [eid league-eid]}                :path} :parameters
+        session                                         :ory-session
+        :as                                             _request}]
+    (let [user-sub (get-in session [:identity :id])
+          result   (domain/create-season
+                    dependencies
+                    {:eid        eid
+                     :league-eid league-eid
+                     :name       name
+                     :timezone   timezone
+                     :start-at   start-at
+                     :end-at     end-at}
+                    user-sub)]
+      (if (= :season/error (:type result))
+        (common/error-fragment 422 (:message result))
+        (let [league   (domain/get-league-by-eid dependencies league-eid)
+              game-eid (:game-eid league)]
+          (common/redirect-response
+           (str "/view/game/" game-eid
+                "/league/" league-eid "/season/" eid "/index.html")))))))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/actions/tournament.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/actions/tournament.clj
@@ -5,8 +5,19 @@
   refresh."
   (:require
    [com.devereux-henley.rts-domain.contract :as domain]
+   [com.devereux-henley.rts-web.orchestration :as orchestration]
    [com.devereux-henley.rts-web.web.actions.common :as common]
    [integrant.core]))
+
+(derive ::web-triggers ::orchestration/web-trigger-source)
+
+(defmethod integrant.core/init-key ::web-triggers
+  [_init-key _config]
+  {:tournament-stage ["tournament-status-updated"
+                      "tournament-entry-created"
+                      "tournament-entry-deleted"
+                      "tournament-registration-updated"
+                      "tournament-round-created"]})
 
 (defmethod integrant.core/init-key ::create-tournament
   [_init-key dependencies]

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/actions/tournament.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/actions/tournament.clj
@@ -1,0 +1,94 @@
+(ns com.devereux-henley.rts-web.web.actions.tournament
+  "/actions handlers for tournament mutations. Body shape mirrors the
+  /api variants so existing view-by-type templates and OOB swaps keep
+  working; HX-Trigger header is added for future listener-bound
+  refresh."
+  (:require
+   [com.devereux-henley.rts-domain.contract :as domain]
+   [com.devereux-henley.rts-web.web.actions.common :as common]
+   [integrant.core]))
+
+(defmethod integrant.core/init-key ::create-tournament
+  [_init-key dependencies]
+  (fn [{{{:keys [name description game-eid league-eid season-eid timezone
+                 registration-opens-at registration-closes-at]}           :body
+         {:keys [version]}                                                :query
+         {:keys [eid]}                                                    :path} :parameters
+        session                                                                  :ory-session
+        :as                                                                      _request}]
+    (let [result (domain/create-tournament
+                  dependencies
+                  (cond-> {:eid                    eid
+                           :game-eid               game-eid
+                           :name                   name
+                           :description            description
+                           :timezone               timezone
+                           :registration-opens-at  registration-opens-at
+                           :registration-closes-at registration-closes-at
+                           :created-by-sub         (get-in session [:identity :id])
+                           :version                version}
+                    league-eid (assoc :league-eid league-eid)
+                    season-eid (assoc :season-eid season-eid)))]
+      (if (= :tournament/create-error (:type result))
+        (common/error-fragment 422 (:message result))
+        (common/redirect-response
+         (str "/view/game/" game-eid "/tournament/" eid "/index.html"))))))
+
+(defmethod integrant.core/init-key ::create-entry
+  [_init-key dependencies]
+  (fn [{{{:keys [eid]} :path} :parameters
+        session               :ory-session
+        :as                   _request}]
+    (let [player-sub (get-in session [:identity :id])
+          result     (domain/create-entry dependencies eid player-sub)]
+      (if (= :tournament/entry-error (:type result))
+        {:status 422 :body result}
+        (common/trigger-status-response 201 "tournament-entry-created" result)))))
+
+(defmethod integrant.core/init-key ::delete-entry
+  [_init-key dependencies]
+  (fn [{{{:keys [eid]} :path} :parameters
+        session               :ory-session
+        :as                   _request}]
+    (let [player-sub (get-in session [:identity :id])
+          result     (domain/delete-entry dependencies eid player-sub)]
+      (if (= :tournament/entry-error (:type result))
+        {:status 422 :body result}
+        (common/trigger-response "tournament-entry-deleted" result)))))
+
+(defmethod integrant.core/init-key ::update-status
+  [_init-key dependencies]
+  (fn [{{{:keys [eid]}    :path
+         {:keys [status]} :body} :parameters
+        session                  :ory-session
+        :as                      _request}]
+    (let [user-sub (get-in session [:identity :id])
+          result   (domain/advance-tournament dependencies eid status user-sub)]
+      (if (= :tournament/advance-success (:type result))
+        (common/trigger-response "tournament-status-updated" result)
+        {:status 422 :body result}))))
+
+(defmethod integrant.core/init-key ::update-registration
+  [_init-key dependencies]
+  (fn [{{{:keys [eid]}          :path
+         {:keys [closed-early]} :body} :parameters
+        session                        :ory-session
+        :as                            _request}]
+    (let [user-sub (get-in session [:identity :id])
+          result   (if closed-early
+                     (domain/close-registration-early dependencies eid user-sub)
+                     {:type :tournament/registration-error :message "No updates specified."})]
+      (if (= :tournament/close-registration-success (:type result))
+        (common/trigger-response "tournament-registration-updated" result)
+        {:status 422 :body result}))))
+
+(defmethod integrant.core/init-key ::create-round
+  [_init-key dependencies]
+  (fn [{{{:keys [eid]} :path} :parameters
+        session               :ory-session
+        :as                   _request}]
+    (let [user-sub (get-in session [:identity :id])
+          result   (domain/generate-next-round dependencies eid user-sub)]
+      (if (= :tournament/phase-error (:type result))
+        {:status 422 :body result}
+        (common/trigger-response "tournament-round-created" result)))))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -1,6 +1,7 @@
 (ns com.devereux-henley.rts-web.web.routes
   (:require
    [com.devereux-henley.rts-domain.contract :as domain]
+   [com.devereux-henley.rts-web.orchestration :as orchestration]
    [com.devereux-henley.rts-web.web.actions.draft :as web.actions.draft]
    [com.devereux-henley.rts-web.web.actions.league :as web.actions.league]
    [com.devereux-henley.rts-web.web.actions.season :as web.actions.season]
@@ -57,7 +58,8 @@
 
 (def view-routes
   ["/view"
-   {:no-doc true}
+   {:no-doc     true
+    :middleware [(integrant.core/ref ::orchestration/middleware)]}
    ["/game/index.html"
     {:get {:produces ["text/html"]
            :handler  (integrant.core/ref ::web.view/game-selector-view)}}]
@@ -188,7 +190,8 @@
 
 (def components-routes
   ["/components"
-   {:no-doc true}
+   {:no-doc     true
+    :middleware [(integrant.core/ref ::orchestration/middleware)]}
    ["/faction/:eid/faction-card.html"
     {:get {:produces   ["application/htmx+html"]
            :parameters {:path  schema.contract/id-path-parameter

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -1,6 +1,10 @@
 (ns com.devereux-henley.rts-web.web.routes
   (:require
    [com.devereux-henley.rts-domain.contract :as domain]
+   [com.devereux-henley.rts-web.web.actions.draft :as web.actions.draft]
+   [com.devereux-henley.rts-web.web.actions.league :as web.actions.league]
+   [com.devereux-henley.rts-web.web.actions.season :as web.actions.season]
+   [com.devereux-henley.rts-web.web.actions.tournament :as web.actions.tournament]
    [com.devereux-henley.rts-web.web.asset.api :as web.asset.api]
    [com.devereux-henley.rts-web.web.configuration :as web.configuration]
    [com.devereux-henley.rts-web.web.draft.api :as web.draft.api]
@@ -257,6 +261,92 @@
            :responses  {200 {:body domain/phase-response}}
            :handler    (integrant.core/ref ::web.tournament.api/get-phase)}}]])
 
+(def actions-routes
+  ["/actions"
+   {:no-doc true}
+   ["/draft/:draft-eid/unit/:eid"
+    {:post {:produces   ["application/htmx+html"]
+            :parameters {:path  (schema.contract/to-schema
+                                 [:map
+                                  [:draft-eid :uuid]
+                                  [:eid :uuid]])
+                         :query (schema.contract/to-schema
+                                 [:map
+                                  [:section [:enum "main" "reinforcements"]]])
+                         :body  domain/add-unit-to-draft-specification}
+            :handler    (integrant.core/ref ::web.actions.draft/add-unit)}}]
+   ["/draft/:draft-eid/entry/:eid"
+    {:patch  {:produces   ["application/htmx+html"]
+              :parameters {:path  (schema.contract/to-schema
+                                   [:map
+                                    [:draft-eid :uuid]
+                                    [:eid :uuid]])
+                           :query (schema.contract/to-schema
+                                   [:map
+                                    [:section [:enum "main" "reinforcements"]]])
+                           :body  domain/add-unit-to-draft-specification}
+              :handler    (integrant.core/ref ::web.actions.draft/update-entry)}
+     :delete {:produces   ["application/htmx+html"]
+              :parameters {:path  (schema.contract/to-schema
+                                   [:map
+                                    [:draft-eid :uuid]
+                                    [:eid :uuid]])
+                           :query (schema.contract/to-schema
+                                   [:map
+                                    [:section [:enum "main" "reinforcements"]]])}
+              :handler    (integrant.core/ref ::web.actions.draft/remove-entry)}}]
+   ["/draft/:eid"
+    {:put   {:produces   ["application/htmx+html"]
+             :parameters {:path  schema.contract/id-path-parameter
+                          :query schema.contract/version-query-parameter
+                          :body  domain/create-draft-specification}
+             :handler    (integrant.core/ref ::web.actions.draft/create-draft)}
+     :patch {:produces   ["application/htmx+html"]
+             :parameters {:path schema.contract/id-path-parameter
+                          :body domain/update-draft-specification}
+             :handler    (integrant.core/ref ::web.actions.draft/update-draft)}}]
+   ["/tournament/:eid"
+    {:put {:produces   ["application/htmx+html"]
+           :parameters {:path  schema.contract/id-path-parameter
+                        :query schema.contract/version-query-parameter
+                        :body  domain/create-tournament-specification}
+           :handler    (integrant.core/ref ::web.actions.tournament/create-tournament)}}]
+   ["/tournament/:eid/entry/me"
+    {:post   {:produces   ["application/htmx+html"]
+              :parameters {:path schema.contract/id-path-parameter}
+              :handler    (integrant.core/ref ::web.actions.tournament/create-entry)}
+     :delete {:produces   ["application/htmx+html"]
+              :parameters {:path schema.contract/id-path-parameter}
+              :handler    (integrant.core/ref ::web.actions.tournament/delete-entry)}}]
+   ["/tournament/:eid/status"
+    {:put {:produces   ["application/htmx+html"]
+           :parameters {:path schema.contract/id-path-parameter
+                        :body domain/update-status-specification}
+           :handler    (integrant.core/ref ::web.actions.tournament/update-status)}}]
+   ["/tournament/:eid/registration"
+    {:patch {:produces   ["application/htmx+html"]
+             :parameters {:path schema.contract/id-path-parameter
+                          :body domain/update-registration-specification}
+             :handler    (integrant.core/ref ::web.actions.tournament/update-registration)}}]
+   ["/tournament/:eid/round"
+    {:post {:produces   ["application/htmx+html"]
+            :parameters {:path schema.contract/id-path-parameter}
+            :handler    (integrant.core/ref ::web.actions.tournament/create-round)}}]
+   ["/league/:eid"
+    {:put {:produces   ["application/htmx+html"]
+           :parameters {:path  schema.contract/id-path-parameter
+                        :query schema.contract/version-query-parameter
+                        :body  domain/create-league-specification}
+           :handler    (integrant.core/ref ::web.actions.league/create-league)}}]
+   ["/season/:league-eid/:eid"
+    {:put {:produces   ["application/htmx+html"]
+           :parameters {:path (schema.contract/to-schema
+                               [:map
+                                [:league-eid :uuid]
+                                [:eid :uuid]])
+                        :body domain/create-season-specification}
+           :handler    (integrant.core/ref ::web.actions.season/create-season)}}]])
+
 (def api-routes
   ["/api"
    {:openapi {:security [{"ory" ["openid"]}]}}
@@ -354,10 +444,10 @@
             :responses  {200 {:body domain/draft-unit-resource}
                          500 {:body domain/draft-error-response}}
             :handler    (integrant.core/ref ::web.draft.api/get-draft-unit)}
-     :post {:produces   ["application/json" "application/hal+json" "application/htmx+html"]
+     :post {:produces   ["application/json" "application/hal+json"]
             :openapi    {:summary      "Assigns a unit to the specified draft."
                          :tags         ["draft"]
-                         :produces     ["application/json" "application/hal+json" "application/htmx+html"]
+                         :produces     ["application/json" "application/hal+json"]
                          :operation-id "draft-unit/create"}
             :parameters {:path  (schema.contract/to-schema
                                  [:map
@@ -396,10 +486,10 @@
                            404 {:body domain/draft-error-response}
                            500 {:body domain/draft-error-response}}
               :handler    (integrant.core/ref ::web.draft.api/get-draft-entry)}
-     :patch  {:produces   ["application/json" "application/hal+json" "application/htmx+html"]
+     :patch  {:produces   ["application/json" "application/hal+json"]
               :openapi    {:summary      "Updates the selections of a placed draft entry."
                            :tags         ["draft"]
-                           :produces     ["application/json" "application/hal+json" "application/htmx+html"]
+                           :produces     ["application/json" "application/hal+json"]
                            :operation-id "draft-entry/update"}
               :parameters {:path  (schema.contract/to-schema
                                    [:map
@@ -413,10 +503,10 @@
                            422 {:body domain/draft-error-response}
                            500 {:body domain/draft-error-response}}
               :handler    (integrant.core/ref ::web.draft.api/draft-update-unit)}
-     :delete {:produces   ["application/json" "application/hal+json" "application/htmx+html"]
+     :delete {:produces   ["application/json" "application/hal+json"]
               :openapi    {:summary      "Removes a placed entry from the specified draft."
                            :tags         ["draft"]
-                           :produces     ["application/json" "application/hal+json" "application/htmx+html"]
+                           :produces     ["application/json" "application/hal+json"]
                            :operation-id "draft-entry/delete"}
               :parameters {:path  (schema.contract/to-schema
                                    [:map
@@ -432,9 +522,9 @@
     {:name  :draft/by-eid
      :put   {:summary    "Creates a draft with the given eid and version."
              :openapi    {:tags         ["draft"]
-                          :produces     ["application/json" "application/hal+json" "application/htmx+html"]
+                          :produces     ["application/json" "application/hal+json"]
                           :operation-id "draft/create"}
-             :produces   ["application/json" "application/hal+json" "application/htmx+html"]
+             :produces   ["application/json" "application/hal+json"]
              :parameters {:path  schema.contract/id-path-parameter
                           :query schema.contract/version-query-parameter
                           :body  domain/create-draft-specification}
@@ -442,9 +532,9 @@
              :handler    (integrant.core/ref ::web.draft.api/create-draft)}
      :patch {:summary    "Applies a partial update to a draft (currently only :name)."
              :openapi    {:tags         ["draft"]
-                          :produces     ["application/json" "application/hal+json" "application/htmx+html"]
+                          :produces     ["application/json" "application/hal+json"]
                           :operation-id "draft/update"}
-             :produces   ["application/json" "application/hal+json" "application/htmx+html"]
+             :produces   ["application/json" "application/hal+json"]
              :parameters {:path schema.contract/id-path-parameter
                           :body domain/update-draft-specification}
              :responses  {200 {:body domain/draft-resource}

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
@@ -7,7 +7,6 @@
   (:require
    [clojure.string :as string]
    [com.devereux-henley.rts-domain.contract :as domain]
-   [com.devereux-henley.rts-web.orchestration :as orchestration]
    [com.devereux-henley.rts-web.render :as render]
    [com.devereux-henley.rts-web.skin :as skin]
    [integrant.core]
@@ -30,12 +29,16 @@
 (defn base-context
   "Template context shared across every view — session, active navbar section,
    any game-context assembled by the middleware, and the HX-Trigger
-   listener registry templates use to wire fragment refresh."
+   registry templates use to wire fragment refresh.
+
+   The trigger registry is injected onto the request by
+   `orchestration/middleware`; this function just surfaces it under
+   `:triggers` for Selmer (`{{ triggers.<event-id> }}`)."
   [request]
   (-> {:session    (:ory-session request)
-       :active-nav (active-nav (:uri request))}
-      (merge (:game-context request))
-      orchestration/assoc-listeners))
+       :active-nav (active-nav (:uri request))
+       :triggers   (:web-triggers request)}
+      (merge (:game-context request))))
 
 (selmer.filters/add-filter! :not-empty? (comp boolean seq))
 

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
@@ -7,6 +7,7 @@
   (:require
    [clojure.string :as string]
    [com.devereux-henley.rts-domain.contract :as domain]
+   [com.devereux-henley.rts-web.orchestration :as orchestration]
    [com.devereux-henley.rts-web.render :as render]
    [com.devereux-henley.rts-web.skin :as skin]
    [integrant.core]
@@ -28,11 +29,13 @@
 
 (defn base-context
   "Template context shared across every view — session, active navbar section,
-   and any game-context assembled by the middleware."
+   any game-context assembled by the middleware, and the HX-Trigger
+   listener registry templates use to wire fragment refresh."
   [request]
-  (merge {:session    (:ory-session request)
-          :active-nav (active-nav (:uri request))}
-         (:game-context request)))
+  (-> {:session    (:ory-session request)
+       :active-nav (active-nav (:uri request))}
+      (merge (:game-context request))
+      orchestration/assoc-listeners))
 
 (selmer.filters/add-filter! :not-empty? (comp boolean seq))
 


### PR DESCRIPTION
## Summary
Moves the 13 htmx-driven mutations templates currently `hx-post`/`hx-put`/`hx-patch`/`hx-delete` to /api into a new `/actions/...` surface. `/api` keeps the same endpoints for JSON + HAL+JSON consumers (e2e tests, etc.) but drops `application/htmx+html` from its `:produces`.

### Mutation routes added under `/actions`

| Verb | Path |
|---|---|
| POST | `/actions/draft/:draft-eid/unit/:eid` |
| PATCH, DELETE | `/actions/draft/:draft-eid/entry/:eid` |
| PUT, PATCH | `/actions/draft/:eid` |
| PUT | `/actions/tournament/:eid` |
| POST, DELETE | `/actions/tournament/:eid/entry/me` |
| PUT | `/actions/tournament/:eid/status` *(RPC — PR E redesigns)* |
| PATCH | `/actions/tournament/:eid/registration` |
| POST | `/actions/tournament/:eid/round` *(RPC — PR E redesigns)* |
| PUT | `/actions/league/:eid` |
| PUT | `/actions/season/:league-eid/:eid` |

### Response shape per the plan

- **Mutation success → `200` + `HX-Trigger: <event>`** + body. Event names follow `<resource>-<crud-verb>` past-tense (`draft-entry-created`, `tournament-status-updated`, etc.). The body is the same `application/htmx+html`-rendered template the `/api` variant returned, so existing OOB swap behavior (slot, budget, status-badge refreshes) still updates the page in-place. The `HX-Trigger` header is the channel future granular `/components` listener fragments will react to.
- **Create + go-somewhere → `200` + `HX-Redirect`** for HTMX-driven navigation. A 3xx response was tried and rejected: the fetch auto-follows before HTMX can see the header.
- **Failure → 4xx + HTML alert fragment** (`<section role=\"alert\">`).

### HX-Trigger registry, assembled via integrant

`components/rts-web/src/.../orchestration.clj` no longer carries a hardcoded fragment-to-event map. Instead, each namespace that owns mutating endpoints contributes its own slice via an integrant key derived from `::orchestration/web-trigger-source`:

```clojure
;; web/actions/draft.clj
(derive ::web-triggers ::orchestration/web-trigger-source)
(defmethod integrant.core/init-key ::web-triggers [_ _]
  {:unit-panel  ["draft-entry-created" "draft-entry-updated" "draft-entry-deleted"]
   :draft-stage ["draft-entry-created" "draft-entry-updated" "draft-entry-deleted" "draft-updated"]})
```

The orchestration namespace gathers all such contributions with `(integrant.core/refset ::web-trigger-source)`, compiles them into HTMX trigger strings (`"draft-entry-created from:body, …"`), and exposes the assembled `::registry`. A `::middleware` init-key wraps `view-routes` and `components-routes` so every request reaching a view handler carries the registry on `:web-triggers`, which `web.view/base-context` surfaces as `:triggers` on the Selmer context.

Templates will resolve event sets as `hx-trigger="{{ triggers.<event-id> }}"` once granular listeners land. The PR establishes the registry but does **not** wire individual fragments to it — the granular swap pattern needs more design (initial attempt hit an htmx interaction quirk between nested `hx-*` attributes and child `hx-target` swaps). A follow-up PR will land the granular listeners. Until then, the existing OOB swap behavior carried by the response body keeps the UI in sync, identical to pre-PR.

Adding a third actions namespace in a future PR is now one `derive` + one `init-key` — no edits to a central registry.

### Produces-enforcement update

The middleware from PR C now also **rewrites** wildcard-only Accept headers to the route's first `:produces` value, rather than just allowing them through. Without this, browser Accept like `text/html, application/xhtml+xml, */*;q=0.8` slips past the wildcard check and muuntaja negotiates to `text/html` even when the route only produces `application/htmx+html`. Test suite expanded from 12 to 13 assertions to cover the rewrite case.

## Test plan
- [x] `clojure -M:poly test` — method-override (16 assertions) + produces-enforcement (13 assertions) all green.
- [x] `cljfmt` and `clj-kondo` clean on all touched files.
- [x] `clojure -M:poly check` clean.
- [x] Full Playwright e2e suite — 104/104 passing locally.
- [x] Live walkthrough via Playwright on the local dev server (toolbox nREPL :7888, Jetty :3001): create-draft form (PUT /actions/draft → HX-Redirect), select a unit, add to main army (POST /actions/draft/:eid/unit/:eid → 200 + HX-Trigger + OOB body swap), filled-slot count goes from 0 to 1.
- [x] REPL-validated registry assembly: `::orchestration/registry` returns the merged `{:unit-panel … :draft-stage … :tournament-stage …}` map after a cold start, and the middleware injects it onto incoming requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)