### PR TITLE
E2E test infra: per-run Datalevin dir + cleanup (rts-jac)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -66,8 +66,10 @@ jobs:
       - name: Start dev server
         env:
           REPLAY_PARSER_BIN: ${{ github.workspace }}/bin/tw-replay-parser
+          DATALEVIN_DB_DIR: ${{ runner.temp }}/datalevin-e2e
         run: |
           mkdir -p db
+          mkdir -p "$DATALEVIN_DB_DIR"
           clojure -M:dev -i components/e2e/resources/e2e/start_dev_server.clj &
           timeout 120 bash -c 'until curl -sf http://localhost:3001/status > /dev/null 2>&1; do sleep 2; done'
 

--- a/components/e2e/src/com/devereux_henley/e2e/contract.clj
+++ b/components/e2e/src/com/devereux_henley/e2e/contract.clj
@@ -46,3 +46,28 @@
         (.disconnect ^HttpURLConnection conn)
         (< code 500)))
     (catch Exception _ false)))
+
+;;; ─── Datalog per-run isolation ─────────────────────────────────────────────
+;;; Datalevin stores state in an LMDB directory. Stale state across runs
+;;; corrupts assertions, so the orchestration (CI script or REPL runner)
+;;; allocates a fresh dir per test run, exports it as `DATALEVIN_DB_DIR`
+;;; before starting the dev server, and deletes it on teardown.
+
+(defn make-datalevin-test-dir!
+  "Create and return a unique Datalevin directory for this test run, suitable
+   for export as `DATALEVIN_DB_DIR` before launching the dev server. Default
+   parent is `java.io.tmpdir`; pass `parent` to override."
+  ([] (make-datalevin-test-dir! (System/getProperty "java.io.tmpdir")))
+  ([parent]
+   (let [dir (io/file parent (str "datalevin-e2e-" (random-uuid)))]
+     (.mkdirs dir)
+     (.getAbsolutePath dir))))
+
+(defn cleanup-datalevin-test-dir!
+  "Recursively delete a Datalevin test directory. Tolerates a missing path so
+   the teardown step stays idempotent."
+  [path]
+  (let [root (io/file path)]
+    (when (.exists root)
+      (doseq [child (reverse (file-seq root))]
+        (.delete ^java.io.File child)))))


### PR DESCRIPTION
Fifth (and final) foundation step for the SQLite → Datalevin migration (epic [rts-7xz]; foundation epic [rts-8ae]).

## Summary
- `e2e/contract.clj`: `make-datalevin-test-dir!` and `cleanup-datalevin-test-dir!` so the orchestration (CI script or REPL runner) can allocate an isolated LMDB dir per test run and tear it down.
- `pr-check.yml`: exports `DATALEVIN_DB_DIR=\${{ runner.temp }}/datalevin-e2e` before starting the dev server, so the store lives in the runner's ephemeral tmp instead of the workspace.

## Scope notes
- The Playwright tests themselves aren't touched. The server is still launched out-of-band; tests still talk HTTP to it. Per-RUN isolation is what the foundation provides; per-TEST isolation (each spec wipes/seeds its own state) waits on the domain migrations, when test-only mutation endpoints land.
- `cleanup-datalevin-test-dir!` is idempotent — tolerates a missing path — so it's safe in `finally`/`if: always()` style blocks.

## Test plan
- [x] `clj-kondo --lint` + `cljfmt check` clean on the changed contract file
- [x] `clojure -M:poly check` clean (warning 207 still expected; clears with the game-domain pilot)
- [x] Smoke test: `make-datalevin-test-dir!` returns a unique tmp path, populated dir is wiped by `cleanup-…`, second cleanup on the same path is a no-op
- [x] CI run on this PR confirms the new `DATALEVIN_DB_DIR` env doesn't break the existing `start_dev_server.clj` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)