### PR TITLE
Add datalog component (rts-066)

### DIFF
--- a/components/datalog/deps.edn
+++ b/components/datalog/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src"]
+ :deps {org.datalevin/datalevin-embedded {:mvn/version "0.10.16"}
+        metosin/malli                    {:mvn/version "0.9.2"}}}

--- a/components/datalog/src/com/devereux_henley/datalog/contract.clj
+++ b/components/datalog/src/com/devereux_henley/datalog/contract.clj
@@ -1,0 +1,59 @@
+(ns com.devereux-henley.datalog.contract
+  "Thin wrapper around Datalevin to provide a single seam for schema decode/encode
+  and to enforce the rule that domain namespaces never call `datalevin.core` directly.
+  Mirrors the role that `com.devereux-henley.jdbc.contract` plays for SQLite."
+  (:require
+   [datalevin.core :as datalevin]))
+
+(defn get-conn
+  "Open (or reuse) a Datalevin connection at `dir` with the given `schema`.
+   `datalevin/get-conn` is idempotent: the schema merges into any pre-existing
+   one, so additive schema changes apply on restart without rewriting LMDB state."
+  ([dir]
+   (datalevin/get-conn dir))
+  ([dir schema]
+   (datalevin/get-conn dir schema)))
+
+(defn close
+  "Close a Datalevin connection. Safe to call from Integrant `halt-key!`."
+  [conn]
+  (datalevin/close conn))
+
+(defn q
+  "Run a datalog query. `query` is a datalog form (vector or map); `inputs` are the
+   sources/bindings (typically the db plus any parameters)."
+  [query & inputs]
+  (apply datalevin/q query inputs))
+
+(defn pull
+  "Pull `pattern` for the entity identified by `eid-or-lookup-ref` from `db-or-conn`.
+   Accepts either a numeric entity id, a lookup ref like
+   `[:tournament/eid #uuid \"...\"]`, or a connection (in which case the
+   connection's current db value is used)."
+  [db-or-conn pattern eid-or-lookup-ref]
+  (datalevin/pull
+   (if (datalevin/conn? db-or-conn) (datalevin/db db-or-conn) db-or-conn)
+   pattern
+   eid-or-lookup-ref))
+
+(defn transact!
+  "Apply `tx-data` to `conn`. Returns the transaction report."
+  ([conn tx-data]
+   (datalevin/transact! conn tx-data))
+  ([conn tx-data tx-meta]
+   (datalevin/transact! conn tx-data tx-meta)))
+
+(defn lookup-ref
+  "Build a lookup ref vector `[attr value]`. Convention: every domain has a
+   `:<domain>/eid` attribute of `:db.unique/identity`, so
+   `(lookup-ref :tournament/eid uuid)` resolves any entity by its public uuid."
+  [attr value]
+  [attr value])
+
+(defn entity
+  "Return the `Entity` map for `eid-or-lookup-ref` from `db-or-conn`. Use for
+   ad-hoc navigation; prefer `pull` when the shape is known and bounded."
+  [db-or-conn eid-or-lookup-ref]
+  (datalevin/entity
+   (if (datalevin/conn? db-or-conn) (datalevin/db db-or-conn) db-or-conn)
+   eid-or-lookup-ref))

--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,7 @@
                                mono/content-negotiation {:local/root "components/content-negotiation"}
                                mono/http {:local/root "components/http"}
                                mono/jdbc {:local/root "components/jdbc"}
+                               mono/datalog {:local/root "components/datalog"}
                                mono/rts-data {:local/root "components/rts-data"}
                                mono/rts-data-access {:local/root "components/rts-data-access"}
                                mono/rts-domain {:local/root "components/rts-domain"}

--- a/projects/api/deps.edn
+++ b/projects/api/deps.edn
@@ -3,6 +3,7 @@
         mono/content-negotiation     {:local/root "../../components/content-negotiation"}
         mono/http                    {:local/root "../../components/http"}
         mono/jdbc                    {:local/root "../../components/jdbc"}
+        mono/datalog                 {:local/root "../../components/datalog"}
         mono/resourcekit             {:local/root "../../components/resourcekit"}
         mono/rts-data                {:local/root "../../components/rts-data"}
         mono/rts-data-access         {:local/root "../../components/rts-data-access"}


### PR DESCRIPTION
First step of the SQLite → Datalevin migration (epic [rts-7xz]; foundation epic [rts-8ae]).

## Summary
- New `datalog` component (parallel to `jdbc`) at `components/datalog/`
- `contract.clj` exposes `get-conn`, `close`, `q`, `pull`, `transact!`, `lookup-ref`, `entity` — the seam every domain will go through; no domain code calls `datalevin.core` directly
- Registered in root `deps.edn :dev` and `projects/api/deps.edn`

## Datalevin packaging note
Depends on `org.datalevin/datalevin-embedded 0.10.16`, not `datalevin/datalevin`. The main jar ships without `datalevin.LlamaEmbedder.class` (which `datalevin.embedding` imports), so requiring `datalevin.core` from it throws `ClassNotFoundException` at load. The lean embedded jar bundles the class and the native libs.

## Test plan
- [x] `clojure -M:poly check` clean (warning 207 — datalog unused in api — clears as soon as the first domain migrates)
- [x] `clj-kondo --lint components/datalog/src` — 0 errors, 0 warnings
- [x] `cljfmt check components/datalog/src` — clean
- [x] Smoke test: `transact!` → `pull` → `entity` against a real LMDB store via the wrappers (see commit message)
- [x] Followed by rts-0sm (Integrant wiring for `:datalog/connection`) which will exercise the contract from the running system

🤖 Generated with [Claude Code](https://claude.com/claude-code)