### PR TITLE
HATEOAS audit: real /api/draft, prune dangling refs, fix prefix bug

### DIFF
--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -63,7 +63,8 @@
             :com.devereux-henley.rts-web.web.game.api/get-game-social-link))
 
 (def draft-configuration
-  (handlers :com.devereux-henley.rts-web.web.draft.api/get-draft-unit
+  (handlers :com.devereux-henley.rts-web.web.draft.api/get-draft
+            :com.devereux-henley.rts-web.web.draft.api/get-draft-unit
             :com.devereux-henley.rts-web.web.draft.api/get-draft-entry))
 
 (def social-media-configuration

--- a/bases/rts-api/test/com/devereux_henley/rts_api/model_transform_test.clj
+++ b/bases/rts-api/test/com/devereux_henley/rts_api/model_transform_test.clj
@@ -22,11 +22,12 @@
 
 (def ^:private match-resource
   (schema/to-schema
-   [:map {:model/type :model/model}
+   [:map {:model/type          :model/model
+          :model/sub-resources {:games :match/games}}
     [:eid {:model/link :match/by-eid} :uuid]
     [:type [:= :tournament/match]]
     [:tournament-eid {:model/link :tournament/by-eid} :uuid]
-    [:_links [:map [:self :url] [:tournament :url]]]]))
+    [:_links [:map [:self :url] [:tournament :url] [:games :url]]]]))
 
 (def ^:private tournament-with-embedded-match
   (schema/to-schema
@@ -46,19 +47,20 @@
 
 (def ^:private router
   (reitit.ring/router
-   [["/api/game/:eid"                             {:name :game/by-eid :get {:handler noop}}]
-    ["/api/tournament/:eid"                       {:name :tournament/by-eid :get {:handler noop}}]
-    ["/api/tournament/:tournament-eid/match"      {:name :tournament/matches
-                                                   :get  {:handler   noop
-                                                          :responses {200 {:body tournament-resource}}}}]
-    ["/api/tournament/:tournament-eid/match/:eid" {:name :match/by-eid
-                                                   :get  {:handler   noop
-                                                          :responses {200 {:body match-resource}}}}]
-    ["/api/tournament/:eid/embedded"              {:get {:handler   noop
-                                                         :responses {200 {:body tournament-with-embedded-match}}}}]
-    ["/api/tournament/:eid/no-schema"             {:get {:handler noop}}]
-    ["/api/tournament/:eid/resource"              {:get {:handler   noop
-                                                         :responses {200 {:body tournament-resource}}}}]]
+   [["/api/game/:eid"                                  {:name :game/by-eid :get {:handler noop}}]
+    ["/api/tournament/:eid"                            {:name :tournament/by-eid :get {:handler noop}}]
+    ["/api/tournament/:tournament-eid/match"           {:name :tournament/matches
+                                                        :get  {:handler   noop
+                                                               :responses {200 {:body tournament-resource}}}}]
+    ["/api/tournament/:tournament-eid/match/:eid"      {:name :match/by-eid
+                                                        :get  {:handler   noop
+                                                               :responses {200 {:body match-resource}}}}]
+    ["/api/tournament/:tournament-eid/match/:eid/game" {:name :match/games :get {:handler noop}}]
+    ["/api/tournament/:eid/embedded"                   {:get {:handler   noop
+                                                              :responses {200 {:body tournament-with-embedded-match}}}}]
+    ["/api/tournament/:eid/no-schema"                  {:get {:handler noop}}]
+    ["/api/tournament/:eid/resource"                   {:get {:handler   noop
+                                                              :responses {200 {:body tournament-resource}}}}]]
    {:data {:coercion (reitit.coercion.malli/create
                       {:compile malli.util/closed-schema})}}))
 
@@ -109,6 +111,20 @@
       (is (= (str hostname "/api/tournament/" tournament-eid "/match")
              (get-in response [:body :_links :matches]))
           "matches route uses :tournament-eid slot, filled from resource's own :eid"))))
