### PR TITLE
Integrant wiring for :datalog/connection (rts-0sm)

### DIFF
--- a/bases/rts-api/Dockerfile
+++ b/bases/rts-api/Dockerfile
@@ -14,6 +14,7 @@ COPY components/content-negotiation/deps.edn         components/content-negotiat
 COPY components/e2e/deps.edn                         components/e2e/deps.edn
 COPY components/http/deps.edn                        components/http/deps.edn
 COPY components/jdbc/deps.edn                        components/jdbc/deps.edn
+COPY components/datalog/deps.edn                     components/datalog/deps.edn
 COPY components/resourcekit/deps.edn                 components/resourcekit/deps.edn
 COPY components/rts-data/deps.edn                    components/rts-data/deps.edn
 COPY components/rts-data-access/deps.edn             components/rts-data-access/deps.edn
@@ -44,9 +45,13 @@ COPY --from=builder --chown=app:app /app/projects/api/target/rts-api.jar /app/rt
 USER app
 
 ENV RTS_API_PORT=3001 \
-    RTS_DB_CONNECTION_URI=jdbc:sqlite:/data/database.db
+    RTS_DB_CONNECTION_URI=jdbc:sqlite:/data/database.db \
+    DATALEVIN_DB_DIR=/data/datalevin
 
 EXPOSE 3001
 VOLUME ["/data"]
 
-ENTRYPOINT ["java", "-jar", "/app/rts-api.jar"]
+ENTRYPOINT ["java", \
+            "--add-opens=java.base/java.nio=ALL-UNNAMED", \
+            "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED", \
+            "-jar", "/app/rts-api.jar"]

--- a/bases/rts-api/deps.edn
+++ b/bases/rts-api/deps.edn
@@ -9,7 +9,8 @@
         clj-http/clj-http {:mvn/version "3.12.3"}
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.834"}
         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
-        org.xerial/sqlite-jdbc {:mvn/version "3.39.3.0"}}
+        org.xerial/sqlite-jdbc {:mvn/version "3.39.3.0"}
+        org.datalevin/datalevin-embedded {:mvn/version "0.10.16"}}
  :aliases {:build {:main-opts ["-m" "com.devereux-henley.rts-api.core"]}
            :dev {:extra-paths ["dev"]}
            :test {:extra-paths ["test"]

--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -3,6 +3,7 @@
    boot a development profile that stubs Ory authentication, while production
    jars still use `core-configuration` with real Ory wiring."
   (:require
+   [com.devereux-henley.rts-api.datalog :as datalog]
    [com.devereux-henley.rts-api.db :as db]
    [com.devereux-henley.rts-api.dev-auth :as dev-auth]
    [com.devereux-henley.rts-api.model-transform]
@@ -35,6 +36,7 @@
   {::rts-data/migrate                                      {:db-spec       db/db-spec
                                                             :migration-dir rts-data/migration-dir}
    ::db/connection                                         {:migrations (integrant.core/ref ::rts-data/migrate)}
+   ::datalog/connection                                    {}
    :com.devereux-henley.rts-api.model-transform/middleware {:hostname hostname}
    ::web/api-view-registry                                 {}
    ::web/component-view-registry                           {}

--- a/bases/rts-api/src/com/devereux_henley/rts_api/datalog.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/datalog.clj
@@ -1,0 +1,26 @@
+(ns com.devereux-henley.rts-api.datalog
+  "Integrant lifecycle for the Datalevin (LMDB) connection. Coexists with
+   `db/connection` (SQLite) for the duration of the storage migration; the
+   key will become the sole store once all domains are migrated and the
+   SQLite ref is removed."
+  (:require
+   [datalevin.core :as datalevin]
+   [integrant.core]))
+
+(def ^:private default-dir "db/datalevin/")
+
+(def dir
+  (or (System/getenv "DATALEVIN_DB_DIR") default-dir))
+
+(def schema
+  "Datalevin schema-as-code. Empty for now; per-domain attributes get merged
+   in by the schema-as-code namespace (rts-8z4) as each domain migrates."
+  {})
+
+(defmethod integrant.core/init-key ::connection
+  [_init-key _dependencies]
+  (datalevin/get-conn dir schema))
+
+(defmethod integrant.core/halt-key! ::connection
+  [_init-key conn]
+  (datalevin/close conn))

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,6 @@
 {:aliases  {:dev {:extra-paths ["development/src"]
+                  :jvm-opts ["--add-opens=java.base/java.nio=ALL-UNNAMED"
+                             "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"]
                   :extra-deps {org.clojure/clojure {:mvn/version "1.11.1"}
                                integrant/repl {:mvn/version "0.5.1"}
                                mono/schema {:local/root "components/schema"}
@@ -25,7 +27,9 @@
                                  "components/rts-data-access"
                                  "components/rts-domain"
                                  "components/e2e"
-                                 "bases/rts-api"]}
+                                 "bases/rts-api"]
+                   :jvm-opts ["--add-opens=java.base/java.nio=ALL-UNNAMED"
+                              "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"]}
 
             :poly {:main-opts ["-m" "polylith.clj.core.poly-cli.core"]
                    :extra-deps {polyfy/polylith


### PR DESCRIPTION
Second step of the SQLite → Datalevin migration (epic [rts-7xz]; foundation epic [rts-8ae]). Builds on #100.

## Summary
- New `bases/rts-api/src/com/devereux_henley/rts_api/datalog.clj` with Integrant `init-key` / `halt-key!` for `::connection`
- `::datalog/connection {}` added to `infrastructure-configuration` so it boots alongside `::db/connection` on `(go!)`
- `DATALEVIN_DB_DIR` env var (default `db/datalevin/`; `/data/datalevin` in Docker)
- Schema is empty `{}` — per-domain attributes get merged by the schema-as-code namespace (rts-8z4) as each domain migrates
- JVM opts `--add-opens=java.base/java.nio=ALL-UNNAMED` + `--add-opens=java.base/sun.nio.ch=ALL-UNNAMED` (required on Java 21+) added to root `:dev` / `:test` aliases and Dockerfile ENTRYPOINT
- Datalevin runtime dep added to `bases/rts-api/deps.edn` and Dockerfile builder layer

## Precedent
Follows `db.clj`: lifecycle file uses `datalevin.core` directly, mirroring `db.clj`'s use of `next.jdbc`. The datalog component contract is for domain query code; the base owns the connection lifecycle.

## Test plan
- [x] `clojure -M:poly check` clean (warning 207 — datalog component unused — clears with the game-domain pilot epic)
- [x] `clj-kondo` clean on touched namespaces
- [x] `cljfmt check` clean
- [x] `init-key` opens a real LMDB conn, `halt-key!` closes it
- [x] Full `development-configuration` expansion shows both `::db/connection` and `::datalog/connection` keys present
- [x] Followed by rts-8z4 (schema-as-code), rts-7pc (dev workspace helpers), rts-jac (e2e test infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)