### PR TITLE
Redesign tournament viewer: bracket grid, standings, hero pill

### DIFF
--- a/bases/rts-demo/src/com/devereux_henley/rts_demo/core.clj
+++ b/bases/rts-demo/src/com/devereux_henley/rts_demo/core.clj
@@ -206,6 +206,12 @@
                                      :rounds     [{:format 1} {:format 1} {:format 1}]}]
                   :qualifier-count 4}}])
 
+(def ^:private registration-tournament-specs
+  [{:eid              #uuid "44444444-4444-4444-8444-444444444444"
+    :name             "Wolves of Norsca Cup"
+    :description      "Open registration — first eight to sign on take the bracket."
+    :initial-entrants 3}])
+
 (defn- build-tournament!
   [connection {:keys [eid name description phase-spec]}]
   (let [deps           {:connection connection}
@@ -220,25 +226,43 @@
        :tournament-eid tournament-eid
        :pending-eids   (mapv :eid final-pending)})))
 
+(defn- build-registration-tournament!
+  "Creates a tournament left in `registration` status with a partial
+   roster so the viewer's registration UI has a live demo target."
+  [connection {:keys [eid name description initial-entrants]}]
+  (let [deps           {:connection connection}
+        tournament-eid (create-tournament! connection {:eid eid :name name :description description})
+        roster         (take initial-entrants player-subs)]
+    (enter-players! deps tournament-eid roster)
+    {:name             name
+     :phase-type       "registration"
+     :tournament-eid   tournament-eid
+     :pending-eids     []
+     :registered-count (count roster)}))
+
 (defn setup!
   "Wipes the SQLite database, reapplies migrations, seeds baseline data,
-  and creates three demo tournaments (single-elim, double-elim, Swiss),
-  each advanced to its last-match state. Returns a vector of summary
-  maps describing each tournament."
+  and creates demo tournaments: three advanced to their last-match
+  state (single-elim, double-elim, Swiss), plus one left in open
+  registration. Returns a vector of summary maps describing each
+  tournament."
   []
   (delete-database-file!)
   (migratus/migrate migratus-config)
   (rts-data/seed-db db-spec)
   (with-open [connection (jdbc/get-connection jdbc-spec)]
-    (mapv #(build-tournament! connection %) tournament-specs)))
+    (into (mapv #(build-tournament! connection %) tournament-specs)
+          (mapv #(build-registration-tournament! connection %) registration-tournament-specs))))
 
 (defn -main [& _args]
   (let [tournaments (setup!)]
     (println "Demo tournaments ready.")
     (println "  game-eid:" warhammer-iii-eid)
-    (doseq [{:keys [name phase-type tournament-eid pending-eids]} tournaments]
+    (doseq [{:keys [name phase-type tournament-eid pending-eids registered-count]} tournaments]
       (println)
       (println (format "  %s (%s)" name phase-type))
       (println (format "    tournament-eid: %s" tournament-eid))
+      (when registered-count
+        (println (format "    registered:     %d of %d slots" registered-count (count player-subs))))
       (doseq [match-eid pending-eids]
         (println (format "    pending match:  %s" match-eid))))))

--- a/bases/rts-demo/src/com/devereux_henley/rts_demo/core.clj
+++ b/bases/rts-demo/src/com/devereux_henley/rts_demo/core.clj
@@ -1,13 +1,11 @@
 (ns com.devereux-henley.rts-demo.core
-  "Bootstraps a fresh SQLite database with a tournament that's ready for
-  replay uploads. Run from the REPL via `(setup!)` or as a one-shot CLI
-  via `clojure -M:dev:claude -m com.devereux-henley.rts-demo.core`.
+  "Bootstraps a fresh SQLite database with three demo tournaments — one
+  single-elimination, one double-elimination, one Swiss — each populated
+  with eight entrants and advanced to the last-match state so the new
+  tournament viewer always has a non-trivial bracket to render.
 
-  After completion the system has:
-   - migrations applied + baseline game data seeded
-   - one tournament organized by `dev-admin`, status `active`, single-elim bo3
-   - two entries (`dev-player-one`, `dev-player-two`)
-   - one round-1 match wired to both players, ready for `/match/:eid/record`."
+  Run from the REPL via `(setup!)` or as a one-shot CLI via
+  `clojure -M:dev:claude -m com.devereux-henley.rts-demo.core`."
   (:require
    [clojure.java.io :as io]
    [com.devereux-henley.rts-data-access.contract :as data-access]
@@ -40,8 +38,10 @@
   #uuid "eea787d7-1065-45eb-a3f6-e26f32c294a1")
 
 (def ^:private organizer-sub "dev-admin")
-(def ^:private player-one-sub "dev-player-one")
-(def ^:private player-two-sub "dev-player-two")
+
+(def ^:private player-subs
+  (mapv #(str "dev-player-" %)
+        ["one" "two" "three" "four" "five" "six" "seven" "eight"]))
 
 (defn- delete-database-file!
   []
@@ -51,9 +51,8 @@
         (.delete file)))))
 
 (defn- create-tournament!
-  [connection]
-  (let [eid       (random-uuid)
-        now       (Instant/now)
+  [connection {:keys [eid name description]}]
+  (let [now       (Instant/now)
         opens-at  (LocalDateTime/now)
         closes-at (.plusDays opens-at 14)
         zone      (ZoneId/of "UTC")]
@@ -61,8 +60,8 @@
      connection
      {:eid            eid
       :game-eid       warhammer-iii-eid
-      :name           "Replay Demo Cup"
-      :description    "Seeded tournament for exercising the replay upload flow."
+      :name           name
+      :description    description
       :created-by-sub organizer-sub
       :version        1
       :created-at     now
@@ -89,51 +88,157 @@
                       {:player-sub player-sub :result result})))
     result))
 
-(defn- configure-and-start!
+(defn- enter-players!
+  [deps tournament-eid players]
+  (doseq [sub players]
+    (enter-player! deps tournament-eid sub)))
+
+(defn- configure-phases!
+  [deps tournament-eid phase-spec]
+  (let [result (domain/configure-phases deps tournament-eid phase-spec organizer-sub)]
+    (when (not= :tournament/phase-configured (:type result))
+      (throw (ex-info "Phase configuration failed" {:result result})))))
+
+(defn- start!
   [deps tournament-eid]
-  (let [phase-result (domain/configure-phases
-                      deps
-                      tournament-eid
-                      {:phases          [{:phase-type "single-elimination"
-                                          :rounds     [{:format 3}]}]
-                       :qualifier-count 2}
-                      organizer-sub)]
-    (when (not= :tournament/phase-configured (:type phase-result))
-      (throw (ex-info "Phase configuration failed" {:result phase-result}))))
-  (let [start-result (domain/start-tournament deps tournament-eid organizer-sub)]
-    (when (not= :tournament/started (:type start-result))
-      (throw (ex-info "Starting tournament failed" {:result start-result}))))
-  (let [round-result (domain/generate-next-round deps tournament-eid organizer-sub)]
-    (when (not= :tournament/round-generated (:type round-result))
-      (throw (ex-info "Round generation failed" {:result round-result})))
-    round-result))
+  (let [result (domain/start-tournament deps tournament-eid organizer-sub)]
+    (when (not= :tournament/started (:type result))
+      (throw (ex-info "Starting tournament failed" {:result result})))))
+
+(defn- generate-round!
+  "Calls generate-next-round, returning the result map. Caller decides
+   what to do with an error response."
+  [deps tournament-eid]
+  (domain/generate-next-round deps tournament-eid organizer-sub))
+
+(defn- resolve-match!
+  "Records the minimum games needed for player-one to win the match.
+   Going through record-game-result (rather than update-match-result)
+   leaves real match_game rows behind so the bracket viewer can show
+   per-player game counts."
+  [deps match]
+  (let [wins-needed (inc (quot (:format match) 2))
+        winner      (:player-one-sub match)]
+    (dotimes [_ wins-needed]
+      (domain/record-game-result deps (:eid match) winner))))
+
+(defn- single-elim-done?
+  "Stop when the only pending match is the bracket final (a sole pending
+   match in a single-elim tournament is always the final)."
+  [pending _all-matches _state]
+  (= 1 (count pending)))
+
+(defn- double-elim-done?
+  "Stop when the grand-final match has been generated. Anything else
+   pending (LB/WB intermediate rounds) still needs to be resolved."
+  [_pending all-matches _state]
+  (boolean
+   (some #(and (= "grand-final" (:bracket-type %))
+               (= "pending" (:status %)))
+         all-matches)))
+
+(defn- swiss-done?
+  "Stop when the last configured round has been generated and still has
+   pending matches. The Swiss demo wants a fresh final round on display."
+  [pending all-matches state]
+  (let [phase-idx    (:current-phase state)
+        phase        (get-in state [:phases phase-idx])
+        total-rounds (count (:rounds phase))]
+    (boolean
+     (and (seq pending)
+          (seq all-matches)
+          (= (apply max (map :round-index all-matches))
+             (dec total-rounds))))))
+
+(def ^:private stop-predicates
+  {"single-elimination" single-elim-done?
+   "double-elimination" double-elim-done?
+   "swiss"              swiss-done?})
+
+(defn- advance-to-last-match!
+  "Drives a tournament forward by alternately resolving pending matches
+   and generating the next round, until the type-specific stop predicate
+   says we're at the final/decisive match state. Returns the final
+   pending-match list."
+  [deps tournament-eid phase-type]
+  (let [stop? (or (stop-predicates phase-type)
+                  (throw (ex-info "Unknown phase type" {:phase-type phase-type})))]
+    (loop [safety 50]
+      (when (zero? safety)
+        (throw (ex-info "advance-to-last-match! exceeded safety limit"
+                        {:tournament-eid tournament-eid})))
+      (let [all-matches (domain/get-matches-for-tournament deps tournament-eid)
+            pending     (filter #(= "pending" (:status %)) all-matches)
+            state       (domain/get-tournament-state deps tournament-eid)]
+        (cond
+          (stop? pending all-matches state)
+          pending
+
+          (empty? pending)
+          (let [result (generate-round! deps tournament-eid)]
+            (if (= :tournament/round-generated (:type result))
+              (recur (dec safety))
+              (throw (ex-info "generate-next-round failed before reaching last-match state"
+                              {:result result}))))
+
+          :else
+          (do
+            (run! #(resolve-match! deps %) pending)
+            (recur (dec safety))))))))
+
+(def ^:private tournament-specs
+  [{:eid         #uuid "11111111-1111-4111-8111-111111111111"
+    :name        "Crown of Karak Eight Peaks"
+    :description "Eight warlords contest the throne in a classic single-elimination bracket."
+    :phase-spec  {:phases          [{:phase-type "single-elimination"
+                                     :rounds     [{:format 5} {:format 5} {:format 5}]}]
+                  :qualifier-count 8}}
+   {:eid         #uuid "22222222-2222-4222-8222-222222222222"
+    :name        "Siege of Naggaroth"
+    :description "Double-elimination — losers get a second life, the winners' champion gets to wait in the grand final."
+    :phase-spec  {:phases          [{:phase-type "double-elimination"
+                                     :rounds     [{:format 3} {:format 3} {:format 3}]}]
+                  :qualifier-count 8}}
+   {:eid         #uuid "33333333-3333-4333-8333-333333333333"
+    :name        "Empire Open"
+    :description "Three-round Swiss. Every entrant plays every round; no one is eliminated until the final tally."
+    :phase-spec  {:phases          [{:phase-type "swiss"
+                                     :rounds     [{:format 1} {:format 1} {:format 1}]}]
+                  :qualifier-count 4}}])
+
+(defn- build-tournament!
+  [connection {:keys [eid name description phase-spec]}]
+  (let [deps           {:connection connection}
+        phase-type     (-> phase-spec :phases first :phase-type)
+        tournament-eid (create-tournament! connection {:eid eid :name name :description description})]
+    (enter-players! deps tournament-eid player-subs)
+    (configure-phases! deps tournament-eid phase-spec)
+    (start! deps tournament-eid)
+    (let [final-pending (advance-to-last-match! deps tournament-eid phase-type)]
+      {:name           name
+       :phase-type     phase-type
+       :tournament-eid tournament-eid
+       :pending-eids   (mapv :eid final-pending)})))
 
 (defn setup!
   "Wipes the SQLite database, reapplies migrations, seeds baseline data,
-  and creates an active tournament with a round-1 match. Returns a map
-  with the tournament eid and the eid of the first match."
+  and creates three demo tournaments (single-elim, double-elim, Swiss),
+  each advanced to its last-match state. Returns a vector of summary
+  maps describing each tournament."
   []
   (delete-database-file!)
   (migratus/migrate migratus-config)
   (rts-data/seed-db db-spec)
   (with-open [connection (jdbc/get-connection jdbc-spec)]
-    (let [deps           {:connection connection}
-          tournament-eid (create-tournament! connection)]
-      (enter-player! deps tournament-eid player-one-sub)
-      (enter-player! deps tournament-eid player-two-sub)
-      (let [{:keys [matches]} (configure-and-start! deps tournament-eid)]
-        {:tournament-eid tournament-eid
-         :game-eid       warhammer-iii-eid
-         :match-eids     (mapv :eid matches)}))))
+    (mapv #(build-tournament! connection %) tournament-specs)))
 
 (defn -main [& _args]
-  (let [{:keys [tournament-eid game-eid match-eids]} (setup!)]
-    (println "Demo tournament ready.")
-    (println "  game-eid:      " game-eid)
-    (println "  tournament-eid:" tournament-eid)
-    (doseq [match-eid match-eids]
-      (println "  match-eid:     " match-eid))
-    (println)
-    (println "Open the post-match modal at:")
-    (doseq [match-eid match-eids]
-      (println (format "  /view/match-record/%s/index.html" match-eid)))))
+  (let [tournaments (setup!)]
+    (println "Demo tournaments ready.")
+    (println "  game-eid:" warhammer-iii-eid)
+    (doseq [{:keys [name phase-type tournament-eid pending-eids]} tournaments]
+      (println)
+      (println (format "  %s (%s)" name phase-type))
+      (println (format "    tournament-eid: %s" tournament-eid))
+      (doseq [match-eid pending-eids]
+        (println (format "    pending match:  %s" match-eid))))))

--- a/components/e2e/tests/tournament.spec.js
+++ b/components/e2e/tests/tournament.spec.js
@@ -49,12 +49,24 @@ async function startTournament(request, eid) {
 }
 
 async function configureSwissPhase(request, eid) {
-  await request.put(`${BASE}/api/tournament/${eid}/phase`, {
+  const res = await request.put(`${BASE}/api/tournament-phase-configuration?tournament-eid=${eid}`, {
     headers: apiHeaders('dev-admin'),
     data: {
       phases: [{ 'phase-type': 'swiss', rounds: [{ 'round-index': 0, format: 1 }] }],
     },
   });
+  expect(res.status()).toBe(200);
+}
+
+async function configureSinglePhase(request, eid) {
+  const res = await request.put(`${BASE}/api/tournament-phase-configuration?tournament-eid=${eid}`, {
+    headers: apiHeaders('dev-admin'),
+    data: {
+      phases: [{ 'phase-type': 'single-elimination', rounds: [{ 'round-index': 0, format: 1 }] }],
+      'qualifier-count': 2,
+    },
+  });
+  expect(res.status()).toBe(200);
 }
 
 async function generateRound(request, eid) {
@@ -94,12 +106,12 @@ test.describe('Tournament UI', () => {
     await expect(page.locator('#registration-closes-at')).toBeVisible();
   });
 
-  test('tournament detail page shows entries section', async ({ page, request }) => {
+  test('tournament detail page shows standings + entry action', async ({ page, request }) => {
     const eid = await createTournament(request);
     await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/index.html`);
     await expect(page).toHaveTitle(/E2E Test Tournament/);
-    await expect(page.locator('h3', { hasText: 'Entries' })).toBeVisible();
-    await expect(page.locator('button', { hasText: 'Enter' })).toBeVisible();
+    await expect(page.locator('h3', { hasText: 'Standings' })).toBeVisible();
+    await expect(page.locator('button', { hasText: 'Enter Tournament' })).toBeVisible();
   });
 
   test('tournament detail shows withdraw button after entering', async ({ page, request }) => {
@@ -107,18 +119,11 @@ test.describe('Tournament UI', () => {
     await enter(request, eid, 'dev-admin');
     await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/index.html`);
     await expect(page.locator('button', { hasText: 'Withdraw' })).toBeVisible();
-    await expect(page.locator('li', { hasText: 'dev-admin' })).toBeVisible();
-  });
-
-  test('organizer sees Start Tournament button', async ({ page, request }) => {
-    const eid = await createTournament(request);
-    await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/index.html`);
-    await expect(page.locator('button', { hasText: 'Start Tournament' })).toBeVisible();
-    await expect(page.locator('button', { hasText: 'Close Registration' })).toBeVisible();
+    await expect(page.locator('table.standings-table tbody tr', { hasText: 'dev-admin' })).toBeVisible();
   });
 });
 
-test.describe('Tournament Detail UI — Tabs', () => {
+test.describe('Tournament Viewer page', () => {
   test.beforeEach(async ({ context }) => {
     await context.addCookies([
       {
@@ -132,31 +137,28 @@ test.describe('Tournament Detail UI — Tabs', () => {
     ]);
   });
 
-  test('entrants tab is selected on initial load', async ({ page, request }) => {
+  test('viewer hero shows status badge and title', async ({ page, request }) => {
     const eid = await createTournament(request);
     await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/index.html`);
-    await expect(page.locator('#tab-entrants')).toHaveAttribute('aria-selected', 'true');
-    await expect(page.locator('#panel-entrants')).toBeVisible();
+    await expect(page.locator('.viewer-hero-title', { hasText: 'E2E Test Tournament' })).toBeVisible();
+    await expect(page.locator('.viewer-hero-status-live')).toBeVisible();
   });
 
-  test('clicking a phase tab lazy-loads the phase panel via htmx', async ({ page, request }) => {
+  test('after start + round generation, bracket section renders matches and schedule lists pending', async ({ page, request }) => {
     const eid = await createTournament(request);
-    await configureSwissPhase(request, eid);
+    await configureSinglePhase(request, eid);
     await enter(request, eid, 'dev-admin');
     await enter(request, eid, 'dev-player-one');
     await startTournament(request, eid);
     await generateRound(request, eid);
 
     await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/index.html`);
-    await expect(page.locator('#panel-phase-0')).toBeHidden();
 
-    await page.locator('#tab-phase-0').click();
+    await expect(page.locator('h3', { hasText: 'Bracket' })).toBeVisible();
+    await expect(page.locator('.bracket-col-label')).toHaveText('Final');
+    await expect(page.locator('.bracket-slot', { hasText: 'dev-admin' })).toBeVisible();
 
-    await expect(page.locator('#tab-phase-0')).toHaveAttribute('aria-selected', 'true');
-    await expect(page.locator('#panel-phase-0')).toBeVisible();
-    await expect(page.locator('#panel-phase-0 table')).toBeVisible();
-    await expect(page.locator('#panel-phase-0 .tourney-match-list')).toBeVisible();
-    await expect(page.locator('#tab-entrants')).toHaveAttribute('aria-selected', 'false');
-    await expect(page.locator('#panel-entrants')).toBeHidden();
+    await expect(page.locator('h3', { hasText: 'Schedule' })).toBeVisible();
+    await expect(page.locator('.schedule-row.schedule-row--next')).toBeVisible();
   });
 });

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -556,7 +556,15 @@
               ;; Generate next round in current phase
               :else
               (let [format    (or (:format round-config) 1)
-                    pairings  (generate-pairings (:phase-type phase) (:standings state) all-matches qualified)
+                    pairings  (if (and (= "single-elimination" (:phase-type phase))
+                                       (pos? next-round))
+                                ;; Subsequent SE rounds advance the bracket
+                                ;; from the previous round's winners; only
+                                ;; round 0 seeds from standings.
+                                (rules/advance-winners-bracket-round
+                                 (filter #(= (dec next-round) (:round-index %))
+                                         phase-matches))
+                                (generate-pairings (:phase-type phase) (:standings state) all-matches qualified))
                     matches   (create-round-matches dependencies tournament-eid phase-index next-round "winners" format pairings)
                     new-state (update-in state [:phases phase-index :rounds next-round]
                                          assoc :match-eids (mapv :eid matches)

--- a/components/rts-web/resources/rts-web/asset/style/app.css
+++ b/components/rts-web/resources/rts-web/asset/style/app.css
@@ -2096,10 +2096,6 @@ h3.draft-category-header {
   white-space: nowrap;
 }
 
-.standings-table thead th[scope="col"]:not(:first-child) {
-  text-align: right;
-}
-
 .standings-table tbody td {
   padding: var(--space-2) var(--space-4);
   border-bottom: 1px solid
@@ -2117,7 +2113,6 @@ h3.draft-category-header {
 }
 
 .standings-table tbody td:not(:first-child) {
-  text-align: right;
   color: var(--color-text);
 }
 
@@ -2493,3 +2488,627 @@ h3.draft-category-header {
 .pm-draft-unit-mark--tzeentch { --mark-fg: #4ea3e8; --mark-bg-edge: #143e6b; }
 .unit-mark--undivided,
 .pm-draft-unit-mark--undivided { --mark-fg: #9c8c63; --mark-bg-edge: #3b2f18; }
+
+/* ============================================================================
+   TOURNAMENT VIEWER — hero, bracket, standings, schedule
+   ============================================================================ */
+
+.viewer-page {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-height: 100%;
+}
+
+/* --- Hero ---------------------------------------------------------------- */
+
+.viewer-hero {
+  position: relative;
+  padding: var(--space-6) var(--space-8) var(--space-5);
+  background:
+    radial-gradient(ellipse 70% 130% at 90% 50%, color-mix(in srgb, var(--color-primary-600) 8%, transparent) 0%, transparent 70%),
+    linear-gradient(180deg, color-mix(in srgb, var(--color-primary-700) 5%, var(--color-bg)) 0%, var(--color-bg) 100%);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-primary-500) 22%, transparent);
+  overflow: hidden;
+}
+.viewer-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 60% 100% at 95% 50%, transparent 48%, color-mix(in srgb, var(--color-primary-600) 12%, transparent) 48.3%, transparent 49.2%),
+    radial-gradient(ellipse 60% 100% at 95% 50%, transparent 62%, color-mix(in srgb, var(--color-primary-600) 10%, transparent) 62.3%, transparent 63.2%),
+    radial-gradient(ellipse 60% 100% at 95% 50%, transparent 78%, color-mix(in srgb, var(--color-primary-600) 8%, transparent) 78.3%, transparent 79.2%);
+  pointer-events: none;
+  z-index: 0;
+}
+.viewer-hero-inner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-8);
+  align-items: end;
+  width: 100%;
+  max-width: 92rem;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+.viewer-hero-left { min-width: 0; }
+
+.viewer-hero-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+  flex-wrap: wrap;
+}
+.viewer-hero-status-live {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 4px var(--space-3);
+  background: var(--color-danger-500);
+  color: var(--color-neutral-900);
+  font-family: var(--font-family-heading);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  border: 1px solid color-mix(in srgb, var(--color-danger-400) 70%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--color-danger-500) 40%, transparent),
+    0 0 12px -1px color-mix(in srgb, var(--color-danger-500) 60%, transparent);
+  animation: viewer-pulse-live 2.2s ease-in-out infinite;
+  white-space: nowrap;
+}
+.viewer-hero-status-live::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-neutral-900);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--color-primary-700) 80%, transparent);
+}
+.viewer-hero-status-live--reg {
+  background: var(--color-primary-600);
+  border-color: color-mix(in srgb, var(--color-primary-500) 70%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--color-primary-500) 40%, transparent),
+    0 0 12px -1px color-mix(in srgb, var(--color-primary-500) 60%, transparent);
+  animation: none;
+}
+.viewer-hero-status-live--done {
+  background: transparent;
+  border-color: var(--color-border);
+  color: var(--color-text-muted);
+  box-shadow: none;
+  animation: none;
+}
+.viewer-hero-status-live--done::before { background: var(--color-text-muted); box-shadow: none; }
+@keyframes viewer-pulse-live {
+  0%, 100% {
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--color-danger-500) 40%, transparent),
+      0 0 12px -1px color-mix(in srgb, var(--color-danger-500) 60%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--color-danger-500) 80%, transparent),
+      0 0 24px 0 color-mix(in srgb, var(--color-danger-500) 70%, transparent);
+  }
+}
+.viewer-hero-status-phase {
+  font-family: var(--font-family-heading);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+.viewer-hero-status-phase strong { color: var(--color-primary-700); font-weight: 600; }
+
+.viewer-hero-title {
+  font-family: var(--font-family-heading);
+  font-size: clamp(2rem, 4.2vw, 3.25rem);
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  line-height: 1.05;
+  margin: 0;
+  color: var(--color-text-strong);
+  text-shadow: 0 1px 0 #000, 0 0 30px color-mix(in srgb, var(--color-primary-500) 15%, transparent);
+  text-wrap: balance;
+}
+.viewer-hero-subtitle {
+  font-family: var(--font-family-base);
+  font-size: 1rem;
+  color: var(--color-text-muted);
+  margin: var(--space-3) 0 var(--space-4);
+  max-width: 60ch;
+}
+
+.viewer-hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-5) var(--space-6);
+  align-items: flex-end;
+}
+.viewer-hero-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.viewer-hero-meta-label {
+  font-family: var(--font-family-heading);
+  font-size: 0.6rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+.viewer-hero-meta-value {
+  font-family: var(--font-family-heading);
+  font-size: 1rem;
+  color: var(--color-text-strong);
+  font-variant-numeric: tabular-nums lining-nums;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+.viewer-hero-meta-value--link {
+  color: var(--color-primary-700);
+  text-decoration: none;
+}
+.viewer-hero-meta-value--link:hover { color: var(--color-primary-800); text-decoration: underline; }
+
+.viewer-hero-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-3);
+}
+.viewer-hero-roles {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  align-items: flex-end;
+}
+.viewer-hero-roles-label {
+  font-family: var(--font-family-heading);
+  font-size: 0.6rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+.viewer-role-links {
+  display: flex;
+  gap: var(--space-2);
+}
+.viewer-role-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: color-mix(in srgb, var(--color-primary-500) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-primary-500) 30%, transparent);
+  font-family: var(--font-family-heading);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-primary-800);
+  cursor: pointer;
+  text-decoration: none;
+  transition: all var(--transition-fast);
+}
+.viewer-role-link:hover {
+  background: color-mix(in srgb, var(--color-primary-500) 12%, transparent);
+  border-color: var(--color-primary-600);
+  color: var(--color-primary-900);
+}
+.viewer-role-link--disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.viewer-role-link--disabled:hover {
+  background: color-mix(in srgb, var(--color-primary-500) 6%, transparent);
+  border-color: color-mix(in srgb, var(--color-primary-500) 30%, transparent);
+  color: var(--color-primary-800);
+}
+.viewer-role-link-icon {
+  font-size: 0.6rem;
+  color: var(--color-primary-600);
+}
+
+/* --- Body and sections --------------------------------------------------- */
+
+.viewer-body {
+  padding: var(--space-6) var(--space-8);
+  width: 100%;
+  max-width: 92rem;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  box-sizing: border-box;
+}
+
+.section-header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-primary-500) 22%, var(--color-border));
+  position: relative;
+  flex-wrap: wrap;
+}
+.section-header::before {
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 80px;
+  height: 2px;
+  background: var(--color-primary-600);
+}
+.section-header-title {
+  font-family: var(--font-family-heading);
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-strong);
+  margin: 0;
+}
+.section-header-subtitle {
+  font-family: var(--font-family-mono);
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+/* --- Bracket ------------------------------------------------------------ */
+
+.bracket {
+  position: relative;
+  display: grid;
+  /* grid-template-columns / -rows come from inline style on the bracket
+     element so the layout can be SE (single row of N) or DE (two rows
+     where Losers Semis stack under Semifinals, Losers Final stacks
+     under Winners Final, and Grand Final spans both rows at the right). */
+  gap: var(--space-5) var(--space-6);
+  padding: var(--space-4);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-primary-600) 3%, var(--color-surface)) 0%, var(--color-surface) 100%);
+  border: 1px solid var(--color-border);
+  overflow-x: auto;
+  min-width: 0;
+}
+.bracket-col {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  justify-content: center;
+}
+.bracket-divider {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  align-self: center;
+  height: 0;
+  border-top: 1px dashed color-mix(in srgb, var(--color-primary-500) 35%, var(--color-border));
+}
+
+/* Connector-line SVG overlay drawn over the bracket grid. The JS at the
+   bottom of viewer-bracket.html sizes the viewBox to the grid's actual
+   pixel dimensions; this rule just positions it and pipes colour
+   through `color`. */
+.bracket-connector-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  color: color-mix(in srgb, var(--color-primary-600) 75%, var(--color-border));
+  z-index: 0;
+}
+.bracket-connector-svg path.is-winner {
+  stroke: var(--color-primary-500);
+  stroke-width: 2;
+  opacity: 0.9;
+}
+.bracket-col {
+  position: relative;
+  z-index: 1;
+}
+.bracket-col-label {
+  font-family: var(--font-family-heading);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-primary-700);
+  text-align: center;
+  margin-bottom: var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-primary-500) 25%, transparent);
+}
+.bracket-col-matches {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  justify-content: space-around;
+  gap: var(--space-4);
+}
+
+.bracket-match {
+  position: relative;
+  background: color-mix(in srgb, var(--color-neutral-100) 80%, var(--color-surface));
+  border: 1px solid var(--color-border);
+  min-width: 11rem;
+}
+.bracket-match--pending {
+  border-color: color-mix(in srgb, var(--color-primary-500) 35%, var(--color-border));
+}
+.bracket-match--complete {
+  border-color: color-mix(in srgb, var(--color-success-500) 35%, var(--color-border));
+}
+.bracket-match--tbd {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--color-border) 60%, transparent);
+  opacity: 0.78;
+}
+
+.bracket-match-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px var(--space-3);
+  font-family: var(--font-family-heading);
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  background: color-mix(in srgb, var(--color-primary-500) 6%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-primary-500) 18%, var(--color-border));
+  color: var(--color-text-muted);
+}
+.bracket-match-head-label { color: var(--color-text); }
+.bracket-match-head-format { font-family: var(--font-family-mono); }
+
+.bracket-match-status {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-2);
+  padding: 4px var(--space-3);
+  font-family: var(--font-family-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+.bracket-match-status-primary { color: var(--color-text); }
+.bracket-match-status-secondary { color: var(--color-text-muted); }
+
+.bracket-slot {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-2);
+  align-items: center;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
+  font-family: var(--font-family-mono);
+  font-size: 0.82rem;
+  color: var(--color-text);
+}
+.bracket-slot:last-of-type { border-bottom: none; }
+.bracket-slot-handle {
+  font-size: 0.85rem;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.bracket-slot-score {
+  font-family: var(--font-family-heading);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums lining-nums;
+  color: var(--color-text-muted);
+  min-width: 1rem;
+  text-align: right;
+}
+.bracket-slot--winner {
+  background: color-mix(in srgb, var(--color-primary-500) 8%, transparent);
+}
+.bracket-slot--winner .bracket-slot-handle {
+  color: var(--color-primary-800);
+  font-weight: 600;
+}
+.bracket-slot--winner .bracket-slot-score { color: var(--color-primary-700); }
+.bracket-slot--tbd .bracket-slot-handle { color: var(--color-text-muted); font-style: italic; }
+.bracket-slot--bye .bracket-slot-handle { color: var(--color-text-muted); }
+
+/* --- Standings + Schedule strip ----------------------------------------- */
+
+.viewer-strip {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: var(--space-6);
+}
+@media (max-width: 1180px) {
+  .viewer-strip { grid-template-columns: 1fr; }
+}
+
+.standings-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-family: var(--font-family-base);
+}
+.standings-table thead th {
+  font-family: var(--font-family-heading);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-primary-500) 25%, var(--color-border));
+}
+/* table-layout: fixed holds col-num and col-record at their declared widths
+   so col-player absorbs the remainder. table. prefix beats the older theme
+   rules. */
+table.standings-table { table-layout: fixed; }
+table.standings-table thead th.col-num { text-align: left; width: 3rem; }
+table.standings-table thead th.col-player,
+table.standings-table tbody td.col-player { text-align: left; padding-left: 0; width: auto; }
+table.standings-table thead th.col-record,
+table.standings-table tbody td.col-record { text-align: left; width: 6rem; }
+table.standings-table thead th.col-status,
+table.standings-table tbody td.col-status { text-align: left; width: 8rem; }
+/* Override the theme's wide first-column padding so the roman-numeral
+   col-num cell stays compact. table. prefix bumps specificity past
+   warhammer3-app.css's .standings-table td:first-child rule. */
+table.standings-table tbody tr td.col-num {
+  width: 2rem;
+  padding-left: 0;
+  padding-right: 0;
+}
+table.standings-table tbody tr td.col-num::before {
+  left: var(--space-3);
+  width: auto;
+  text-align: left;
+}
+.standings-table tbody td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 50%, transparent);
+  font-size: 0.88rem;
+  color: var(--color-text);
+}
+.standings-table tbody tr.standings-row--advanced td {
+  background: color-mix(in srgb, var(--color-primary-500) 4%, transparent);
+}
+.standings-table td.col-num {
+  text-align: left;
+  font-family: var(--font-family-heading);
+  font-weight: 700;
+  color: var(--color-primary-700);
+}
+.standings-table td.col-record {
+  text-align: left;
+  font-family: var(--font-family-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text);
+}
+.standings-table td.col-status { text-align: left; }
+.standings-handle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.standings-handle-text {
+  font-family: var(--font-family-mono);
+  font-size: 0.86rem;
+  color: inherit;
+}
+.standings-status {
+  font-family: var(--font-family-heading);
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 2px var(--space-2);
+  border: 1px solid currentColor;
+  white-space: nowrap;
+}
+.standings-status--alive { color: var(--color-primary-700); }
+
+.schedule-list {
+  display: flex;
+  flex-direction: column;
+}
+.schedule-row {
+  display: grid;
+  grid-template-columns: 7rem 1fr auto;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3) var(--space-2);
+  border-bottom: 1px dashed color-mix(in srgb, var(--color-border) 70%, transparent);
+}
+.schedule-row:last-child { border-bottom: none; }
+.schedule-time {
+  font-family: var(--font-family-mono);
+  font-size: 0.84rem;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+.schedule-time-label {
+  display: block;
+  font-family: var(--font-family-heading);
+  font-size: 0.58rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+.schedule-match {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.schedule-match-pair {
+  font-family: var(--font-family-mono);
+  font-size: 0.86rem;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.schedule-match-pair-vs {
+  color: var(--color-text-muted);
+  margin: 0 var(--space-2);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.schedule-match-meta {
+  font-family: var(--font-family-mono);
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+}
+.schedule-state {
+  font-family: var(--font-family-heading);
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 2px var(--space-2);
+  border: 1px solid currentColor;
+  white-space: nowrap;
+}
+.schedule-state--next { color: var(--color-primary-700); }
+.schedule-state--upcoming { color: var(--color-text-muted); }
+.schedule-row--next { background: color-mix(in srgb, var(--color-primary-500) 4%, transparent); }
+
+/* --- Entry + organizer panels at page bottom ---------------------------- */
+
+.viewer-action-card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  background: color-mix(in srgb, var(--color-primary-500) 4%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-primary-500) 22%, var(--color-border));
+  border-left: 3px solid var(--color-primary-600);
+  flex-wrap: wrap;
+}
+.viewer-action-card-text {
+  flex: 1;
+  font-size: 0.92rem;
+  color: var(--color-text);
+}
+.viewer-action-card-text.muted { color: var(--color-text-muted); }
+.viewer-action .entry-error {
+  flex-basis: 100%;
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-danger-400);
+  border: 1px solid color-mix(in srgb, var(--color-danger-500) 50%, transparent);
+  background: color-mix(in srgb, var(--color-danger-500) 6%, transparent);
+}
+
+.muted { color: var(--color-text-muted); }

--- a/components/rts-web/resources/rts-web/components/tournament/viewer-bracket.html
+++ b/components/rts-web/resources/rts-web/components/tournament/viewer-bracket.html
@@ -1,0 +1,176 @@
+{# Renders a grid-positioned bracket from `cells` (decorated round
+   groups with :grid-style, :column-label, :matches). Caller supplies
+   `cols` and `rows` for the grid template.
+
+   The matching JS at the bottom draws SVG connector lines between
+   matches in adjacent grid columns. It uses getBoundingClientRect for
+   accurate placement against the grid's auto-sized rows, and re-runs
+   on container resize. #}
+<div class="bracket" style="grid-template-columns: repeat({{cols}}, minmax(13rem, 1fr)); grid-template-rows: repeat({{rows}}, auto);">
+    {% if divider? %}<div class="bracket-divider" aria-hidden="true"></div>{% endif %}
+    {% for cell in cells %}
+    <div class="bracket-col"
+         style="{{cell.grid-style}}"
+         data-bracket-col="{{cell.bracket-col}}"
+         data-bracket-row="{{cell.bracket-row}}"
+         data-bracket-row-span="{{cell.bracket-row-span}}">
+        {% if cell.column-label %}<div class="bracket-col-label">{{cell.column-label}}</div>{% endif %}
+        <div class="bracket-col-matches">
+            {% for match in cell.matches %}
+            <div class="bracket-match{% ifequal match.status "complete" %} bracket-match--complete{% endifequal %}{% ifequal match.status "pending" %} bracket-match--pending{% endifequal %}{% if match.placeholder? %} bracket-match--tbd{% endif %}"
+                 data-match-id="{{match.eid}}">
+                <div class="bracket-match-head">
+                    <span class="bracket-match-head-label">{{match.match-label}}</span>
+                    <span class="bracket-match-head-format">Bo{{match.format}}</span>
+                </div>
+                <div class="bracket-slot{% if match.p1-winner? %} bracket-slot--winner{% endif %}{% if match.p1-tbd? %} bracket-slot--tbd{% endif %}">
+                    <span class="bracket-slot-handle">{% if match.player-one-sub %}{{match.player-one-sub}}{% else %}TBD{% endif %}</span>
+                    <span class="bracket-slot-score">{% if match.placeholder? %}·{% else %}{{match.p1-games-won}}{% endif %}</span>
+                </div>
+                <div class="bracket-slot{% if match.p2-winner? %} bracket-slot--winner{% endif %}{% if match.p2-tbd? %} bracket-slot--tbd{% endif %}{% if match.p2-bye? %} bracket-slot--bye{% endif %}">
+                    <span class="bracket-slot-handle">{% if match.player-two-sub %}{{match.player-two-sub}}{% elif match.p2-bye? %}<em>bye</em>{% else %}TBD{% endif %}</span>
+                    <span class="bracket-slot-score">{% if match.placeholder? %}·{% else %}{{match.p2-games-won}}{% endif %}</span>
+                </div>
+                <div class="bracket-match-status">
+                    <span class="bracket-match-status-primary">{{match.status-primary}}</span>
+                    <span class="bracket-match-status-secondary">{{match.status-secondary}}</span>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endfor %}
+</div>
+
+<script>
+(function () {
+  // Idempotent: bail if this page already wired the connector logic.
+  if (window.__rtsBracketConnectorsInitialized) return;
+  window.__rtsBracketConnectorsInitialized = true;
+
+  const SVG_NS = "http://www.w3.org/2000/svg";
+
+  function cellPos(cell) {
+    return {
+      col: parseInt(cell.dataset.bracketCol, 10),
+      row: parseInt(cell.dataset.bracketRow, 10),
+      span: parseInt(cell.dataset.bracketRowSpan || "1", 10),
+    };
+  }
+
+  function midRect(rect, originRect) {
+    return {
+      left: rect.left - originRect.left,
+      right: rect.right - originRect.left,
+      midY: rect.top + rect.height / 2 - originRect.top,
+    };
+  }
+
+  function findNextCell(cells, fromCol, fromRow) {
+    // Prefer a same-row cell at col+1. Otherwise any cell at col+1 whose
+    // row-span overlaps fromRow (e.g. the Grand Final cell spanning rows 1-3).
+    const exact = cells.find(c => {
+      const p = cellPos(c);
+      return p.col === fromCol + 1 && p.row === fromRow;
+    });
+    if (exact) return exact;
+    return cells.find(c => {
+      const p = cellPos(c);
+      return p.col === fromCol + 1 && p.row <= fromRow && (p.row + p.span - 1) >= fromRow;
+    });
+  }
+
+  function buildPathsForBracket(bracket) {
+    const bRect = bracket.getBoundingClientRect();
+    const cells = Array.from(bracket.querySelectorAll('.bracket-col[data-bracket-col]'));
+    const paths = [];
+
+    cells.forEach(cell => {
+      const { col, row } = cellPos(cell);
+      if (Number.isNaN(col) || Number.isNaN(row)) return;
+      const matches = Array.from(cell.querySelectorAll('.bracket-match'));
+      if (matches.length === 0) return;
+      const next = findNextCell(cells, col, row);
+      if (!next) return;
+      const dests = Array.from(next.querySelectorAll('.bracket-match'));
+      if (dests.length === 0) return;
+
+      const src = matches.map(m => midRect(m.getBoundingClientRect(), bRect));
+      const dst = dests.map(m => midRect(m.getBoundingClientRect(), bRect));
+      const isComplete = i => matches[i].classList.contains('bracket-match--complete');
+
+      if (src.length === 2 * dst.length) {
+        // pair-up: every pair of source matches feeds one dest match
+        for (let i = 0; i < dst.length; i++) {
+          const s1 = src[i * 2];
+          const s2 = src[i * 2 + 1];
+          const d = dst[i];
+          const midX = (s1.right + d.left) / 2;
+          paths.push({d: `M ${s1.right} ${s1.midY} H ${midX} V ${d.midY} H ${d.left}`, winner: isComplete(i * 2)});
+          paths.push({d: `M ${s2.right} ${s2.midY} H ${midX} V ${d.midY}`,           winner: isComplete(i * 2 + 1)});
+        }
+      } else if (src.length === dst.length) {
+        // 1-to-1: simple L-shape per match
+        for (let i = 0; i < src.length; i++) {
+          const s = src[i];
+          const d = dst[i];
+          const midX = (s.right + d.left) / 2;
+          paths.push({d: `M ${s.right} ${s.midY} H ${midX} V ${d.midY} H ${d.left}`, winner: isComplete(i)});
+        }
+      } else if (src.length === 1) {
+        // single source fanning into multiple dests — unusual but handle
+        const s = src[0];
+        const winner = isComplete(0);
+        dst.forEach(d => {
+          const midX = (s.right + d.left) / 2;
+          paths.push({d: `M ${s.right} ${s.midY} H ${midX} V ${d.midY} H ${d.left}`, winner});
+        });
+      }
+    });
+
+    return { paths, width: bRect.width, height: bRect.height };
+  }
+
+  function renderConnectors(bracket) {
+    let svg = bracket.querySelector(':scope > svg.bracket-connector-svg');
+    if (!svg) {
+      svg = document.createElementNS(SVG_NS, 'svg');
+      svg.setAttribute('class', 'bracket-connector-svg');
+      svg.setAttribute('aria-hidden', 'true');
+      bracket.insertBefore(svg, bracket.firstChild);
+    }
+    const { paths, width, height } = buildPathsForBracket(bracket);
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.setAttribute('width', width);
+    svg.setAttribute('height', height);
+    svg.innerHTML = paths
+      .map(p => `<path d="${p.d}" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round"${p.winner ? ' class="is-winner"' : ''} />`)
+      .join('');
+  }
+
+  function wireBracket(bracket) {
+    if (bracket.dataset.connectorsWired === '1') return;
+    bracket.dataset.connectorsWired = '1';
+    const run = () => renderConnectors(bracket);
+    run();
+    // Re-run after layout settles + on resize.
+    setTimeout(run, 100);
+    if (window.ResizeObserver) {
+      new ResizeObserver(run).observe(bracket);
+    }
+    window.addEventListener('resize', run);
+  }
+
+  function wireAll() {
+    document.querySelectorAll('.bracket').forEach(wireBracket);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', wireAll);
+  } else {
+    wireAll();
+  }
+  // Re-scan when HTMX swaps content back in.
+  document.body.addEventListener('htmx:afterSwap', wireAll);
+})();
+</script>

--- a/components/rts-web/resources/rts-web/view/tournament-index.html
+++ b/components/rts-web/resources/rts-web/view/tournament-index.html
@@ -2,217 +2,231 @@
 
 {% block title %}{{data.name}} | {{game.name}} | RTS-UI{% endblock %}
 
-{% block page-styles %}
-<link rel="preload" href="/style/post-match.css" as="style" onload="this.onload=null;this.rel='stylesheet'"/>
-<noscript><link rel="stylesheet" href="/style/post-match.css"/></noscript>
-{% endblock %}
-
 {% block content %}
-<div id="tournament-stage" class="tourney-page">
+<div id="tournament-stage" class="viewer-page">
 
     <!-- ═══════════════════════════════════════════════════════════════ -->
     <!-- Hero                                                           -->
     <!-- ═══════════════════════════════════════════════════════════════ -->
-    <header class="tourney-hero" aria-labelledby="tournament-heading">
-        <div class="tourney-hero-inner">
-            <div>
-                <div class="cluster cluster-2" style="align-items: center; gap: var(--space-3);">
-                    <h2 id="tournament-heading" class="tourney-hero-title">{{data.name}}</h2>
-                    <span class="badge
-                        {% ifequal tournament-state.status "registration" %}badge-primary{% endifequal %}
-                        {% ifequal tournament-state.status "active" %}badge-success{% endifequal %}
-                        {% ifequal tournament-state.status "complete" %}badge-danger{% endifequal %}
-                        {% ifequal tournament-state.status "cancelled" %}badge-danger{% endifequal %}
-                    ">{{tournament-state.status}}</span>
+    <header class="viewer-hero" aria-labelledby="tournament-heading">
+        <div class="viewer-hero-inner">
+            <div class="viewer-hero-left">
+                <div class="viewer-hero-status">
+                    {% ifequal tournament-state.status "active" %}
+                    <span class="viewer-hero-status-live">Live</span>
+                    {% endifequal %}
+                    {% ifequal tournament-state.status "registration" %}
+                    <span class="viewer-hero-status-live viewer-hero-status-live--reg">Registration</span>
+                    {% endifequal %}
+                    {% ifequal tournament-state.status "complete" %}
+                    <span class="viewer-hero-status-live viewer-hero-status-live--done">Complete</span>
+                    {% endifequal %}
+                    {% ifequal tournament-state.status "cancelled" %}
+                    <span class="viewer-hero-status-live viewer-hero-status-live--done">Cancelled</span>
+                    {% endifequal %}
+                    {% if current-phase-label %}
+                    <span class="viewer-hero-status-phase">
+                        Phase {{tournament-state.current-phase|add:1}} of {{phase-count}} ·
+                        <strong>{{current-phase-label}}</strong>
+                        {% if current-round-label %} · {{current-round-label}}{% endif %}
+                    </span>
+                    {% endif %}
+                </div>
+                <h2 id="tournament-heading" class="viewer-hero-title">{{data.name}}</h2>
+                {% if data.description %}
+                <p class="viewer-hero-subtitle">{{data.description}}</p>
+                {% endif %}
+                <div class="viewer-hero-meta">
+                    <div class="viewer-hero-meta-item">
+                        <span class="viewer-hero-meta-label">Hosted by</span>
+                        <span class="viewer-hero-meta-value">{{data.created-by-sub}}</span>
+                    </div>
                     {% if league %}
-                    <a class="badge badge-league"
-                       href="/view/game/{{game-eid}}/league/{{league.eid}}/index.html"
-                       title="Part of league {{league.name}}">
-                        {{league.name}}{% if season %} · {{season.display-name}}{% endif %}
+                    <div class="viewer-hero-meta-item">
+                        <span class="viewer-hero-meta-label">League</span>
+                        <a class="viewer-hero-meta-value viewer-hero-meta-value--link"
+                           href="/view/game/{{game-eid}}/league/{{league.eid}}/index.html">
+                            {{league.name}}{% if season %} · {{season.display-name}}{% endif %}
+                        </a>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+
+            {% if any has-entry is-organizer %}
+            <div class="viewer-hero-right">
+                <div class="viewer-role-links">
+                    {% if has-entry %}
+                    <a class="viewer-role-link viewer-role-link--disabled"
+                       aria-disabled="true"
+                       title="Player console — coming soon">
+                        <span class="viewer-role-link-icon" aria-hidden="true">▶</span>
+                        Player Console
+                    </a>
+                    {% endif %}
+                    {% if is-organizer %}
+                    <a class="viewer-role-link viewer-role-link--disabled"
+                       aria-disabled="true"
+                       title="Organizer console — coming soon">
+                        <span class="viewer-role-link-icon" aria-hidden="true">⚙</span>
+                        Organizer Console
                     </a>
                     {% endif %}
                 </div>
-                <p class="tourney-hero-desc">{{data.description}}</p>
             </div>
+            {% endif %}
         </div>
     </header>
 
-    <div class="tourney-body">
+    <div class="viewer-body">
 
-        <!-- ═══════════════════════════════════════════════════════════ -->
-        <!-- Sidebar: Status, Registration, Actions                     -->
-        <!-- ═══════════════════════════════════════════════════════════ -->
-        <aside class="tourney-sidebar" aria-label="Tournament info">
-
-            <!-- Registration card -->
-            <div class="tourney-info-card">
-                <div class="tourney-info-card-header">Registration</div>
-                <div class="tourney-info-card-body">
-                    <dl class="tourney-dl">
-                        {% if tournament-state.registration.opens-at %}
-                        <dt>Opens</dt>
-                        <dd>{{tournament-state.registration.opens-at}}</dd>
-                        {% endif %}
-                        {% if tournament-state.registration.closes-at %}
-                        <dt>Closes</dt>
-                        <dd>{{tournament-state.registration.closes-at}}</dd>
-                        {% endif %}
-                        {% if tournament-state.registration.timezone %}
-                        <dt>Timezone</dt>
-                        <dd>{{tournament-state.registration.timezone}}</dd>
-                        {% endif %}
-                        {% if tournament-state.registration.closed-early %}
-                        <dt>Early Close</dt>
-                        <dd><span class="badge badge-warning">Closed early</span></dd>
-                        {% endif %}
-                    </dl>
-                </div>
-            </div>
-
-            <!-- Player action -->
-            {% if session %}
-            {% ifequal tournament-state.status "registration" %}
-            <div class="tourney-info-card">
-                <div class="tourney-info-card-header">Your Entry</div>
-                <div class="tourney-info-card-body">
-                    {% if has-entry %}
-                    <p style="margin-bottom: var(--space-3);">You are registered.</p>
-                    <form hx-delete="/actions/tournament/{{data.eid}}/entry/me" hx-swap="none">
-                        <button type="submit" class="btn btn-danger btn-sm" style="width:100%;">Withdraw</button>
-                    </form>
-                    {% elif registration-open %}
-                    <form hx-post="/actions/tournament/{{data.eid}}/entry/me" hx-swap="none">
-                        <button type="submit" class="btn btn-primary" style="width:100%;">Enter Tournament</button>
-                    </form>
+        <!-- ─── Bracket ─── -->
+        {% for phase-group in matches-by-phase %}
+        {% if phase-group.bracket-cells|not-empty? %}
+        <section aria-labelledby="bracket-{{phase-group.phase}}-heading">
+            <header class="section-header">
+                <h3 class="section-header-title" id="bracket-{{phase-group.phase}}-heading">
+                    {% if single-phase? %}
+                        {% ifequal phase-group.phase-type "swiss" %}Rounds{% endifequal %}
+                        {% ifequal phase-group.phase-type "round-robin" %}Rounds{% endifequal %}
+                        {% ifequal phase-group.phase-type "single-elimination" %}Bracket{% endifequal %}
+                        {% ifequal phase-group.phase-type "double-elimination" %}Bracket{% endifequal %}
                     {% else %}
-                    <p class="tourney-closed-msg">Registration is closed.</p>
+                        Phase {{phase-group.phase|add:1}}
                     {% endif %}
-                    <div id="entry-error" class="entry-error" role="alert" aria-live="assertive" hidden></div>
-                </div>
-            </div>
-            {% endifequal %}
-            {% endif %}
+                </h3>
+            </header>
+            {% with cells=phase-group.bracket-cells cols=phase-group.bracket-cols rows=phase-group.bracket-rows divider?=phase-group.bracket-divider? %}{% include "rts-web/components/tournament/viewer-bracket.html" %}{% endwith %}
+        </section>
+        {% endif %}
+        {% endfor %}
 
-            <!-- Phase config display -->
-            {% if tournament-state.phases|not-empty? %}
-            <div class="tourney-info-card">
-                <div class="tourney-info-card-header">Phases</div>
-                <div class="tourney-info-card-body">
-                    {% for phase in tournament-state.phases %}
-                    <div class="tourney-phase-item {% ifequal forloop.counter0 tournament-state.current-phase %}tourney-phase-item--active{% endifequal %}">
-                        <span class="tourney-phase-label">{{phase.phase-type}}</span>
-                        <span class="tourney-phase-rounds">{{phase.rounds|length}} rounds</span>
+        <!-- ─── Standings + Schedule ─── -->
+        <section class="viewer-strip" aria-labelledby="standings-heading schedule-heading">
+            <div>
+                <header class="section-header">
+                    <h3 class="section-header-title" id="standings-heading">Standings</h3>
+                    <span class="section-header-subtitle">
+                        {% if tournament-state.qualifier-count %}Top {{tournament-state.qualifier-count}} advance{% else %}{{entries|length}} entrants{% endif %}
+                    </span>
+                </header>
+                {% if tournament-state.standings|not-empty? %}
+                <table class="standings-table">
+                    <caption class="sr-only">Tournament standings sorted by points</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col" class="col-num">#</th>
+                            <th scope="col" class="col-player">Player</th>
+                            <th scope="col" class="col-record">Record</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for standing in tournament-state.standings %}
+                        <tr class="standings-row{% if standing.advanced? %} standings-row--advanced{% endif %}">
+                            <td class="col-num"></td>
+                            <td class="col-player">
+                                <span class="standings-handle">
+                                    <span class="standings-handle-text">{{standing.player-sub}}</span>
+                                </span>
+                            </td>
+                            <td class="col-record">{{standing.wins}}-{{standing.losses}}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                {% elif entries|not-empty? %}
+                <table class="standings-table">
+                    <caption class="sr-only">Tournament entrants</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col" class="col-num">#</th>
+                            <th scope="col" class="col-player">Player</th>
+                            <th scope="col" class="col-status">Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for entry in entries %}
+                        <tr class="standings-row standings-row--entry">
+                            <td class="col-num"></td>
+                            <td class="col-player">
+                                <span class="standings-handle">
+                                    <span class="standings-handle-text">{{entry.player-sub}}</span>
+                                </span>
+                            </td>
+                            <td class="col-status">
+                                <span class="standings-status standings-status--alive">Entered</span>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                {% else %}
+                <p class="muted">No entrants yet.</p>
+                {% endif %}
+            </div>
+            <div>
+                <header class="section-header">
+                    <h3 class="section-header-title" id="schedule-heading">Schedule</h3>
+                    <span class="section-header-subtitle">Pending matches</span>
+                </header>
+                {% if schedule|not-empty? %}
+                <div class="schedule-list">
+                    {% for s in schedule %}
+                    <div class="schedule-row{% if s.up-next? %} schedule-row--next{% else %} schedule-row--upcoming{% endif %}">
+                        <div class="schedule-time">
+                            <span class="schedule-time-label">{{s.phase-label}}</span>
+                            {{s.round-label}}
+                        </div>
+                        <div class="schedule-match">
+                            <div class="schedule-match-pair">
+                                {{s.player-one-sub}}
+                                <span class="schedule-match-pair-vs">vs</span>
+                                {% if s.player-two-sub %}{{s.player-two-sub}}{% else %}TBD{% endif %}
+                            </div>
+                            <div class="schedule-match-meta">Bo{{s.format}}</div>
+                        </div>
+                        <span class="schedule-state{% if s.up-next? %} schedule-state--next{% else %} schedule-state--upcoming{% endif %}">
+                            {% if s.up-next? %}Up Next{% else %}Scheduled{% endif %}
+                        </span>
                     </div>
                     {% endfor %}
-                    {% if tournament-state.qualifier-count %}
-                    <div class="tourney-qualifier-note">Top {{tournament-state.qualifier-count}} advance</div>
-                    {% endif %}
                 </div>
+                {% else %}
+                <p class="muted">No pending matches.</p>
+                {% endif %}
             </div>
-            {% endif %}
+        </section>
 
-            <!-- Organizer controls -->
-            {% if organizer-has-actions %}
-            <div class="tourney-info-card tourney-organizer-card">
-                <div class="tourney-info-card-header">Organizer Controls</div>
-                <div class="tourney-info-card-body stack stack-2">
-                    {% ifequal tournament-state.status "registration" %}
-                    <form hx-post="/actions/tournament/{{data.eid}}/close-registration" hx-swap="none">
-                        <button type="submit" class="btn btn-secondary btn-sm" style="width:100%;">Close Registration</button>
-                    </form>
-                    <form hx-post="/actions/tournament/{{data.eid}}/start" hx-swap="none">
-                        <button type="submit" class="btn btn-primary btn-sm" style="width:100%;">Start Tournament</button>
-                    </form>
-                    {% endifequal %}
-                    {% ifequal tournament-state.status "active" %}
-                    <form hx-post="/actions/tournament/{{data.eid}}/round" hx-swap="none">
-                        <button type="submit" class="btn btn-primary btn-sm" style="width:100%;">Generate Next Round</button>
-                    </form>
-                    <form hx-post="/actions/tournament/{{data.eid}}/complete" hx-swap="none">
-                        <button type="submit" class="btn btn-secondary btn-sm" style="width:100%;">Complete Tournament</button>
-                    </form>
-                    {% endifequal %}
-                    {% ifequal tournament-state.status "registration" %}
-                    <form hx-post="/actions/tournament/{{data.eid}}/cancel" hx-swap="none">
-                        <button type="submit" class="btn btn-danger btn-sm" style="width:100%;">Cancel Tournament</button>
-                    </form>
-                    {% endifequal %}
-                    {% ifequal tournament-state.status "active" %}
-                    <form hx-post="/actions/tournament/{{data.eid}}/cancel" hx-swap="none">
-                        <button type="submit" class="btn btn-danger btn-sm" style="width:100%;">Cancel Tournament</button>
-                    </form>
-                    {% endifequal %}
-                </div>
+        <!-- ─── Player entry action ─── -->
+        {% if session %}
+        {% ifequal tournament-state.status "registration" %}
+        <section class="viewer-action" aria-labelledby="entry-heading">
+            <header class="section-header">
+                <h3 class="section-header-title" id="entry-heading">Your Entry</h3>
+                <span class="section-header-subtitle">
+                    {% if tournament-state.registration.closes-at %}Closes {{tournament-state.registration.closes-at}}{% endif %}
+                </span>
+            </header>
+            <div class="viewer-action-card">
+                {% if has-entry %}
+                <div class="viewer-action-card-text">You are registered for this tournament.</div>
+                <form hx-delete="/actions/tournament/{{data.eid}}/entry/me" hx-swap="none">
+                    <button type="submit" class="btn btn-danger btn-sm">Withdraw</button>
+                </form>
+                {% elif registration-open %}
+                <div class="viewer-action-card-text">Registration is open.</div>
+                <form hx-post="/actions/tournament/{{data.eid}}/entry/me" hx-swap="none">
+                    <button type="submit" class="btn btn-primary">Enter Tournament</button>
+                </form>
+                {% else %}
+                <div class="viewer-action-card-text muted">Registration is closed.</div>
+                {% endif %}
+                <div id="entry-error" class="entry-error" role="alert" aria-live="assertive" hidden></div>
             </div>
-            {% endif %}
-        </aside>
+        </section>
+        {% endifequal %}
+        {% endif %}
 
-        <!-- ═══════════════════════════════════════════════════════════ -->
-        <!-- Main content: Standings, Matches, Entries                  -->
-        <!-- ═══════════════════════════════════════════════════════════ -->
-        <div class="tourney-main">
-
-            <div class="tourney-tabs" role="tablist" aria-label="Tournament sections">
-                <button type="button" role="tab" id="tab-entrants"
-                        aria-selected="true" aria-controls="panel-entrants"
-                        class="tourney-tab"
-                        _="on click
-                           add @hidden to <[role=tabpanel]/> in the closest .tourney-main
-                           then remove @hidden from #panel-entrants
-                           then set @aria-selected of <[role=tab]/> in my parentElement to 'false'
-                           then set my @aria-selected to 'true'">
-                    Entrants
-                </button>
-                {% for phase-group in matches-by-phase %}
-                <button type="button" role="tab" id="tab-phase-{{phase-group.phase}}"
-                        aria-selected="false" aria-controls="panel-phase-{{phase-group.phase}}"
-                        class="tourney-tab"
-                        hx-get="/components/tournament/{{data.eid}}/phase/{{phase-group.phase}}/phase-panel.html"
-                        hx-target="#panel-phase-{{phase-group.phase}}"
-                        hx-swap="innerHTML"
-                        _="on click
-                           add @hidden to <[role=tabpanel]/> in the closest .tourney-main
-                           then remove @hidden from #panel-phase-{{phase-group.phase}}
-                           then set @aria-selected of <[role=tab]/> in my parentElement to 'false'
-                           then set my @aria-selected to 'true'">
-                    Phase {{phase-group.phase|add:1}}
-                    <span class="tourney-tab-sub">{% ifequal phase-group.phase-type "single-elimination" %}Single Elimination{% endifequal %}{% ifequal phase-group.phase-type "double-elimination" %}Double Elimination{% endifequal %}{% ifequal phase-group.phase-type "swiss" %}Swiss{% endifequal %}{% ifequal phase-group.phase-type "round-robin" %}Round Robin{% endifequal %}</span>
-                </button>
-                {% endfor %}
-            </div>
-
-            <section id="panel-entrants" role="tabpanel" aria-labelledby="tab-entrants" class="tourney-tab-panel">
-                <section class="tourney-section" aria-labelledby="entries-heading">
-                    <h3 class="tourney-section-heading" id="entries-heading">
-                        Entries
-                        {% if entries %}<span class="tourney-entry-count">{{entries|length}}</span>{% endif %}
-                    </h3>
-                    {% if entries %}
-                    <ul class="tourney-entry-grid">
-                        {% for entry in entries %}
-                        <li class="tourney-entry-chip">
-                            <span class="tourney-entry-name">{{entry.player-sub}}</span>
-                        </li>
-                        {% endfor %}
-                    </ul>
-                    {% else %}
-                    <p class="tourney-empty-msg">No entries yet.</p>
-                    {% endif %}
-                </section>
-            </section>
-
-            {% for phase-group in matches-by-phase %}
-            <section id="panel-phase-{{phase-group.phase}}"
-                     role="tabpanel"
-                     aria-labelledby="tab-phase-{{phase-group.phase}}"
-                     class="tourney-tab-panel"
-                     hidden
-                     hx-get="/components/tournament/{{data.eid}}/phase/{{phase-group.phase}}/phase-panel.html"
-                     hx-trigger="match-recorded from:body"
-                     hx-swap="innerHTML"></section>
-            {% endfor %}
-
-        </div>
     </div>
 </div>
 {% endblock %}

--- a/components/rts-web/resources/rts-web/view/tournament-index.html
+++ b/components/rts-web/resources/rts-web/view/tournament-index.html
@@ -3,7 +3,12 @@
 {% block title %}{{data.name}} | {{game.name}} | RTS-UI{% endblock %}
 
 {% block content %}
-<div id="tournament-stage" class="viewer-page">
+<div id="tournament-stage" class="viewer-page"
+     hx-get="/view/game/{{game-eid}}/tournament/{{data.eid}}/index.html"
+     hx-trigger="{{ triggers.tournament-stage }}"
+     hx-target="this"
+     hx-swap="outerHTML"
+     hx-select="#tournament-stage">
 
     <!-- ═══════════════════════════════════════════════════════════════ -->
     <!-- Hero                                                           -->

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
@@ -115,38 +115,293 @@
      :headers {"Content-Type" "text/html; charset=utf-8"}
      :body    (render/render-component "tournament-round.html" {})}))
 
+(def ^:private phase-type-labels
+  {"single-elimination" "Single Elimination"
+   "double-elimination" "Double Elimination"
+   "swiss"              "Swiss"
+   "round-robin"        "Round Robin"})
+
+(defn- column-label
+  "Bracket column heading. Branches by bracket type so DE's losers/grand-final
+   rounds get appropriate labels instead of `Final` clashing with WB."
+  [bracket round-index total-rounds]
+  (let [distance-from-end (- (dec total-rounds) round-index)]
+    (case bracket
+      "grand-final" "Grand Final"
+      "losers"      (case distance-from-end
+                      0 "Losers Final"
+                      1 "Losers Semis"
+                      (str "Losers R" (inc round-index)))
+      "winners"     (case distance-from-end
+                      0 "Final"
+                      1 "Semifinals"
+                      2 "Quarterfinals"
+                      (str "Round " (inc round-index)))
+      ;; fallback for swiss/round-robin rounds rendered through this
+      ;; same helper.
+      (str "Round " (inc round-index)))))
+
+(defn- match-label
+  "Per-card label inside a bracket column."
+  [bracket round-index total-rounds match-position]
+  (let [distance-from-end (- (dec total-rounds) round-index)]
+    (case bracket
+      "grand-final" "GF"
+      "losers"      (str "LB R" (inc round-index) " M" match-position)
+      "winners"     (case distance-from-end
+                      0 "F"
+                      1 (str "SF " match-position)
+                      2 (str "QF " match-position)
+                      (str "R" (inc round-index) " M" match-position))
+      (str "R" (inc round-index) " M" match-position))))
+
+(defn- with-game-counts
+  "Adds :p1-games-won and :p2-games-won to a match by counting :winner-sub
+   in the match's games. Bracket cells display these instead of W/L."
+  [dependencies match]
+  (let [games (domain/get-games-for-match dependencies (:eid match))
+        wins  (frequencies (keep :winner-sub games))]
+    (assoc match
+           :p1-games-won (get wins (:player-one-sub match) 0)
+           :p2-games-won (get wins (:player-two-sub match) 0))))
+
+(defn- match-status-subheader
+  "Returns :status-primary + :status-secondary strings for a bracket match
+   based on its state. The viewer renders these as a two-line subfooter
+   under the card."
+  [{:keys [placeholder? p1-tbd? p2-tbd? p1-games-won p2-games-won status]}]
+  (let [games-played (+ (or p1-games-won 0) (or p2-games-won 0))
+        awaiting?    (or placeholder?
+                         (and (= "pending" status) (or p1-tbd? p2-tbd?)))]
+    (cond
+      awaiting?
+      {:status-primary "Awaiting bracket" :status-secondary "·"}
+
+      (= "complete" status)
+      {:status-primary "Final" :status-secondary "Settled"}
+
+      (and (= "pending" status) (pos? games-played))
+      {:status-primary (str "Game " (inc games-played)) :status-secondary "Live"}
+
+      :else
+      {:status-primary "Scheduled" :status-secondary "—"})))
+
+(defn- decorate-bracket-round
+  "Annotates one round of a bracket with the labels and per-match flags
+   the template needs (Selmer can't do arithmetic comparisons, so it all
+   has to be precomputed). `bracket` is `winners` / `losers` /
+   `grand-final` so column/match labels branch correctly for DE."
+  [bracket {:keys [round total-rounds matches] :as round-group}]
+  (assoc round-group
+         :column-label (column-label bracket round total-rounds)
+         :matches      (mapv (fn [position match]
+                               (let [p1         (:player-one-sub match)
+                                     p2         (:player-two-sub match)
+                                     winner     (:winner-sub match)
+                                     complete?  (= "complete" (:status match))
+                                     base-match (assoc match
+                                                       :match-label  (match-label bracket round total-rounds position)
+                                                       :p1-winner?   (and complete? (= winner p1))
+                                                       :p2-winner?   (and complete? (= winner p2))
+                                                       :p1-loser?    (and complete? (some? p1) (not= winner p1))
+                                                       :p2-loser?    (and complete? (some? p2) (not= winner p2))
+                                                       :p1-tbd?      (nil? p1)
+                                                       :p2-tbd?      (nil? p2)
+                                                       :p2-bye?      (and (some? p1) (nil? p2))
+                                                       :placeholder? (nil? (:eid match)))]
+                                 (merge base-match (match-status-subheader base-match))))
+                             (iterate inc 1)
+                             matches)))
+
+(defn- relabel-winners-final
+  "In a double-elimination bracket the last WB round is the 'Winners Final',
+   not the tournament final — that's the grand final. Override the column
+   label + per-match label so the unified bracket strip reads correctly."
+  [wb-rounds]
+  (if (seq wb-rounds)
+    (update wb-rounds (dec (count wb-rounds))
+            (fn [round]
+              (-> round
+                  (assoc :column-label "Winners Final")
+                  (update :matches
+                          (fn [matches]
+                            (mapv #(assoc % :match-label "WF") matches))))))
+    wb-rounds))
+
+(defn- assign-grid
+  "Decorates each round-cell with grid placement metadata: `:grid-style`
+   (CSS fragment for inline style), plus `:bracket-col`, `:bracket-row`,
+   `:bracket-row-span` for the connector JS to pair adjacent cells."
+  ([column row cell] (assign-grid column row 1 cell))
+  ([column row row-span cell]
+   (assoc cell
+          :grid-style       (format "grid-column: %d; grid-row: %d / span %d;"
+                                    column row row-span)
+          :bracket-col      column
+          :bracket-row      row
+          :bracket-row-span row-span)))
+
+(defn- decorate-bracket-phase
+  "Annotates a phase group with grid-positioned cells for the unified
+   viewer bracket. Covers SE, DE (WB on top, LB stacked below, GF as the
+   final column spanning both rows), and Swiss / round-robin (flat row).
+
+   Exposes:
+   - `:bracket-cells` — the flat list of decorated round-cells, each
+     carrying `:grid-style` for explicit grid placement.
+   - `:bracket-cols`  — column count for `grid-template-columns`.
+   - `:bracket-rows`  — row count (1 for SE/Swiss/RR, 2 for DE)."
+  [phase-group]
+  (let [decorated (cond-> phase-group
+                    (:winners-bracket phase-group) (update :winners-bracket #(mapv (partial decorate-bracket-round "winners") %))
+                    (:losers-bracket phase-group)  (update :losers-bracket  #(mapv (partial decorate-bracket-round "losers") %))
+                    (:grand-final phase-group)     (update :grand-final     #(mapv (partial decorate-bracket-round "grand-final") %))
+                    (:rounds phase-group)          (update :rounds          #(mapv (partial decorate-bracket-round "rounds") %)))
+        de?       (boolean (or (:losers-bracket decorated) (:grand-final decorated)))
+        wb        (cond-> (:winners-bracket decorated)
+                    de? relabel-winners-final)
+        lb        (or (:losers-bracket decorated) [])
+        gf        (or (:grand-final decorated) [])
+        rounds    (or (:rounds decorated) [])
+        cells     (cond
+                    de?
+                    (let [n     (count wb)
+                          ;; 3-row grid: WB on row 1, dashed divider on
+                          ;; row 2, LB on row 3. GF spans all three so
+                          ;; it sits flush at the right edge.
+                          wb-cs (map-indexed (fn [i r] (assign-grid (inc i) 1 r)) wb)
+                          ;; Drop the per-LB column label — the WB
+                          ;; column above already labels each column.
+                          lb-cs (map-indexed (fn [i r]
+                                               (assign-grid (+ i 2) 3 (assoc r :column-label nil)))
+                                             lb)
+                          gf-cs (map (fn [r] (assign-grid (inc n) 1 3 r)) gf)]
+                      (vec (concat wb-cs lb-cs gf-cs)))
+
+                    (seq rounds)
+                    (vec (map-indexed (fn [i r] (assign-grid (inc i) 1 r)) rounds))
+
+                    :else
+                    (vec (map-indexed (fn [i r] (assign-grid (inc i) 1 r)) wb)))
+        cols      (cond
+                    de?         (inc (count wb))
+                    (seq rounds) (count rounds)
+                    :else        (count wb))
+        rows      (if de? 3 1)]
+    (assoc decorated
+           :bracket-cells cells
+           :bracket-cols  cols
+           :bracket-rows  rows
+           :bracket-divider? de?)))
+
+(def ^:private bracket-labels
+  {"winners"     "Winners"
+   "losers"      "Losers"
+   "grand-final" "Grand Final"})
+
+(defn- round-buckets-for-phase
+  "Flattens every bucket inside a phase-group into a flat round-list,
+   tagged with the bracket it came from. Covers Swiss/RR `:rounds`, SE
+   `:winners-bracket`, plus DE's `:losers-bracket` and `:grand-final`."
+  [phase-group]
+  (let [tag-bracket (fn [bracket rounds]
+                      (mapv #(assoc % :bracket-label (bracket-labels bracket))
+                            (or rounds [])))]
+    (concat (tag-bracket "winners"     (or (:rounds phase-group) (:winners-bracket phase-group)))
+            (tag-bracket "losers"      (:losers-bracket phase-group))
+            (tag-bracket "grand-final" (:grand-final phase-group)))))
+
+(defn- pending-matches-schedule
+  "Flat, round-ordered list of pending matches across every phase and
+   bracket, shaped for the viewer's Schedule list. Drops placeholder
+   rows (no :eid) and complete matches. First entry is marked `:up-next?`
+   so the template highlights it without peeking at forloop.first."
+  [matches-by-phase]
+  (let [round-buckets (mapcat round-buckets-for-phase matches-by-phase)
+        rows          (->> round-buckets
+                           (mapcat (fn [{:keys [round phase-type matches bracket-label]}]
+                                     (let [phase-label (or (phase-type-labels phase-type)
+                                                           phase-type)
+                                           round-label (cond
+                                                         (= "Grand Final" bracket-label) bracket-label
+                                                         (= "Winners"     bracket-label) (str "Round " (inc round))
+                                                         :else                           (str bracket-label " R" (inc round)))]
+                                       (->> matches
+                                            (filter :eid)
+                                            (filter #(= "pending" (:status %)))
+                                            (map #(assoc %
+                                                         :round-label round-label
+                                                         :phase-label phase-label))))))
+                           vec)]
+    (if (empty? rows)
+      rows
+      (assoc-in rows [0 :up-next?] true))))
+
+(defn- current-round-label
+  "Returns the column-label of the bracket cell containing the next
+   pending match across all phases. Used in the hero pill so the viewer
+   shows e.g. `Quarterfinals` while QF matches are still being played."
+  [decorated-phases up-next-eid]
+  (when up-next-eid
+    (let [cells (mapcat :bracket-cells decorated-phases)
+          cell  (first (filter (fn [c]
+                                 (some #(= up-next-eid (:eid %)) (:matches c)))
+                               cells))]
+      (:column-label cell))))
+
+(defn- decorate-standings
+  "Sorts standings by points descending, then annotates each row with its
+   1-based rank and a boolean for whether it falls within the qualifier cut."
+  [standings qualifier-count]
+  (mapv (fn [rank row]
+          (assoc row
+                 :rank      rank
+                 :advanced? (and qualifier-count (<= rank qualifier-count))))
+        (iterate inc 1)
+        (sort-by #(- (or (:points %) 0)) standings)))
+
 (defmethod integrant.core/init-key ::tournament-view
   [_init-key dependencies]
   (partial web.view/standard-entity-view-handler
            (fn [eid] (web.tournament.share/get-tournament-by-eid dependencies eid))
            "tournament-index.html"
            (fn [data request]
-             (let [tournament-eid        (:eid data)
-                   state                 (domain/get-tournament-state dependencies tournament-eid)
-                   entries               (domain/get-entries dependencies tournament-eid)
-                   raw-matches           (domain/get-matches-for-tournament dependencies tournament-eid)
-                   phases                (:phases state)
-                   qualifier-count       (or (:qualifier-count state) (count (:standings state)))
-                   user-sub              (get-in request [:ory-session :identity :id])
-                   has-entry             (some #(= user-sub (:player-sub %)) entries)
-                   now                   (java.time.Instant/now)
-                   reg-open              (domain/is-registration-open? state now)
-                   is-organizer          (= user-sub (:created-by-sub data))
-                   organizer-has-actions (and is-organizer
-                                              (contains? #{"registration" "active"} (:status state)))
-                   league                (when (:league-eid data)
-                                           (domain/get-league-by-eid dependencies (:league-eid data)))
-                   season                (when (:season-eid data)
-                                           (domain/get-season-by-eid dependencies (:season-eid data)))]
-               {:tournament-state      state
-                :entries               entries
-                :matches-by-phase      (domain/group-matches-by-phase raw-matches phases qualifier-count)
-                :league                league
-                :season                season
-                :has-entry             has-entry
-                :registration-open     reg-open
-                :is-organizer          is-organizer
-                :organizer-has-actions organizer-has-actions}))))
+             (let [tournament-eid       (:eid data)
+                   state                (domain/get-tournament-state dependencies tournament-eid)
+                   entries              (domain/get-entries dependencies tournament-eid)
+                   raw-matches          (mapv (partial with-game-counts dependencies)
+                                              (domain/get-matches-for-tournament dependencies tournament-eid))
+                   phases               (:phases state)
+                   qualifier-count      (or (:qualifier-count state) (count (:standings state)))
+                   user-sub             (get-in request [:ory-session :identity :id])
+                   has-entry            (some #(= user-sub (:player-sub %)) entries)
+                   now                  (java.time.Instant/now)
+                   reg-open             (domain/is-registration-open? state now)
+                   is-organizer         (= user-sub (:created-by-sub data))
+                   league               (when (:league-eid data)
+                                          (domain/get-league-by-eid dependencies (:league-eid data)))
+                   season               (when (:season-eid data)
+                                          (domain/get-season-by-eid dependencies (:season-eid data)))
+                   matches-by-phase     (domain/group-matches-by-phase raw-matches phases qualifier-count)
+                   decorated-phases     (mapv decorate-bracket-phase matches-by-phase)
+                   current-phase-config (get phases (:current-phase state))
+                   current-phase-label  (or (phase-type-labels (:phase-type current-phase-config))
+                                            (:phase-type current-phase-config))
+                   phase-count          (count phases)
+                   schedule             (pending-matches-schedule matches-by-phase)]
+               {:tournament-state    (update state :standings decorate-standings (:qualifier-count state))
+                :entries             entries
+                :matches-by-phase    decorated-phases
+                :schedule            schedule
+                :current-phase-label current-phase-label
+                :current-round-label (current-round-label decorated-phases (:eid (first schedule)))
+                :phase-count         phase-count
+                :single-phase?       (= 1 phase-count)
+                :league              league
+                :season              season
+                :has-entry           has-entry
+                :registration-open   reg-open
+                :is-organizer        is-organizer}))))
 
 ;; ─── Post-match modal helpers ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- New bracket viewer (`viewer-bracket.html`) renders SE / DE / Swiss / round-robin from grid-positioned cells, with SVG connectors that read in stronger gold when their source match has a winner.
- Bracket cards show per-player game wins (instead of W/L) plus a small status subheader: `Final · Settled`, `Game N · Live`, `Scheduled · —`, or `Awaiting bracket · ·`.
- Hero pill drops Game and Entrants; appends the current round label (Quarterfinals / Grand Final / Round 3) after the phase-type label.
- Standings simplified: roman-numeral rank only, sorted by points descending, player flush-left, fixed-width `#` and `Record` columns with Player flexing, single `Record` column showing `W-L`.
- Featured-stream placeholder removed (will revisit later).
- `rts-demo` now uses stable tournament eids and records per-match games via `record-game-result`, so the viewer can display realistic game counts on the demo data. SE rounds after round 0 advance from the previous round's winners instead of re-seeding from standings.

## Test plan

- [x] `clojure -M:poly check` clean
- [x] `clojure -M:poly test` green on `rts-domain`, `rts-web`
- [x] e2e: `cd components/e2e && npx playwright test` against a running dev server
- [x] Manual: navigate to `/view/game/<game-eid>/tournament/<eid>/index.html` for each demo tournament (single-elim, double-elim, Swiss) and confirm bracket, standings, hero pill, and connector lines render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)