+
+(deftest sub-resource-respects-existing-parent-eid
+  (testing "When the schema's :type namespace matches a parent-eid field already on the
+   value (e.g. :tournament/match carries its parent's :tournament-eid), the
+   sub-resource link must use the carried value, not overwrite it with the
+   resource's own :eid"
+    (let [response (run-middleware (str "/api/tournament/" tournament-eid "/match/" match-eid)
+                                   (handler-returning
+                                    {:type           :tournament/match
+                                     :eid            match-eid
+                                     :tournament-eid tournament-eid}))]
+      (is (= (str hostname "/api/tournament/" tournament-eid "/match/" match-eid "/game")
+             (get-in response [:body :_links :games]))
+          "games sub-resource URL keeps the real tournament-eid in the parent slot"))))
 
 (deftest nested-embedded-resource-also-gets-links
   (testing "nested :model/model maps reachable through :_embedded are transformed too"

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
@@ -91,7 +91,6 @@
 (def tournament-resource                          schema/tournament-resource)
 (def create-tournament-specification              schema/create-tournament-specification)
 (def tournament-collection-resource               schema/tournament-collection-resource)
-(def tournament-entry-resource                     schema/tournament-entry-resource)
 
 (def get-tournament-by-eid                        handlers.tournament/get-tournament-by-eid)
 (def get-tournaments-for-game                     handlers.tournament/get-tournaments-for-game)

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/draft.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/draft.clj
@@ -266,11 +266,14 @@
     (assoc draft :display-name (or trimmed (draft-default-name draft)))))
 
 (defn get-draft-by-eid
-  "Fetches a draft by eid and attaches :type :game/draft + :display-name."
+  "Fetches a draft by eid and attaches :type :game/draft + :display-name.
+   Returns nil when no row matches so callers can distinguish missing from
+   present."
   [dependencies eid]
-  (-> (db/get-draft-by-eid (:connection dependencies) eid)
-      with-display-name
-      (assoc :type :game/draft)))
+  (when-let [draft (db/get-draft-by-eid (:connection dependencies) eid)]
+    (-> draft
+        with-display-name
+        (assoc :type :game/draft))))
 
 (defn create-draft
   "Creates a new draft, stamping :created-at and :updated-at, and attaches :type :game/draft."

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/schema.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/schema.clj
@@ -136,7 +136,8 @@
      {:model/sub-resources {:status       :tournament/status
                             :registration :tournament/registration
                             :entries      :tournament/entries
-                            :matches      :tournament/matches}}
+                            :matches      :tournament/matches
+                            :round        :tournament/round}}
      [:eid {:model/link :tournament/by-eid} :uuid]
      [:type [:= :tournament/tournament]]
      [:name {:min 1} :string]
@@ -154,7 +155,8 @@
        [:status :url]
        [:registration :url]
        [:entries :url]
-       [:matches :url]]]])))
+       [:matches :url]
+       [:round :url]]]])))
 
 (def create-tournament-specification
   (schema.contract/to-schema
@@ -180,6 +182,7 @@
    schema.contract/base-resource
    (schema.contract/to-schema
     [:map
+     {:model/sub-resources {:games :match/games}}
      [:eid {:model/link :match/by-eid} :uuid]
      [:type [:= :tournament/match]]
      [:tournament-eid {:model/link :tournament/by-eid} :uuid]
@@ -194,7 +197,8 @@
      [:_links
       [:map
        [:self :url]
-       [:tournament :url]]]])))
+       [:tournament :url]
+       [:games :url]]]])))
 
 (def create-match-specification
   (schema.contract/to-schema
@@ -209,21 +213,6 @@
   (schema.contract/to-schema
    [:map
     [:winner-sub :string]]))
-
-(def tournament-entry-resource
-  (malli.util/merge
-   schema.contract/base-resource
-   (schema.contract/to-schema
-    [:map
-     [:eid {:model/link :tournament-entry/by-eid} :uuid]
-     [:type [:= :tournament/entry]]
-     [:tournament-eid {:model/link :tournament/by-eid} :uuid]
-     [:player-sub :string]
-     [:created-at :instant]
-     [:_links
-      [:map
-       [:self :url]
-       [:tournament :url]]]])))
 
 ;; ─── Subresource response schemas ───────────────────────────────────────────
 
@@ -423,11 +412,15 @@
     [:map
      [:eid {:model/link :draft/by-eid} :uuid]
      [:type [:= :game/draft]]
-     [:game-mode-eid {:model/link :game-mode/by-eid} :uuid]
+     [:game-mode-eid :uuid]
      [:faction-eid {:model/link :game/faction-by-eid} :uuid]
      [:name {:optional true} [:maybe :string]]
      [:display-name {:optional true} :string]
-     [:player-sub :string]])))
+     [:player-sub :string]
+     [:_links
+      [:map
+       [:self :url]
+       [:faction :url]]]])))
 
 (def create-draft-specification
   (schema.contract/to-schema
@@ -588,7 +581,8 @@
      [:_links
       [:map
        [:self :url]
-       [:draft :url]]]])))
+       [:draft :url]
+       [:game :url]]]])))
 
 (def draft-entry-resource
   "A placed draft entry — addressing (entry eid, draft-eid, unit-eid,

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/draft_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/draft_test.clj
@@ -236,6 +236,10 @@
       (is (= test-faction-eid (:faction-eid result)))
       (is (= test-game-mode-eid (:game-mode-eid result))))))
 
