### PR TITLE
Datalog schema-as-code namespace (rts-8z4)

### DIFF
--- a/bases/rts-api/src/com/devereux_henley/rts_api/datalog.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/datalog.clj
@@ -4,6 +4,7 @@
    key will become the sole store once all domains are migrated and the
    SQLite ref is removed."
   (:require
+   [com.devereux-henley.rts-data-access.contract :as rts-data-access]
    [datalevin.core :as datalevin]
    [integrant.core]))
 
@@ -12,14 +13,9 @@
 (def dir
   (or (System/getenv "DATALEVIN_DB_DIR") default-dir))
 
-(def schema
-  "Datalevin schema-as-code. Empty for now; per-domain attributes get merged
-   in by the schema-as-code namespace (rts-8z4) as each domain migrates."
-  {})
-
 (defmethod integrant.core/init-key ::connection
   [_init-key _dependencies]
-  (datalevin/get-conn dir schema))
+  (datalevin/get-conn dir rts-data-access/datalog-schema))
 
 (defmethod integrant.core/halt-key! ::connection
   [_init-key conn]

--- a/components/datalog/src/com/devereux_henley/datalog/contract.clj
+++ b/components/datalog/src/com/devereux_henley/datalog/contract.clj
@@ -43,6 +43,13 @@
   ([conn tx-data tx-meta]
    (datalevin/transact! conn tx-data tx-meta)))
 
+(defn update-schema
+  "Apply additive schema changes to `conn` without restarting the JVM. Use at
+   the REPL after editing `schema.datalog/schema`; the initial schema applied
+   at `get-conn` only sees the snapshot captured when the connection opened."
+  [conn schema-update]
+  (datalevin/update-schema conn schema-update))
+
 (defn lookup-ref
   "Build a lookup ref vector `[attr value]`. Convention: every domain has a
    `:<domain>/eid` attribute of `:db.unique/identity`, so

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
@@ -7,7 +7,12 @@
    [com.devereux-henley.rts-data-access.query.social-media :as query.social-media]
    [com.devereux-henley.rts-data-access.query.stats :as query.stats]
    [com.devereux-henley.rts-data-access.query.tournament :as query.tournament]
-   [com.devereux-henley.rts-data-access.schema :as schema]))
+   [com.devereux-henley.rts-data-access.schema :as schema]
+   [com.devereux-henley.rts-data-access.schema.datalog :as schema.datalog]))
+
+;;; ─── Datalog schema-as-code ────────────────────────────────────────────────
+
+(def datalog-schema schema.datalog/schema)
 
 ;;; ─── Game DB entities ──────────────────────────────────────────────────────
 

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog.clj
@@ -1,0 +1,20 @@
+(ns com.devereux-henley.rts-data-access.schema.datalog
+  "Datalevin schema-as-code for the entire database. Applied idempotently when
+  the Datalevin connection is opened (see `bases/rts-api/.../datalog.clj`).
+
+  Each domain epic merges its own attribute map into [[schema]] as it migrates
+  off SQLite. Conventions:
+
+  - Every domain has a `:<domain>/eid` attribute, `:db.type/uuid` and
+    `:db.unique/identity`. Routes, templates, and `match-by-name!` keep working
+    unchanged because `[:<domain>/eid uuid]` is the lookup ref everywhere.
+  - References use `:db/valueType :db.type/ref`. Set
+    `:db/cardinality :db.cardinality/many` when the parent owns a collection.
+  - Datalevin is additive at runtime: opening a conn with a superset schema
+    only adds the new attributes. Use `datalog.contract/update-schema` at the
+    REPL to apply a change without restarting the JVM.")
+
+(def schema
+  "The full Datalevin schema map. Per-domain attribute maps merge in here as
+  each domain migrates off SQLite. Empty until the game-domain pilot lands."
+  {})


### PR DESCRIPTION
Third step of the SQLite → Datalevin migration (epic [rts-7xz]; foundation epic [rts-8ae]).

## Summary
- New `components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog.clj` — single map, empty until the game-domain pilot lands; per-domain epics merge their attribute maps in here
- Re-exported from `rts-data-access/contract` as `datalog-schema` so callers go through the contract
- `bases/rts-api/.../datalog.clj` now sources the schema from `rts-data-access/datalog-schema` instead of an inline `{}`
- New `datalog.contract/update-schema` wraps `datalevin/update-schema` — a connection opened with the snapshot schema needs this to pick up edits made later in the same REPL session

## Why the contract re-export
Following the existing pattern in `rts-data-access/contract.clj`: every schema/query var is re-exported from the contract; downstream callers never import the package namespaces directly. This keeps `datalog-schema` swappable without touching every caller.

## Test plan
- [x] `clj-kondo --lint` clean on all changed files
- [x] `cljfmt check` clean
- [x] `clojure -M:poly check` clean (warning 207 still expected — clears with the game-domain pilot epic)
- [x] Smoke test: `(go!)`-equivalent init opens conn using the new schema source, `update-schema` adds a new attribute mid-session, `transact!` + `pull` round-trip works, `halt!` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)