+(deftest get-draft-by-eid-returns-nil-when-row-missing
+  (with-redefs [data-access.contract/get-draft-by-eid (fn [_ _] nil)]
+    (is (nil? (handlers.draft/get-draft-by-eid test-deps test-draft-eid)))))
+
 ;; --- create-draft ---
 
 (deftest create-draft-assigns-type

--- a/components/rts-web/resources/rts-web/resource/draft.html
+++ b/components/rts-web/resources/rts-web/resource/draft.html
@@ -1,5 +1,8 @@
 <section class="resource">
-    <h2>Draft Created</h2>
-    <p>Your draft has been created successfully.</p>
-    <a class="btn btn-ghost btn-sm" href="/view/draft/{{data.eid}}/index.html">View Draft</a>
+    <h2>{{ data.display-name|default:"Draft" }}</h2>
+    <dl>
+        <dt>player</dt><dd>{{ data.player-sub }}</dd>
+        {% if data._links.faction %}<dt>faction</dt><dd><a href="{{ data._links.faction }}">{{ data.faction-eid }}</a></dd>{% endif %}
+    </dl>
+    <a class="btn btn-ghost btn-sm" href="/view/draft/{{ data.eid }}/index.html">View Draft</a>
 </section>

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/draft/api.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/draft/api.clj
@@ -79,6 +79,18 @@
       (get-in resource [:_embedded :unit])
       (update-in [:_embedded :unit] attach))))
 
+(defmethod integrant.core/init-key ::get-draft
+  [_init-key dependencies]
+  (fn [{{{:keys [eid]} :path} :parameters
+        router                :reitit.core/router
+        :as                   _request}]
+    (if-let [draft (domain/get-draft-by-eid dependencies eid)]
+      (web.core/handle-fetch-response
+       domain/draft-resource
+       {:hostname (:hostname dependencies) :router router}
+       (constantly draft))
+      {:status 404 :body {:type :missing/resource :name "draft" :id eid}})))
+
 (defmethod integrant.core/init-key ::get-draft-unit
   [_init-key dependencies]
   (fn [{{{:keys [draft-eid eid]}      :path

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -411,6 +411,12 @@
             :handler    (integrant.core/ref ::web.game.api/get-faction)}}]
 
    ;; ─── Draft (reads only — mutations live on /actions) ────────────────────
+   ["/draft/:eid"
+    {:name :draft/by-eid
+     :get  {:produces   ["text/html"]
+            :parameters {:path schema.contract/id-path-parameter}
+            :responses  {200 {:body domain/draft-resource}}
+            :handler    (integrant.core/ref ::web.draft.api/get-draft)}}]
    ["/draft/:draft-eid/unit"
     {:name :draft-unit/preview
      :get  {:produces   ["text/html"]
@@ -538,13 +544,14 @@
               :responses  {200 {:body domain/match-resource}}
               :handler    (integrant.core/ref ::web.tournament.api/get-match)}}]
      ["/:eid/game"
-      {:get {:produces   ["text/html"]
-             :parameters {:path (schema.contract/to-schema
-                                 [:map
-                                  [:tournament-eid :uuid]
-                                  [:eid :uuid]])}
-             :responses  {200 {:body domain/tournament-games-response}}
-             :handler    (integrant.core/ref ::web.tournament.api/get-games)}}]]]
+      {:name :match/games
+       :get  {:produces   ["text/html"]
+              :parameters {:path (schema.contract/to-schema
+                                  [:map
+                                   [:tournament-eid :uuid]
+                                   [:eid :uuid]])}
+              :responses  {200 {:body domain/tournament-games-response}}
+              :handler    (integrant.core/ref ::web.tournament.api/get-games)}}]]]
 
    ;; ─── League ────────────────────────────────────────────────────────────
    ["/league"

--- a/components/schema/src/com/devereux_henley/schema/contract.clj
+++ b/components/schema/src/com/devereux_henley/schema/contract.clj
@@ -306,10 +306,13 @@
 
    If the schema's properties include `:model/sub-resources
    {<rel-key> <route-name>, ...}`, every entry also produces a
-   `_links.<rel-key>` resolved with the resource's own eid both as
-   `:eid` and as `:<resource-type>-eid` (derived from the schema's
-   `:type` field), so routes that hang sub-resources off either slot
-   resolve correctly."
+   `_links.<rel-key>` resolved with the resource's own eid. The
+   schema's `:type` field's namespace is also tried as a
+   `:<namespace>-eid` slot when the value doesn't already carry one,
+   so a parent resource (e.g. `:type :tournament/tournament`) fills
+   its sub-routes' `:tournament-eid` slot from `:eid` without
+   clobbering an existing `:tournament-eid` field on child resources
+   like `:type :tournament/match`."
   [route-data schema]
   (let [mapping       (key-to-link-mapping schema)
         props         (malli.core/properties schema)
@@ -317,9 +320,11 @@
         prefix        (resource-type-prefix schema)]
     (fn [value]
       (let [parent-params   (parent-eid-params value)
+            prefix-key      (some-> prefix (str "-eid") keyword)
             sub-link-params (cond-> (assoc parent-params :eid (:eid value))
-                              prefix (assoc (keyword (str prefix "-eid"))
-                                            (:eid value)))]
+                              (and prefix-key
+                                   (not (contains? parent-params prefix-key)))
+                              (assoc prefix-key (:eid value)))]
         (cond-> (reduce-kv
                  (fn [acc k v]
                    (cond


### PR DESCRIPTION
## Summary

Audit pass over every \`/api\` response surface to verify HATEOAS works end-to-end. Found three dangling \`:model/link\` route names (silently collapsed to \`http://localhost:3001\` because reitit's \`match-by-name!\` returned nil), missing \`_links\` declarations (stripped by reitit response coercion), and a subtle prefix-override bug in the model transformer that broke sub-resource URLs on every \`:tournament/match\`.

Two commits:

1. **\`Don't clobber a child's parent-eid with its own eid\`** — The \`:type\` namespace prefix derives a \`:<prefix>-eid\` slot so a parent resource (e.g. \`:tournament/tournament\`) can fill its sub-routes' \`:tournament-eid\` from its own \`:eid\`. It was unconditionally overwriting any matching parent FK already on the value, so a child resource (\`:tournament/match\`) had its real \`:tournament-eid\` replaced with its own match eid. Now only fills the slot when not already supplied. Regression test in \`model_transform_test.clj\`.

2. **\`HATEOAS audit\`** — Dangling \`:model/link\` cleanup, missing \`_links\` declarations, and rounding out sub-resources:
   - Add \`GET /api/draft/:eid\` so \`:draft/by-eid\` references in draft-unit/-entry actually resolve. \`get-draft-by-eid\` now returns nil on missing rows.
   - Drop dangling \`:game-mode/by-eid\` annotation (no route, no template needs it).
   - Delete dead \`tournament-entry-resource\` (and its \`:tournament-entry/by-eid\` annotation).
   - Declare \`_links\` explicitly on draft-unit-resource (\`:game\`) and draft-resource (\`:faction\`).
   - Name the match-games route \`:match/games\`; surface it as a sub-resource link on \`match-resource\`.
   - Surface \`:tournament/round\` as a sub-resource link on \`tournament-resource\`.
   - Rewrite \`draft.html\` as a proper resource view (was inherited create-response copy).

## Test plan

- [x] \`clojure -M:poly check\` — green
- [x] \`clojure -M:poly test :all\` — green (model-transform-test now has 10 assertions including the new regression test)
- [x] \`clojure -M:cljfmt check\` (whole workspace)
- [x] \`clj-kondo --lint $CLJ_FILES\` — 0 errors, 0 warnings
- [x] \`cd components/e2e && npx playwright test\` — 40 passed
- [x] \`GET /api/draft/<real-uuid>\` — 200 with \`_links.faction\` resolving to \`/api/game/faction/<faction-eid>\`
- [x] \`GET /api/draft/<bogus-uuid>\` — 404 with missing-resource fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)