### PR TITLE
Game domain: per-template Datalevin queries (rts-nx0)

### DIFF
--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -21,9 +21,10 @@
 (def auth-hostname (or (System/getenv "AUTH_HOSTNAME") "http://localhost:4000"))
 (def session-name (str "ory_session_" (or (System/getenv "AUTH_SLUG") "eloquentyalowwhtijq6my4")))
 (def replay-parser-bin (or (System/getenv "REPLAY_PARSER_BIN") "tw-replay-parser"))
-(def default-dependencies {:hostname          hostname
-                           :connection        (integrant.core/ref ::db/connection)
-                           :replay-parser-bin replay-parser-bin})
+(def default-dependencies {:hostname           hostname
+                           :connection         (integrant.core/ref ::db/connection)
+                           :datalog-connection (integrant.core/ref ::datalog/connection)
+                           :replay-parser-bin  replay-parser-bin})
 
 (defn- handlers
   "Maps each Integrant key to default-dependencies."

--- a/components/datalog/src/com/devereux_henley/datalog/contract.clj
+++ b/components/datalog/src/com/devereux_henley/datalog/contract.clj
@@ -20,10 +20,14 @@
   (datalevin/close conn))
 
 (defn q
-  "Run a datalog query. `query` is a datalog form (vector or map); `inputs` are the
-   sources/bindings (typically the db plus any parameters)."
-  [query & inputs]
-  (apply datalevin/q query inputs))
+  "Run a datalog query. `query` is a datalog form (vector or map); the first
+   input is the source — either a db value or a connection (unwrapped to its
+   current db). Remaining inputs are the query parameters."
+  [query db-or-conn & inputs]
+  (apply datalevin/q
+         query
+         (if (datalevin/conn? db-or-conn) (datalevin/db db-or-conn) db-or-conn)
+         inputs))
 
 (defn pull
   "Pull `pattern` for the entity identified by `eid-or-lookup-ref` from `db-or-conn`.

--- a/components/datalog/src/com/devereux_henley/datalog/contract.clj
+++ b/components/datalog/src/com/devereux_henley/datalog/contract.clj
@@ -20,14 +20,17 @@
   (datalevin/close conn))
 
 (defn q
-  "Run a datalog query. `query` is a datalog form (vector or map); the first
-   input is the source — either a db value or a connection (unwrapped to its
-   current db). Remaining inputs are the query parameters."
-  [query db-or-conn & inputs]
-  (apply datalevin/q
-         query
-         (if (datalevin/conn? db-or-conn) (datalevin/db db-or-conn) db-or-conn)
-         inputs))
+  "Run a datalog query. `query` is a datalog form (vector or map); `inputs` are the
+   sources/bindings (typically the db plus any parameters)."
+  [query & inputs]
+  (apply datalevin/q query inputs))
+
+(defn db
+  "Snapshot the current db value from a connection. Cheap (single atomic
+   deref); call once at the top of a read fn so a multi-step query sees a
+   consistent point-in-time view."
+  [conn]
+  (datalevin/db conn))
 
 (defn pull
   "Pull `pattern` for the entity identified by `eid-or-lookup-ref` from `db-or-conn`.

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
@@ -1,5 +1,6 @@
 (ns com.devereux-henley.rts-data-access.contract
   (:require
+   [com.devereux-henley.rts-data-access.query.datalog.game :as query.datalog.game]
    [com.devereux-henley.rts-data-access.query.game :as query.game]
    [com.devereux-henley.rts-data-access.query.league :as query.league]
    [com.devereux-henley.rts-data-access.query.replay :as query.replay]
@@ -105,6 +106,25 @@
 
 (def unit-statistics-raw-schema schema/unit-statistics-raw-schema)
 (def unit-statistics-transformer schema/unit-statistics-transformer)
+
+;;; ─── Game Datalog queries (per-template) ───────────────────────────────────
+
+(def games                query.datalog.game/games)
+(def game-by-eid          query.datalog.game/game-by-eid)
+(def factions             query.datalog.game/factions)
+(def factions-for-game    query.datalog.game/factions-for-game)
+(def faction-by-eid       query.datalog.game/faction-by-eid)
+(def units                query.datalog.game/units)
+(def units-for-game       query.datalog.game/units-for-game)
+(def units-for-faction    query.datalog.game/units-for-faction)
+(def unit-by-eid          query.datalog.game/unit-by-eid)
+(def game-modes-for-game  query.datalog.game/game-modes-for-game)
+(def socials-for-game     query.datalog.game/socials-for-game)
+(def mounts-for-unit      query.datalog.game/mounts-for-unit)
+(def items-for-unit       query.datalog.game/items-for-unit)
+(def spells-by-keys       query.datalog.game/spells-by-keys)
+(def spells-for-lore      query.datalog.game/spells-for-lore)
+(def abilities-by-keys    query.datalog.game/abilities-by-keys)
 
 ;;; ─── Tournament DB entities ────────────────────────────────────────────────
 

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/game.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/game.clj
@@ -1,15 +1,21 @@
-(ns com.devereux-henley.rts-web.web.game.queries
-  "Per-template Datalevin pull/q queries for the game domain. Each public fn
-  matches one template's data shape (game-collection, game detail,
+(ns com.devereux-henley.rts-data-access.query.datalog.game
+  "Per-template Datalevin pull/q queries for the game domain. Each public
+  fn matches one template's data shape (game-collection, game detail,
   faction-collection, faction detail, unit-collection, unit detail,
-  game-selector). Handlers in `web.game.view`, `web.game.api`, and
-  `web.view` call these instead of the SQLite-era `query/game.clj` fns;
-  the SQL path lives until `rts-khy` retires it.
+  game-selector). Handlers reach these through `rts-data-access.contract`
+  alongside the SQLite-era `query/game.clj` fns; the SQL path lives until
+  `rts-khy` retires it.
 
-  Result maps use unqualified keys (`:eid`, `:name`, `:game-eid`, …) so the
-  existing resource schemas in `rts-domain` and Selmer templates render
-  unchanged. Foreign-key refs are pulled as `{<ns>/eid uuid}` sub-maps and
-  flattened to `:<thing>-eid` to match the SQLite-era entity shape."
+  Result maps use unqualified keys (`:eid`, `:name`, `:game-eid`, …) so
+  the existing resource schemas in `rts-domain` and Selmer templates
+  render unchanged. Foreign-key refs are pulled as `{<ns>/eid uuid}`
+  sub-maps and flattened to `:<thing>-eid` to match the SQLite-era entity
+  shape.
+
+  Each public fn snapshots the current db at entry (`(dl/db conn)`) and
+  uses it for the single pull/q it issues. The snapshot is cheap (one
+  atomic deref) and binds the query to a consistent point-in-time view —
+  later transacts don't change the result mid-fn."
   (:require
    [com.devereux-henley.datalog.contract :as dl]))
 
@@ -208,146 +214,156 @@
 (defn games
   "All games. Drives the `game-collection` template and `game-selector`."
   [conn]
-  (->> (dl/q '[:find [(pull ?g pattern) ...]
-               :in $ pattern
-               :where [?g :game/eid]]
-             conn game-pattern)
-       (mapv ->game)
-       (sort-by :name)
-       vec))
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?g pattern) ...]
+                 :in $ pattern
+                 :where [?g :game/eid]]
+               db game-pattern)
+         (mapv ->game)
+         (sort-by :name)
+         vec)))
 
 (defn game-by-eid
   "Single game for the `game` detail template. Returns nil when not found."
   [conn eid]
-  (->game (dl/pull conn game-pattern (dl/lookup-ref :game/eid eid))))
+  (->game (dl/pull (dl/db conn) game-pattern (dl/lookup-ref :game/eid eid))))
 
 ;; ─── Faction queries ───────────────────────────────────────────────────────
 
 (defn factions-for-game
   "Factions for a game, sorted by name. Drives `faction-collection`."
   [conn game-eid]
-  (->> (dl/q '[:find [(pull ?f pattern) ...]
-               :in $ pattern ?game-eid
-               :where
-               [?g :game/eid ?game-eid]
-               [?f :faction/game ?g]]
-             conn faction-pattern game-eid)
-       (mapv ->faction)
-       (sort-by :name)
-       vec))
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?f pattern) ...]
+                 :in $ pattern ?game-eid
+                 :where
+                 [?g :game/eid ?game-eid]
+                 [?f :faction/game ?g]]
+               db faction-pattern game-eid)
+         (mapv ->faction)
+         (sort-by :name)
+         vec)))
 
 (defn factions
   "Every faction in the system, sorted by name."
   [conn]
-  (->> (dl/q '[:find [(pull ?f pattern) ...]
-               :in $ pattern
-               :where [?f :faction/eid]]
-             conn faction-pattern)
-       (mapv ->faction)
-       (sort-by :name)
-       vec))
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?f pattern) ...]
+                 :in $ pattern
+                 :where [?f :faction/eid]]
+               db faction-pattern)
+         (mapv ->faction)
+         (sort-by :name)
+         vec)))
 
 (defn faction-by-eid
   "Single faction for the `faction` detail template."
   [conn eid]
-  (->faction (dl/pull conn faction-pattern (dl/lookup-ref :faction/eid eid))))
+  (->faction (dl/pull (dl/db conn) faction-pattern (dl/lookup-ref :faction/eid eid))))
 
 ;; ─── Unit queries ──────────────────────────────────────────────────────────
 
 (defn units-for-faction
   "Unit summary rows for a faction, sorted by `(unit-category-name, name)`."
   [conn faction-eid]
-  (->> (dl/q '[:find [(pull ?u pattern) ...]
-               :in $ pattern ?faction-eid
-               :where
-               [?f :faction/eid ?faction-eid]
-               [?u :unit/faction ?f]]
-             conn unit-summary-pattern faction-eid)
-       (mapv ->unit-summary)
-       (sort-by (juxt :unit-category-name :name))
-       vec))
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?u pattern) ...]
+                 :in $ pattern ?faction-eid
+                 :where
+                 [?f :faction/eid ?faction-eid]
+                 [?u :unit/faction ?f]]
+               db unit-summary-pattern faction-eid)
+         (mapv ->unit-summary)
+         (sort-by (juxt :unit-category-name :name))
+         vec)))
 
 (defn units-for-game
   "Unit summary rows for a game."
   [conn game-eid]
-  (->> (dl/q '[:find [(pull ?u pattern) ...]
-               :in $ pattern ?game-eid
-               :where
-               [?g :game/eid ?game-eid]
-               [?u :unit/game ?g]]
-             conn unit-summary-pattern game-eid)
-       (mapv ->unit-summary)
-       (sort-by (juxt :unit-category-name :name))
-       vec))
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?u pattern) ...]
+                 :in $ pattern ?game-eid
+                 :where
+                 [?g :game/eid ?game-eid]
+                 [?u :unit/game ?g]]
+               db unit-summary-pattern game-eid)
+         (mapv ->unit-summary)
+         (sort-by (juxt :unit-category-name :name))
+         vec)))
 
 (defn units
   "Every unit summary in the system."
   [conn]
-  (->> (dl/q '[:find [(pull ?u pattern) ...]
-               :in $ pattern
-               :where [?u :unit/eid]]
-             conn unit-summary-pattern)
-       (mapv ->unit-summary)
-       (sort-by (juxt :unit-category-name :name))
-       vec))
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?u pattern) ...]
+                 :in $ pattern
+                 :where [?u :unit/eid]]
+               db unit-summary-pattern)
+         (mapv ->unit-summary)
+         (sort-by (juxt :unit-category-name :name))
+         vec)))
 
 (defn unit-by-eid
   "Full unit row including the decoded `:unit-statistics` document."
   [conn eid]
-  (->unit-detail (dl/pull conn unit-detail-pattern (dl/lookup-ref :unit/eid eid))))
+  (->unit-detail (dl/pull (dl/db conn) unit-detail-pattern (dl/lookup-ref :unit/eid eid))))
 
 ;; ─── Embed queries (game detail + faction detail enrichments) ──────────────
 
 (defn game-modes-for-game
   [conn game-eid]
-  (->> (dl/q '[:find [(pull ?gm pattern) ...]
-               :in $ pattern ?game-eid
-               :where
-               [?g :game/eid ?game-eid]
-               [?gm :game-mode/game ?g]]
-             conn game-mode-pattern game-eid)
-       (mapv ->game-mode)
-       (sort-by :name)
-       vec))
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?gm pattern) ...]
+                 :in $ pattern ?game-eid
+                 :where
+                 [?g :game/eid ?game-eid]
+                 [?gm :game-mode/game ?g]]
+               db game-mode-pattern game-eid)
+         (mapv ->game-mode)
+         (sort-by :name)
+         vec)))
 
 (defn socials-for-game
   [conn game-eid]
-  (->> (dl/q '[:find [(pull ?s pattern) ...]
-               :in $ pattern ?game-eid
-               :where
-               [?g :game/eid ?game-eid]
-               [?s :game-social-link/game ?g]]
-             conn social-link-pattern game-eid)
-       (mapv ->social)
-       (sort-by :platform-name)
-       vec))
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?s pattern) ...]
+                 :in $ pattern ?game-eid
+                 :where
+                 [?g :game/eid ?game-eid]
+                 [?s :game-social-link/game ?g]]
+               db social-link-pattern game-eid)
+         (mapv ->social)
+         (sort-by :platform-name)
+         vec)))
 
 ;; ─── Unit enrichments (detail page) ────────────────────────────────────────
 
 (defn mounts-for-unit
   [conn unit-eid]
-  (->> (dl/q '[:find [(pull ?um pattern) ...]
-               :in $ pattern ?unit-eid
-               :where
-               [?u :unit/eid ?unit-eid]
-               [?um :unit-mount/unit ?u]]
-             conn mount-pattern unit-eid)
-       (mapv ->mount)
-       (sort-by :name)
-       vec))
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?um pattern) ...]
+                 :in $ pattern ?unit-eid
+                 :where
+                 [?u :unit/eid ?unit-eid]
+                 [?um :unit-mount/unit ?u]]
+               db mount-pattern unit-eid)
+         (mapv ->mount)
+         (sort-by :name)
+         vec)))
 
 (defn items-for-unit
   [conn unit-eid]
-  (->> (dl/q '[:find [(pull ?i pattern) ...]
-               :in $ pattern ?unit-eid
-               :where
-               [?u :unit/eid ?unit-eid]
-               [?ui :unit-item/unit ?u]
-               [?ui :unit-item/item ?i]]
-             conn item-pattern unit-eid)
-       (mapv ->item)
-       (sort-by :name)
-       vec))
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?i pattern) ...]
+                 :in $ pattern ?unit-eid
+                 :where
+                 [?u :unit/eid ?unit-eid]
+                 [?ui :unit-item/unit ?u]
+                 [?ui :unit-item/item ?i]]
+               db item-pattern unit-eid)
+         (mapv ->item)
+         (sort-by :name)
+         vec)))
 
 (defn spells-by-keys
   "Resolve a seq of spell keys into a `{key spell-resource}` map."
@@ -356,22 +372,23 @@
     (let [results (dl/q '[:find [(pull ?s pattern) ...]
                           :in $ pattern [?key ...]
                           :where [?s :spell/key ?key]]
-                        conn spell-pattern (vec spell-keys))]
+                        (dl/db conn) spell-pattern (vec spell-keys))]
       (into {} (map (fn [m] [(:spell/key m) (->spell m)])) results))))
 
 (defn spells-for-lore
   "All spells assigned to a given lore key (resolved via spell-lore)."
   [conn lore-key]
-  (->> (dl/q '[:find [(pull ?s pattern) ...]
-               :in $ pattern ?lore-key
-               :where
-               [?l :lore/key ?lore-key]
-               [?sl :spell-lore/lore ?l]
-               [?sl :spell-lore/spell ?s]]
-             conn spell-pattern lore-key)
-       (mapv ->spell)
-       (sort-by :name)
-       vec))
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?s pattern) ...]
+                 :in $ pattern ?lore-key
+                 :where
+                 [?l :lore/key ?lore-key]
+                 [?sl :spell-lore/lore ?l]
+                 [?sl :spell-lore/spell ?s]]
+               db spell-pattern lore-key)
+         (mapv ->spell)
+         (sort-by :name)
+         vec)))
 
 (defn abilities-by-keys
   "Resolve a seq of ability keys into a `{key ability-resource}` map."
@@ -380,5 +397,5 @@
     (let [results (dl/q '[:find [(pull ?a pattern) ...]
                           :in $ pattern [?key ...]
                           :where [?a :ability/key ?key]]
-                        conn ability-pattern (vec ability-keys))]
+                        (dl/db conn) ability-pattern (vec ability-keys))]
       (into {} (map (fn [m] [(:ability/key m) (->ability m)])) results))))

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/draft.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/draft.clj
@@ -89,8 +89,19 @@
               (assoc :attack-modifiers (vec miss-mods))))
           stats)))
 
+(def ^:private stats-object-mapper
+  (jsonista/object-mapper {:decode-key-fn name}))
+
+(defn decode-unit-statistics-json
+  "Decode a SQLite-era unit-statistics JSON string into the string-keyed
+  map shape `parse-unit-statistics` expects. Datalevin callers skip this
+  step — the `:unit-statistics/data` idoc already comes back decoded."
+  [s]
+  (jsonista/read-value s stats-object-mapper))
+
 (defn parse-unit-statistics
-  "Parses a unit-statistics JSON string into a structured map with keys:
+  "Parses a decoded unit-statistics document (string-keyed map) into a
+  structured map with keys:
      :stats            — vector of {:stat name :value val :tooltip str-or-nil} for numeric/list fields
      :health           — integer HP value (rendered separately as a health bar)
      :barrier          — integer barrier value, or nil if absent/zero
@@ -101,9 +112,9 @@
   Mounts are no longer embedded in unit_statistics — they live in the
   `mount` / `unit_mount` tables and are fetched via
   `db/get-mounts-for-unit`."
-  [unit-statistics-str]
+  [stats-doc]
   (let [decoded (m/decode db/unit-statistics-raw-schema
-                          (jsonista/read-value unit-statistics-str (jsonista/object-mapper {:decode-key-fn name}))
+                          stats-doc
                           db/unit-statistics-transformer)]
     {:stats
      (-> (into [] (keep stat-entry) decoded)
@@ -155,7 +166,8 @@
   (m/schema
    [:map {:decode/unit-hydrate
           (fn [unit]
-            (let [{:keys [stats abilities]} (parse-unit-statistics (:unit-statistics unit))]
+            (let [{:keys [stats abilities]} (parse-unit-statistics
+                                             (decode-unit-statistics-json (:unit-statistics unit)))]
               (assoc unit
                      :parsed-stats     stats
                      :parsed-abilities abilities
@@ -455,7 +467,7 @@
   (let [raw-stats    (:stats-override mount)
         raw-granted  (:granted-ability-keys mount)
         parsed       (when (and raw-stats (seq raw-stats))
-                       (parse-unit-statistics raw-stats))
+                       (parse-unit-statistics (decode-unit-statistics-json raw-stats)))
         granted-keys (parse-granted-ability-keys raw-granted)
         granted      (hydrate-granted-abilities conn granted-keys)]
     (cond-> (assoc mount :granted-abilities (or granted []))
@@ -711,7 +723,8 @@
         draft                                                                (db/get-draft-by-eid conn draft-eid)
         game-mode                                                            (db/get-game-mode-by-eid conn (:game-mode-eid draft))
         unit                                                                 (db/get-unit-by-eid conn unit-eid)
-        {:keys [stats health barrier abilities draftable-spells attributes]} (parse-unit-statistics (:unit-statistics unit))
+        {:keys [stats health barrier abilities draftable-spells attributes]} (parse-unit-statistics
+                                                                              (decode-unit-statistics-json (:unit-statistics unit)))
         unit-statistics                                                      (mapv add-stat-percentage stats)
         mounts                                                               (mapv #(hydrate-mount-overrides conn %)
                                                                                    (db/get-mounts-for-unit conn unit-eid))

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/draft_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/draft_test.clj
@@ -72,29 +72,29 @@
 
 (deftest parse-unit-statistics-extracts-stats
   (let [json   "{\"leadership\":75,\"speed\":30,\"armor\":25}"
-        result (handlers.draft/parse-unit-statistics json)]
+        result (handlers.draft/parse-unit-statistics (handlers.draft/decode-unit-statistics-json json))]
     (is (= 3 (count (:stats result))))))
 
 (deftest parse-unit-statistics-excludes-reserved-keys
   (let [json   "{\"leadership\":75,\"abilities\":[\"Frenzy\"],\"mounts\":[{\"name\":\"Horse\",\"mp_cost\":50}]}"
-        result (handlers.draft/parse-unit-statistics json)]
+        result (handlers.draft/parse-unit-statistics (handlers.draft/decode-unit-statistics-json json))]
     (is (every? #(not= "abilities" (:stat %)) (:stats result)))
     (is (every? #(not= "mounts" (:stat %)) (:stats result)))))
 
 (deftest parse-unit-statistics-parses-abilities
   (let [json   "{\"abilities\":[\"Frenzy\",\"Fear\"]}"
-        result (handlers.draft/parse-unit-statistics json)]
+        result (handlers.draft/parse-unit-statistics (handlers.draft/decode-unit-statistics-json json))]
     (is (= ["Frenzy" "Fear"] (:abilities result)))))
 
 (deftest parse-unit-statistics-omits-zero-values
   (let [json   "{\"charge bonus\":0,\"leadership\":50}"
-        result (handlers.draft/parse-unit-statistics json)]
+        result (handlers.draft/parse-unit-statistics (handlers.draft/decode-unit-statistics-json json))]
     (is (= 1 (count (:stats result))))
     (is (= "leadership" (:stat (first (:stats result)))))))
 
 (deftest parse-unit-statistics-omits-empty-vectors
   (let [json   "{\"abilities\":[],\"leadership\":50}"
-        result (handlers.draft/parse-unit-statistics json)]
+        result (handlers.draft/parse-unit-statistics (handlers.draft/decode-unit-statistics-json json))]
     (is (= 1 (count (:stats result))))))
 
 ;; --- hydrate-units-with-stats ---

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/game/api.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/game/api.clj
@@ -2,36 +2,37 @@
   (:require
    [com.devereux-henley.http.contract :as web.core]
    [com.devereux-henley.rts-domain.contract :as domain]
+   [com.devereux-henley.rts-web.web.game.queries :as queries]
    [com.devereux-henley.schema.contract :as schema.contract]
    [integrant.core]
    [reitit.core]))
 
 (defn get-game-by-eid
-  [dependencies eid]
-  (or (domain/get-game-by-eid dependencies eid)
+  [{:keys [datalog-connection]} eid]
+  (or (queries/game-by-eid datalog-connection eid)
       {:type :missing/resource :name "game" :id eid}))
 
 (defn embed-factions
   "Enrichment fn: returns the game model with the game's factions
    embedded under :_embedded.factions. Bound into game-embed-registry
    so /api/game/:eid?embed=factions opts into it."
-  [dependencies model]
+  [{:keys [datalog-connection]} model]
   (assoc-in model [:_embedded :factions]
-            (domain/get-factions-for-game dependencies (:eid model))))
+            (queries/factions-for-game datalog-connection (:eid model))))
 
 (defn embed-game-modes
   "Enrichment fn: returns the game model with its game modes embedded
    under :_embedded.game-modes."
-  [dependencies model]
+  [{:keys [datalog-connection]} model]
   (assoc-in model [:_embedded :game-modes]
-            (domain/get-game-modes-for-game dependencies (:eid model))))
+            (queries/game-modes-for-game datalog-connection (:eid model))))
 
 (defn embed-socials
   "Enrichment fn: returns the game model with the game's social-link
    resources embedded under :_embedded.socials."
-  [dependencies model]
+  [{:keys [datalog-connection]} model]
   (assoc-in model [:_embedded :socials]
-            (domain/get-socials-for-game dependencies (:eid model))))
+            (queries/socials-for-game datalog-connection (:eid model))))
 
 (def game-embed-registry
   {:factions   embed-factions
@@ -47,8 +48,8 @@
 (defn embed-units-by-category
   "Enrichment fn: returns the faction model with its units embedded
    under :_embedded.units-by-category, grouped by unit category."
-  [dependencies model]
-  (let [units             (domain/get-units-for-faction dependencies (:eid model))
+  [{:keys [datalog-connection]} model]
+  (let [units             (queries/units-for-faction datalog-connection (:eid model))
         units-by-category (->> units
                                (partition-by :unit-category-name)
                                (mapv (fn [group]
@@ -71,8 +72,8 @@
       {:type :missing/resource :name "draft" :id eid}))
 
 (defn get-unit-by-eid
-  [dependencies eid]
-  (or (domain/get-unit-by-eid dependencies eid)
+  [{:keys [datalog-connection]} eid]
+  (or (queries/unit-by-eid datalog-connection eid)
       {:type :missing/resource :name "unit" :id eid}))
 
 (defn- enrich-unit
@@ -80,19 +81,20 @@
    and mounts to a unit row. Spells come from `draftable-spells` in
    unit-statistics for fixed-list casters; lore-based casters expose
    the full lore via `:lore`, in which case we fall back to
-   `get-spells-for-lore`."
-  [dependencies {:keys [unit-statistics eid lore] :as unit}]
+   `queries/spells-for-lore`."
+  [{:keys [datalog-connection] :as _dependencies}
+   {:keys [unit-statistics eid lore] :as unit}]
   (let [parsed     (when unit-statistics
                      (domain/parse-unit-statistics unit-statistics))
         ability-ks (:abilities parsed)
         spell-ks   (:draftable-spells parsed)
         abilities  (when (seq ability-ks)
-                     (vals (domain/get-abilities-by-keys dependencies ability-ks)))
+                     (vals (queries/abilities-by-keys datalog-connection ability-ks)))
         spells     (cond
-                     (seq spell-ks) (vals (domain/get-spells-by-keys dependencies spell-ks))
-                     (seq lore)     (domain/get-spells-for-lore dependencies lore))
-        items      (domain/get-items-for-unit dependencies eid)
-        mounts     (domain/get-mounts-for-unit dependencies eid)]
+                     (seq spell-ks) (vals (queries/spells-by-keys datalog-connection spell-ks))
+                     (seq lore)     (queries/spells-for-lore datalog-connection lore))
+        items      (queries/items-for-unit datalog-connection eid)
+        mounts     (queries/mounts-for-unit datalog-connection eid)]
     (-> unit
         (assoc :stats      (vec (:stats parsed))
                :attributes (vec (:attributes parsed))
@@ -104,14 +106,14 @@
                            :mounts    (vec mounts)}))))
 
 (defn get-faction-by-eid
-  [dependencies eid]
-  (or (domain/get-faction-by-eid dependencies eid)
+  [{:keys [datalog-connection]} eid]
+  (or (queries/faction-by-eid datalog-connection eid)
       {:type :missing/resource :name "faction" :id eid}))
 
 (defn get-games
-  [dependencies {:keys [hostname router]}]
+  [{:keys [datalog-connection]} {:keys [hostname router]}]
   {:type      :collection/game
-   :_embedded {:results (domain/get-games dependencies)}
+   :_embedded {:results (queries/games datalog-connection)}
    :_links    {:self (str hostname
                           (-> router
                               (reitit.core/match-by-name! :collection/game)
@@ -144,11 +146,11 @@
                               (get-game-by-eid dependencies eid))))))
 
 (defn get-factions
-  [dependencies game-eid {:keys [hostname router]}]
+  [{:keys [datalog-connection]} game-eid {:keys [hostname router]}]
   {:type      :collection/faction
    :_embedded {:results (if game-eid
-                          (domain/get-factions-for-game dependencies game-eid)
-                          (domain/get-factions dependencies))}
+                          (queries/factions-for-game datalog-connection game-eid)
+                          (queries/factions datalog-connection))}
    :_links    {:self (str hostname
                           (-> router
                               (reitit.core/match-by-name! :collection/faction)
@@ -167,11 +169,11 @@
 (defn get-units
   "Collection builder for /api/unit. When `faction-eid` is set the
    collection is filtered to that faction; nil returns every unit."
-  [dependencies faction-eid {:keys [hostname router]}]
+  [{:keys [datalog-connection]} faction-eid {:keys [hostname router]}]
   {:type      :collection/unit
    :_embedded {:results (vec (if faction-eid
-                               (domain/get-units-for-faction dependencies faction-eid)
-                               (domain/get-units dependencies)))}
+                               (queries/units-for-faction datalog-connection faction-eid)
+                               (queries/units datalog-connection)))}
    :_links    {:self (str hostname
                           (-> router
                               (reitit.core/match-by-name! :collection/unit)

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/game/api.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/game/api.clj
@@ -1,15 +1,15 @@
 (ns com.devereux-henley.rts-web.web.game.api
   (:require
    [com.devereux-henley.http.contract :as web.core]
+   [com.devereux-henley.rts-data-access.contract :as db]
    [com.devereux-henley.rts-domain.contract :as domain]
-   [com.devereux-henley.rts-web.web.game.queries :as queries]
    [com.devereux-henley.schema.contract :as schema.contract]
    [integrant.core]
    [reitit.core]))
 
 (defn get-game-by-eid
   [{:keys [datalog-connection]} eid]
-  (or (queries/game-by-eid datalog-connection eid)
+  (or (db/game-by-eid datalog-connection eid)
       {:type :missing/resource :name "game" :id eid}))
 
 (defn embed-factions
@@ -18,21 +18,21 @@
    so /api/game/:eid?embed=factions opts into it."
   [{:keys [datalog-connection]} model]
   (assoc-in model [:_embedded :factions]
-            (queries/factions-for-game datalog-connection (:eid model))))
+            (db/factions-for-game datalog-connection (:eid model))))
 
 (defn embed-game-modes
   "Enrichment fn: returns the game model with its game modes embedded
    under :_embedded.game-modes."
   [{:keys [datalog-connection]} model]
   (assoc-in model [:_embedded :game-modes]
-            (queries/game-modes-for-game datalog-connection (:eid model))))
+            (db/game-modes-for-game datalog-connection (:eid model))))
 
 (defn embed-socials
   "Enrichment fn: returns the game model with the game's social-link
    resources embedded under :_embedded.socials."
   [{:keys [datalog-connection]} model]
   (assoc-in model [:_embedded :socials]
-            (queries/socials-for-game datalog-connection (:eid model))))
+            (db/socials-for-game datalog-connection (:eid model))))
 
 (def game-embed-registry
   {:factions   embed-factions
@@ -49,7 +49,7 @@
   "Enrichment fn: returns the faction model with its units embedded
    under :_embedded.units-by-category, grouped by unit category."
   [{:keys [datalog-connection]} model]
-  (let [units             (queries/units-for-faction datalog-connection (:eid model))
+  (let [units             (db/units-for-faction datalog-connection (:eid model))
         units-by-category (->> units
                                (partition-by :unit-category-name)
                                (mapv (fn [group]
@@ -73,7 +73,7 @@
 
 (defn get-unit-by-eid
   [{:keys [datalog-connection]} eid]
-  (or (queries/unit-by-eid datalog-connection eid)
+  (or (db/unit-by-eid datalog-connection eid)
       {:type :missing/resource :name "unit" :id eid}))
 
 (defn- enrich-unit
@@ -81,7 +81,7 @@
    and mounts to a unit row. Spells come from `draftable-spells` in
    unit-statistics for fixed-list casters; lore-based casters expose
    the full lore via `:lore`, in which case we fall back to
-   `queries/spells-for-lore`."
+   `db/spells-for-lore`."
   [{:keys [datalog-connection] :as _dependencies}
    {:keys [unit-statistics eid lore] :as unit}]
   (let [parsed     (when unit-statistics
@@ -89,12 +89,12 @@
         ability-ks (:abilities parsed)
         spell-ks   (:draftable-spells parsed)
         abilities  (when (seq ability-ks)
-                     (vals (queries/abilities-by-keys datalog-connection ability-ks)))
+                     (vals (db/abilities-by-keys datalog-connection ability-ks)))
         spells     (cond
-                     (seq spell-ks) (vals (queries/spells-by-keys datalog-connection spell-ks))
-                     (seq lore)     (queries/spells-for-lore datalog-connection lore))
-        items      (queries/items-for-unit datalog-connection eid)
-        mounts     (queries/mounts-for-unit datalog-connection eid)]
+                     (seq spell-ks) (vals (db/spells-by-keys datalog-connection spell-ks))
+                     (seq lore)     (db/spells-for-lore datalog-connection lore))
+        items      (db/items-for-unit datalog-connection eid)
+        mounts     (db/mounts-for-unit datalog-connection eid)]
     (-> unit
         (assoc :stats      (vec (:stats parsed))
                :attributes (vec (:attributes parsed))
@@ -107,13 +107,13 @@
 
 (defn get-faction-by-eid
   [{:keys [datalog-connection]} eid]
-  (or (queries/faction-by-eid datalog-connection eid)
+  (or (db/faction-by-eid datalog-connection eid)
       {:type :missing/resource :name "faction" :id eid}))
 
 (defn get-games
   [{:keys [datalog-connection]} {:keys [hostname router]}]
   {:type      :collection/game
-   :_embedded {:results (queries/games datalog-connection)}
+   :_embedded {:results (db/games datalog-connection)}
    :_links    {:self (str hostname
                           (-> router
                               (reitit.core/match-by-name! :collection/game)
@@ -149,8 +149,8 @@
   [{:keys [datalog-connection]} game-eid {:keys [hostname router]}]
   {:type      :collection/faction
    :_embedded {:results (if game-eid
-                          (queries/factions-for-game datalog-connection game-eid)
-                          (queries/factions datalog-connection))}
+                          (db/factions-for-game datalog-connection game-eid)
+                          (db/factions datalog-connection))}
    :_links    {:self (str hostname
                           (-> router
                               (reitit.core/match-by-name! :collection/faction)
@@ -172,8 +172,8 @@
   [{:keys [datalog-connection]} faction-eid {:keys [hostname router]}]
   {:type      :collection/unit
    :_embedded {:results (vec (if faction-eid
-                               (queries/units-for-faction datalog-connection faction-eid)
-                               (queries/units datalog-connection)))}
+                               (db/units-for-faction datalog-connection faction-eid)
+                               (db/units datalog-connection)))}
    :_links    {:self (str hostname
                           (-> router
                               (reitit.core/match-by-name! :collection/unit)

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/game/queries.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/game/queries.clj
@@ -108,10 +108,10 @@
   (only populated by `->unit-detail`)."
   [m {:keys [include-data?]}]
   (when m
-    (let [stats              (latest-stats (:unit-statistics/_unit m))
-          {ut-eid :unit-type/eid
-           ut-name :unit-type/name} (:unit/unit-type m)
-          {uc-eid :unit-category/eid
+    (let [stats                         (latest-stats (:unit-statistics/_unit m))
+          {ut-eid  :unit-type/eid
+           ut-name :unit-type/name}     (:unit/unit-type m)
+          {uc-eid  :unit-category/eid
            uc-name :unit-category/name} (:unit/unit-category m)]
       (cond-> {:type               :game/unit
                :eid                (:unit/eid m)
@@ -165,7 +165,7 @@
 (defn- ->mount
   [m]
   (when m
-    (let [mount (:unit-mount/mount m)
+    (let [mount   (:unit-mount/mount m)
           granted (:unit-mount/granted-ability-keys m)]
       {:eid                  (:mount/eid mount)
        :key                  (:mount/key mount)
@@ -209,9 +209,9 @@
   "All games. Drives the `game-collection` template and `game-selector`."
   [conn]
   (->> (dl/q '[:find [(pull ?g pattern) ...]
-                    :in $ pattern
-                    :where [?g :game/eid]]
-                  conn game-pattern)
+               :in $ pattern
+               :where [?g :game/eid]]
+             conn game-pattern)
        (mapv ->game)
        (sort-by :name)
        vec))
@@ -227,11 +227,11 @@
   "Factions for a game, sorted by name. Drives `faction-collection`."
   [conn game-eid]
   (->> (dl/q '[:find [(pull ?f pattern) ...]
-                    :in $ pattern ?game-eid
-                    :where
-                    [?g :game/eid ?game-eid]
-                    [?f :faction/game ?g]]
-                  conn faction-pattern game-eid)
+               :in $ pattern ?game-eid
+               :where
+               [?g :game/eid ?game-eid]
+               [?f :faction/game ?g]]
+             conn faction-pattern game-eid)
        (mapv ->faction)
        (sort-by :name)
        vec))
@@ -240,9 +240,9 @@
   "Every faction in the system, sorted by name."
   [conn]
   (->> (dl/q '[:find [(pull ?f pattern) ...]
-                    :in $ pattern
-                    :where [?f :faction/eid]]
-                  conn faction-pattern)
+               :in $ pattern
+               :where [?f :faction/eid]]
+             conn faction-pattern)
        (mapv ->faction)
        (sort-by :name)
        vec))
@@ -258,11 +258,11 @@
   "Unit summary rows for a faction, sorted by `(unit-category-name, name)`."
   [conn faction-eid]
   (->> (dl/q '[:find [(pull ?u pattern) ...]
-                    :in $ pattern ?faction-eid
-                    :where
-                    [?f :faction/eid ?faction-eid]
-                    [?u :unit/faction ?f]]
-                  conn unit-summary-pattern faction-eid)
+               :in $ pattern ?faction-eid
+               :where
+               [?f :faction/eid ?faction-eid]
+               [?u :unit/faction ?f]]
+             conn unit-summary-pattern faction-eid)
        (mapv ->unit-summary)
        (sort-by (juxt :unit-category-name :name))
        vec))
@@ -271,11 +271,11 @@
   "Unit summary rows for a game."
   [conn game-eid]
   (->> (dl/q '[:find [(pull ?u pattern) ...]
-                    :in $ pattern ?game-eid
-                    :where
-                    [?g :game/eid ?game-eid]
-                    [?u :unit/game ?g]]
-                  conn unit-summary-pattern game-eid)
+               :in $ pattern ?game-eid
+               :where
+               [?g :game/eid ?game-eid]
+               [?u :unit/game ?g]]
+             conn unit-summary-pattern game-eid)
        (mapv ->unit-summary)
        (sort-by (juxt :unit-category-name :name))
        vec))
@@ -284,9 +284,9 @@
   "Every unit summary in the system."
   [conn]
   (->> (dl/q '[:find [(pull ?u pattern) ...]
-                    :in $ pattern
-                    :where [?u :unit/eid]]
-                  conn unit-summary-pattern)
+               :in $ pattern
+               :where [?u :unit/eid]]
+             conn unit-summary-pattern)
        (mapv ->unit-summary)
        (sort-by (juxt :unit-category-name :name))
        vec))
@@ -301,11 +301,11 @@
 (defn game-modes-for-game
   [conn game-eid]
   (->> (dl/q '[:find [(pull ?gm pattern) ...]
-                    :in $ pattern ?game-eid
-                    :where
-                    [?g :game/eid ?game-eid]
-                    [?gm :game-mode/game ?g]]
-                  conn game-mode-pattern game-eid)
+               :in $ pattern ?game-eid
+               :where
+               [?g :game/eid ?game-eid]
+               [?gm :game-mode/game ?g]]
+             conn game-mode-pattern game-eid)
        (mapv ->game-mode)
        (sort-by :name)
        vec))
@@ -313,11 +313,11 @@
 (defn socials-for-game
   [conn game-eid]
   (->> (dl/q '[:find [(pull ?s pattern) ...]
-                    :in $ pattern ?game-eid
-                    :where
-                    [?g :game/eid ?game-eid]
-                    [?s :game-social-link/game ?g]]
-                  conn social-link-pattern game-eid)
+               :in $ pattern ?game-eid
+               :where
+               [?g :game/eid ?game-eid]
+               [?s :game-social-link/game ?g]]
+             conn social-link-pattern game-eid)
        (mapv ->social)
        (sort-by :platform-name)
        vec))
@@ -327,11 +327,11 @@
 (defn mounts-for-unit
   [conn unit-eid]
   (->> (dl/q '[:find [(pull ?um pattern) ...]
-                    :in $ pattern ?unit-eid
-                    :where
-                    [?u :unit/eid ?unit-eid]
-                    [?um :unit-mount/unit ?u]]
-                  conn mount-pattern unit-eid)
+               :in $ pattern ?unit-eid
+               :where
+               [?u :unit/eid ?unit-eid]
+               [?um :unit-mount/unit ?u]]
+             conn mount-pattern unit-eid)
        (mapv ->mount)
        (sort-by :name)
        vec))
@@ -339,12 +339,12 @@
 (defn items-for-unit
   [conn unit-eid]
   (->> (dl/q '[:find [(pull ?i pattern) ...]
-                    :in $ pattern ?unit-eid
-                    :where
-                    [?u :unit/eid ?unit-eid]
-                    [?ui :unit-item/unit ?u]
-                    [?ui :unit-item/item ?i]]
-                  conn item-pattern unit-eid)
+               :in $ pattern ?unit-eid
+               :where
+               [?u :unit/eid ?unit-eid]
+               [?ui :unit-item/unit ?u]
+               [?ui :unit-item/item ?i]]
+             conn item-pattern unit-eid)
        (mapv ->item)
        (sort-by :name)
        vec))
@@ -354,21 +354,21 @@
   [conn spell-keys]
   (when (seq spell-keys)
     (let [results (dl/q '[:find [(pull ?s pattern) ...]
-                               :in $ pattern [?key ...]
-                               :where [?s :spell/key ?key]]
-                             conn spell-pattern (vec spell-keys))]
+                          :in $ pattern [?key ...]
+                          :where [?s :spell/key ?key]]
+                        conn spell-pattern (vec spell-keys))]
       (into {} (map (fn [m] [(:spell/key m) (->spell m)])) results))))
 
 (defn spells-for-lore
   "All spells assigned to a given lore key (resolved via spell-lore)."
   [conn lore-key]
   (->> (dl/q '[:find [(pull ?s pattern) ...]
-                    :in $ pattern ?lore-key
-                    :where
-                    [?l :lore/key ?lore-key]
-                    [?sl :spell-lore/lore ?l]
-                    [?sl :spell-lore/spell ?s]]
-                  conn spell-pattern lore-key)
+               :in $ pattern ?lore-key
+               :where
+               [?l :lore/key ?lore-key]
+               [?sl :spell-lore/lore ?l]
+               [?sl :spell-lore/spell ?s]]
+             conn spell-pattern lore-key)
        (mapv ->spell)
        (sort-by :name)
        vec))
@@ -378,7 +378,7 @@
   [conn ability-keys]
   (when (seq ability-keys)
     (let [results (dl/q '[:find [(pull ?a pattern) ...]
-                               :in $ pattern [?key ...]
-                               :where [?a :ability/key ?key]]
-                             conn ability-pattern (vec ability-keys))]
+                          :in $ pattern [?key ...]
+                          :where [?a :ability/key ?key]]
+                        conn ability-pattern (vec ability-keys))]
       (into {} (map (fn [m] [(:ability/key m) (->ability m)])) results))))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/game/queries.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/game/queries.clj
@@ -1,0 +1,384 @@
+(ns com.devereux-henley.rts-web.web.game.queries
+  "Per-template Datalevin pull/q queries for the game domain. Each public fn
+  matches one template's data shape (game-collection, game detail,
+  faction-collection, faction detail, unit-collection, unit detail,
+  game-selector). Handlers in `web.game.view`, `web.game.api`, and
+  `web.view` call these instead of the SQLite-era `query/game.clj` fns;
+  the SQL path lives until `rts-khy` retires it.
+
+  Result maps use unqualified keys (`:eid`, `:name`, `:game-eid`, …) so the
+  existing resource schemas in `rts-domain` and Selmer templates render
+  unchanged. Foreign-key refs are pulled as `{<ns>/eid uuid}` sub-maps and
+  flattened to `:<thing>-eid` to match the SQLite-era entity shape."
+  (:require
+   [com.devereux-henley.datalog.contract :as dl]))
+
+;; ─── Pull patterns ─────────────────────────────────────────────────────────
+
+(def ^:private game-pattern
+  [:game/eid :game/name :game/description])
+
+(def ^:private faction-pattern
+  [:faction/eid :faction/name :faction/key :faction/description
+   {:faction/game [:game/eid]}])
+
+(def ^:private unit-summary-pattern
+  "Shape for unit lists / cards. Includes only the fields list templates and
+   the resource collection schemas read; full statline lives on the detail
+   pattern."
+  [:unit/eid :unit/key :unit/name :unit/family-name :unit/description
+   :unit/mark :unit/lore :unit/is-unique
+   {:unit/game [:game/eid]}
+   {:unit/faction [:faction/eid]}
+   {:unit/unit-type [:unit-type/eid :unit-type/name]}
+   {:unit/unit-category [:unit-category/eid :unit-category/name]}
+   {:unit-statistics/_unit [:unit-statistics/cost
+                            {:unit-statistics/patch [:patch/released-at]}]}])
+
+(def ^:private unit-detail-pattern
+  "Adds the full statistics document for the unit detail view."
+  [:unit/eid :unit/key :unit/name :unit/family-name :unit/description
+   :unit/mark :unit/lore :unit/is-unique
+   {:unit/game [:game/eid]}
+   {:unit/faction [:faction/eid]}
+   {:unit/unit-type [:unit-type/eid :unit-type/name]}
+   {:unit/unit-category [:unit-category/eid :unit-category/name]}
+   {:unit-statistics/_unit [:unit-statistics/cost :unit-statistics/data
+                            {:unit-statistics/patch [:patch/released-at]}]}])
+
+(def ^:private game-mode-pattern
+  [:game-mode/eid :game-mode/name :game-mode/description :game-mode/draft-value
+   :game-mode/player-count :game-mode/reinforcement-value
+   :game-mode/reinforcements-enabled
+   {:game-mode/game [:game/eid]}])
+
+(def ^:private social-link-pattern
+  [:game-social-link/eid :game-social-link/url
+   {:game-social-link/game [:game/eid]}
+   {:game-social-link/platform [:social-media-platform/eid
+                                :social-media-platform/name
+                                :social-media-platform/description
+                                :social-media-platform/platform-url]}])
+
+(def ^:private mount-pattern
+  [:unit-mount/cost :unit-mount/stats-override :unit-mount/granted-ability-keys
+   {:unit-mount/mount [:mount/eid :mount/key :mount/name :mount/icon-key]}])
+
+(def ^:private item-pattern
+  [:item/eid :item/key :item/name :item/category :item/cost :item/icon-key])
+
+(def ^:private spell-pattern
+  [:spell/eid :spell/key :spell/name :spell/mana-cost :spell/cost])
+
+(def ^:private ability-pattern
+  [:ability/eid :ability/key :ability/name :ability/description :ability/cost])
+
+;; ─── Result builders ───────────────────────────────────────────────────────
+
+(defn- latest-stats
+  "Pick the unit-statistics record with the most recent patch released-at
+  from a `:unit-statistics/_unit` reverse-ref pull result."
+  [stats-rows]
+  (->> stats-rows
+       (sort-by (comp :patch/released-at :unit-statistics/patch))
+       last))
+
+(defn- ->game
+  [m]
+  (when m
+    {:type        :game/game
+     :eid         (:game/eid m)
+     :name        (:game/name m)
+     :description (:game/description m)}))
+
+(defn- ->faction
+  [m]
+  (when m
+    {:type        :game/faction
+     :eid         (:faction/eid m)
+     :name        (:faction/name m)
+     :key         (:faction/key m)
+     :description (:faction/description m)
+     :game-eid    (some-> m :faction/game :game/eid)}))
+
+(defn- ->unit-row
+  "Build the row shape `unit-entity` consumers expect from a pull result.
+  `stats-rows` is the `:unit-statistics/_unit` vector; the latest patch's
+  cost lands on `:cost`, and `:unit-statistics` carries the decoded doc
+  (only populated by `->unit-detail`)."
+  [m {:keys [include-data?]}]
+  (when m
+    (let [stats              (latest-stats (:unit-statistics/_unit m))
+          {ut-eid :unit-type/eid
+           ut-name :unit-type/name} (:unit/unit-type m)
+          {uc-eid :unit-category/eid
+           uc-name :unit-category/name} (:unit/unit-category m)]
+      (cond-> {:type               :game/unit
+               :eid                (:unit/eid m)
+               :key                (:unit/key m)
+               :name               (:unit/name m)
+               :family-name        (:unit/family-name m)
+               :description        (:unit/description m)
+               :mark               (some-> (:unit/mark m) name)
+               :lore               (:unit/lore m)
+               :is-unique          (if (:unit/is-unique m) 1 0)
+               :game-eid           (some-> m :unit/game :game/eid)
+               :faction-eid        (some-> m :unit/faction :faction/eid)
+               :unit-type-eid      ut-eid
+               :unit-type-name     ut-name
+               :unit-category-eid  uc-eid
+               :unit-category-name uc-name
+               :cost               (:unit-statistics/cost stats)}
+        include-data? (assoc :unit-statistics (:unit-statistics/data stats))))))
+
+(defn- ->unit-summary [m] (->unit-row m {:include-data? false}))
+(defn- ->unit-detail  [m] (->unit-row m {:include-data? true}))
+
+(defn- ->game-mode
+  [m]
+  (when m
+    {:eid                    (:game-mode/eid m)
+     :name                   (:game-mode/name m)
+     :description            (:game-mode/description m)
+     :draft-value            (:game-mode/draft-value m)
+     :player-count           (:game-mode/player-count m)
+     :reinforcement-value    (:game-mode/reinforcement-value m)
+     :reinforcements-enabled (:game-mode/reinforcements-enabled m)
+     :game-eid               (some-> m :game-mode/game :game/eid)}))
+
+(defn- ->social
+  [m]
+  (when m
+    (let [{p-eid  :social-media-platform/eid
+           p-name :social-media-platform/name
+           p-desc :social-media-platform/description
+           p-url  :social-media-platform/platform-url} (:game-social-link/platform m)]
+      {:type                      :game/social
+       :eid                       (:game-social-link/eid m)
+       :url                       (:game-social-link/url m)
+       :game-eid                  (some-> m :game-social-link/game :game/eid)
+       :social-media-platform-eid p-eid
+       :platform-name             p-name
+       :platform-description      p-desc
+       :platform-url              p-url})))
+
+(defn- ->mount
+  [m]
+  (when m
+    (let [mount (:unit-mount/mount m)
+          granted (:unit-mount/granted-ability-keys m)]
+      {:eid                  (:mount/eid mount)
+       :key                  (:mount/key mount)
+       :name                 (:mount/name mount)
+       :icon-key             (:mount/icon-key mount)
+       :cost                 (:unit-mount/cost m)
+       :stats-override       (:unit-mount/stats-override m)
+       :granted-ability-keys (when (seq granted) (vec granted))})))
+
+(defn- ->item
+  [m]
+  (when m
+    {:eid      (:item/eid m)
+     :key      (:item/key m)
+     :name     (:item/name m)
+     :category (:item/category m)
+     :cost     (:item/cost m)
+     :icon-key (:item/icon-key m)}))
+
+(defn- ->spell
+  [m]
+  (when m
+    {:eid       (:spell/eid m)
+     :key       (:spell/key m)
+     :name      (:spell/name m)
+     :mana-cost (:spell/mana-cost m)
+     :cost      (:spell/cost m)}))
+
+(defn- ->ability
+  [m]
+  (when m
+    {:eid         (:ability/eid m)
+     :key         (:ability/key m)
+     :name        (:ability/name m)
+     :description (:ability/description m)
+     :cost        (:ability/cost m)}))
+
+;; ─── Game queries ──────────────────────────────────────────────────────────
+
+(defn games
+  "All games. Drives the `game-collection` template and `game-selector`."
+  [conn]
+  (->> (dl/q '[:find [(pull ?g pattern) ...]
+                    :in $ pattern
+                    :where [?g :game/eid]]
+                  conn game-pattern)
+       (mapv ->game)
+       (sort-by :name)
+       vec))
+
+(defn game-by-eid
+  "Single game for the `game` detail template. Returns nil when not found."
+  [conn eid]
+  (->game (dl/pull conn game-pattern (dl/lookup-ref :game/eid eid))))
+
+;; ─── Faction queries ───────────────────────────────────────────────────────
+
+(defn factions-for-game
+  "Factions for a game, sorted by name. Drives `faction-collection`."
+  [conn game-eid]
+  (->> (dl/q '[:find [(pull ?f pattern) ...]
+                    :in $ pattern ?game-eid
+                    :where
+                    [?g :game/eid ?game-eid]
+                    [?f :faction/game ?g]]
+                  conn faction-pattern game-eid)
+       (mapv ->faction)
+       (sort-by :name)
+       vec))
+
+(defn factions
+  "Every faction in the system, sorted by name."
+  [conn]
+  (->> (dl/q '[:find [(pull ?f pattern) ...]
+                    :in $ pattern
+                    :where [?f :faction/eid]]
+                  conn faction-pattern)
+       (mapv ->faction)
+       (sort-by :name)
+       vec))
+
+(defn faction-by-eid
+  "Single faction for the `faction` detail template."
+  [conn eid]
+  (->faction (dl/pull conn faction-pattern (dl/lookup-ref :faction/eid eid))))
+
+;; ─── Unit queries ──────────────────────────────────────────────────────────
+
+(defn units-for-faction
+  "Unit summary rows for a faction, sorted by `(unit-category-name, name)`."
+  [conn faction-eid]
+  (->> (dl/q '[:find [(pull ?u pattern) ...]
+                    :in $ pattern ?faction-eid
+                    :where
+                    [?f :faction/eid ?faction-eid]
+                    [?u :unit/faction ?f]]
+                  conn unit-summary-pattern faction-eid)
+       (mapv ->unit-summary)
+       (sort-by (juxt :unit-category-name :name))
+       vec))
+
+(defn units-for-game
+  "Unit summary rows for a game."
+  [conn game-eid]
+  (->> (dl/q '[:find [(pull ?u pattern) ...]
+                    :in $ pattern ?game-eid
+                    :where
+                    [?g :game/eid ?game-eid]
+                    [?u :unit/game ?g]]
+                  conn unit-summary-pattern game-eid)
+       (mapv ->unit-summary)
+       (sort-by (juxt :unit-category-name :name))
+       vec))
+
+(defn units
+  "Every unit summary in the system."
+  [conn]
+  (->> (dl/q '[:find [(pull ?u pattern) ...]
+                    :in $ pattern
+                    :where [?u :unit/eid]]
+                  conn unit-summary-pattern)
+       (mapv ->unit-summary)
+       (sort-by (juxt :unit-category-name :name))
+       vec))
+
+(defn unit-by-eid
+  "Full unit row including the decoded `:unit-statistics` document."
+  [conn eid]
+  (->unit-detail (dl/pull conn unit-detail-pattern (dl/lookup-ref :unit/eid eid))))
+
+;; ─── Embed queries (game detail + faction detail enrichments) ──────────────
+
+(defn game-modes-for-game
+  [conn game-eid]
+  (->> (dl/q '[:find [(pull ?gm pattern) ...]
+                    :in $ pattern ?game-eid
+                    :where
+                    [?g :game/eid ?game-eid]
+                    [?gm :game-mode/game ?g]]
+                  conn game-mode-pattern game-eid)
+       (mapv ->game-mode)
+       (sort-by :name)
+       vec))
+
+(defn socials-for-game
+  [conn game-eid]
+  (->> (dl/q '[:find [(pull ?s pattern) ...]
+                    :in $ pattern ?game-eid
+                    :where
+                    [?g :game/eid ?game-eid]
+                    [?s :game-social-link/game ?g]]
+                  conn social-link-pattern game-eid)
+       (mapv ->social)
+       (sort-by :platform-name)
+       vec))
+
+;; ─── Unit enrichments (detail page) ────────────────────────────────────────
+
+(defn mounts-for-unit
+  [conn unit-eid]
+  (->> (dl/q '[:find [(pull ?um pattern) ...]
+                    :in $ pattern ?unit-eid
+                    :where
+                    [?u :unit/eid ?unit-eid]
+                    [?um :unit-mount/unit ?u]]
+                  conn mount-pattern unit-eid)
+       (mapv ->mount)
+       (sort-by :name)
+       vec))
+
+(defn items-for-unit
+  [conn unit-eid]
+  (->> (dl/q '[:find [(pull ?i pattern) ...]
+                    :in $ pattern ?unit-eid
+                    :where
+                    [?u :unit/eid ?unit-eid]
+                    [?ui :unit-item/unit ?u]
+                    [?ui :unit-item/item ?i]]
+                  conn item-pattern unit-eid)
+       (mapv ->item)
+       (sort-by :name)
+       vec))
+
+(defn spells-by-keys
+  "Resolve a seq of spell keys into a `{key spell-resource}` map."
+  [conn spell-keys]
+  (when (seq spell-keys)
+    (let [results (dl/q '[:find [(pull ?s pattern) ...]
+                               :in $ pattern [?key ...]
+                               :where [?s :spell/key ?key]]
+                             conn spell-pattern (vec spell-keys))]
+      (into {} (map (fn [m] [(:spell/key m) (->spell m)])) results))))
+
+(defn spells-for-lore
+  "All spells assigned to a given lore key (resolved via spell-lore)."
+  [conn lore-key]
+  (->> (dl/q '[:find [(pull ?s pattern) ...]
+                    :in $ pattern ?lore-key
+                    :where
+                    [?l :lore/key ?lore-key]
+                    [?sl :spell-lore/lore ?l]
+                    [?sl :spell-lore/spell ?s]]
+                  conn spell-pattern lore-key)
+       (mapv ->spell)
+       (sort-by :name)
+       vec))
+
+(defn abilities-by-keys
+  "Resolve a seq of ability keys into a `{key ability-resource}` map."
+  [conn ability-keys]
+  (when (seq ability-keys)
+    (let [results (dl/q '[:find [(pull ?a pattern) ...]
+                               :in $ pattern [?key ...]
+                               :where [?a :ability/key ?key]]
+                             conn ability-pattern (vec ability-keys))]
+      (into {} (map (fn [m] [(:ability/key m) (->ability m)])) results))))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/game/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/game/view.clj
@@ -1,9 +1,9 @@
 (ns com.devereux-henley.rts-web.web.game.view
   (:require
    [clojure.java.io :as io]
+   [com.devereux-henley.rts-data-access.contract :as db]
    [com.devereux-henley.rts-domain.contract :as domain]
    [com.devereux-henley.rts-web.render :as render]
-   [com.devereux-henley.rts-web.web.game.queries :as queries]
    [com.devereux-henley.rts-web.web.view :as web.view]
    [integrant.core]))
 
@@ -33,10 +33,10 @@
   [_init-key {:keys [datalog-connection]}]
   (partial web.view/standard-entity-view-handler
            (fn [eid]
-             (if-let [faction (queries/faction-by-eid datalog-connection eid)]
+             (if-let [faction (db/faction-by-eid datalog-connection eid)]
                (assoc-in faction [:_embedded :units-by-category]
                          (units-by-category
-                          (queries/units-for-faction datalog-connection eid)))
+                          (db/units-for-faction datalog-connection eid)))
                {:type :missing/resource :name "faction" :id eid}))
            "faction.html"
            (fn [_data _request] {})))
@@ -49,8 +49,8 @@
   (if lore-key
     (mapv (fn [{:keys [eid key name mana-cost cost]}]
             {:eid eid :key key :name name :mana-cost mana-cost :cost cost})
-          (queries/spells-for-lore conn lore-key))
-    (let [key->spell (queries/spells-by-keys conn draftable-spells)]
+          (db/spells-for-lore conn lore-key))
+    (let [key->spell (db/spells-by-keys conn draftable-spells)]
       (mapv (fn [k]
               (let [spell (get key->spell k)]
                 {:name      (or (:name spell) k)
@@ -63,7 +63,7 @@
   "Resolve ability keys against the ability table, preserving the input
   order so the rendered list matches the order the unit lists them."
   [conn ability-keys]
-  (let [key->ability (queries/abilities-by-keys conn ability-keys)]
+  (let [key->ability (db/abilities-by-keys conn ability-keys)]
     (mapv (fn [k]
             (let [a (get key->ability k)]
               {:name        (:name a)
@@ -75,7 +75,7 @@
   [_init-key {:keys [datalog-connection]}]
   (partial web.view/standard-entity-view-handler
            (fn [eid]
-             (or (queries/unit-by-eid datalog-connection eid)
+             (or (db/unit-by-eid datalog-connection eid)
                  {:type :missing/resource :name "unit" :id eid}))
            "unit.html"
            (fn [data _request]
@@ -83,8 +83,8 @@
                    lore-key                                   (:lore data)
                    resolved-spells                            (resolve-spells datalog-connection lore-key draftable-spells)
                    resolved-abilities                         (resolve-abilities datalog-connection abilities)
-                   mounts                                     (queries/mounts-for-unit datalog-connection (:eid data))
-                   items                                      (queries/items-for-unit datalog-connection (:eid data))
+                   mounts                                     (db/mounts-for-unit datalog-connection (:eid data))
+                   items                                      (db/items-for-unit datalog-connection (:eid data))
                    portrait-stem                              (:eid data)]
                {:unit-statistics  stats
                 :abilities        (not-empty resolved-abilities)

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/game/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/game/view.clj
@@ -3,7 +3,7 @@
    [clojure.java.io :as io]
    [com.devereux-henley.rts-domain.contract :as domain]
    [com.devereux-henley.rts-web.render :as render]
-   [com.devereux-henley.rts-web.web.game.api :as web.game.api]
+   [com.devereux-henley.rts-web.web.game.queries :as queries]
    [com.devereux-henley.rts-web.web.view :as web.view]
    [integrant.core]))
 
@@ -19,55 +19,72 @@
                                  (assoc (web.view/base-context request)
                                         :data (:game (:game-context request))))}))
 
+(defn- units-by-category
+  "Group a faction's units by category. The query sorts by
+  `(unit-category-name, name)` so a sequential partition produces stable
+  groups without resorting."
+  [units]
+  (mapv (fn [group]
+          {:category (:unit-category-name (first group))
+           :units    (vec group)})
+        (partition-by :unit-category-name units)))
+
 (defmethod integrant.core/init-key ::faction-view
-  [_init-key dependencies]
+  [_init-key {:keys [datalog-connection]}]
   (partial web.view/standard-entity-view-handler
            (fn [eid]
-             (web.game.api/embed-units-by-category
-              dependencies
-              (web.game.api/get-faction-by-eid dependencies eid)))
+             (if-let [faction (queries/faction-by-eid datalog-connection eid)]
+               (assoc-in faction [:_embedded :units-by-category]
+                         (units-by-category
+                          (queries/units-for-faction datalog-connection eid)))
+               {:type :missing/resource :name "faction" :id eid}))
            "faction.html"
            (fn [_data _request] {})))
 
+(defn- resolve-spells
+  "Spell resolution for unit detail: lore-based wizards pull from the
+  `spell-lore` table; fixed-list casters resolve `draftable-spells` keys
+  against the spell table."
+  [conn lore-key draftable-spells]
+  (if lore-key
+    (mapv (fn [{:keys [eid key name mana-cost cost]}]
+            {:eid eid :key key :name name :mana-cost mana-cost :cost cost})
+          (queries/spells-for-lore conn lore-key))
+    (let [key->spell (queries/spells-by-keys conn draftable-spells)]
+      (mapv (fn [k]
+              (let [spell (get key->spell k)]
+                {:name      (or (:name spell) k)
+                 :eid       (:eid spell)
+                 :mana-cost (:mana-cost spell)
+                 :cost      (:cost spell)}))
+            draftable-spells))))
+
+(defn- resolve-abilities
+  "Resolve ability keys against the ability table, preserving the input
+  order so the rendered list matches the order the unit lists them."
+  [conn ability-keys]
+  (let [key->ability (queries/abilities-by-keys conn ability-keys)]
+    (mapv (fn [k]
+            (let [a (get key->ability k)]
+              {:name        (:name a)
+               :eid         (:eid a)
+               :description (:description a)}))
+          ability-keys)))
+
 (defmethod integrant.core/init-key ::unit-view
-  [_init-key dependencies]
+  [_init-key {:keys [datalog-connection]}]
   (partial web.view/standard-entity-view-handler
-           (fn [eid] (web.game.api/get-unit-by-eid dependencies eid))
+           (fn [eid]
+             (or (queries/unit-by-eid datalog-connection eid)
+                 {:type :missing/resource :name "unit" :id eid}))
            "unit.html"
            (fn [data _request]
              (let [{:keys [stats abilities draftable-spells]} (domain/parse-unit-statistics (:unit-statistics data))
                    lore-key                                   (:lore data)
-                   ;; Wizard rows carry a `lore` column.  When set, the
-                   ;; spell pool comes from the canonical spell_lore
-                   ;; junction (one source of truth per lore); otherwise
-                   ;; the unit's own draftable-spells from
-                   ;; unit_statistics applies (unique characters / non-
-                   ;; spellcasters).
-                   resolved-spells                            (if lore-key
-                                                                (mapv (fn [{:keys [key eid name mana-cost cost]}]
-                                                                        {:name      name
-                                                                         :key       key
-                                                                         :eid       eid
-                                                                         :mana-cost mana-cost
-                                                                         :cost      cost})
-                                                                      (domain/get-spells-for-lore dependencies lore-key))
-                                                                (let [key->spell (domain/get-spells-by-keys dependencies draftable-spells)]
-                                                                  (mapv (fn [k]
-                                                                          (let [spell (get key->spell k)]
-                                                                            {:name      (or (:name spell) k)
-                                                                             :eid       (:eid spell)
-                                                                             :mana-cost (:mana-cost spell)
-                                                                             :cost      (:cost spell)}))
-                                                                        draftable-spells)))
-                   key->ability                               (domain/get-abilities-by-keys dependencies abilities)
-                   resolved-abilities                         (mapv (fn [k]
-                                                                      (let [a (get key->ability k)]
-                                                                        {:name        (:name a)
-                                                                         :eid         (:eid a)
-                                                                         :description (:description a)}))
-                                                                    abilities)
-                   mounts                                     (domain/get-mounts-for-unit dependencies (:eid data))
-                   items                                      (domain/get-items-for-unit dependencies (:eid data))
+                   resolved-spells                            (resolve-spells datalog-connection lore-key draftable-spells)
+                   resolved-abilities                         (resolve-abilities datalog-connection abilities)
+                   mounts                                     (queries/mounts-for-unit datalog-connection (:eid data))
+                   items                                      (queries/items-for-unit datalog-connection (:eid data))
                    portrait-stem                              (:eid data)]
                {:unit-statistics  stats
                 :abilities        (not-empty resolved-abilities)

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
@@ -6,9 +6,9 @@
   Domain-specific view handlers live in `web/<domain>/view.clj`."
   (:require
    [clojure.string :as string]
-   [com.devereux-henley.rts-domain.contract :as domain]
    [com.devereux-henley.rts-web.render :as render]
    [com.devereux-henley.rts-web.skin :as skin]
+   [com.devereux-henley.rts-web.web.game.queries :as queries]
    [integrant.core]
    [selmer.filters]
    [taoensso.timbre :as log]))
@@ -64,25 +64,25 @@
                                           (extra-data-fn data request)))})))
 
 (defmethod integrant.core/init-key ::game-context-middleware
-  [_init-key dependencies]
+  [_init-key {:keys [datalog-connection]}]
   (fn [handler]
     (fn [request]
       (let [game-eid (get-in request [:parameters :path :game-eid])
-            game     (domain/get-game-by-eid dependencies game-eid)]
+            game     (queries/game-by-eid datalog-connection game-eid)]
         (if game
           (handler (assoc request :game-context {:game-eid game-eid
                                                  :game     (assoc game :logo (skin/logo-for-game game-eid))
-                                                 :factions (domain/get-factions-for-game dependencies game-eid)
-                                                 :socials  (domain/get-socials-for-game dependencies game-eid)
+                                                 :factions (queries/factions-for-game datalog-connection game-eid)
+                                                 :socials  (queries/socials-for-game datalog-connection game-eid)
                                                  :skin     (skin/skin-for-game game-eid)}))
           {:status 404 :body {:type :missing/resource :name "game" :id game-eid}})))))
 
 (defmethod integrant.core/init-key ::game-selector-view
-  [_init-key dependencies]
+  [_init-key {:keys [datalog-connection]}]
   (fn [request]
     (let [games (mapv (fn [game]
                         (assoc game :logo (skin/logo-for-game (:eid game))))
-                      (domain/get-games dependencies))]
+                      (queries/games datalog-connection))]
       {:status 200
        :body   (render/render-view "game-selector.html"
                                    (assoc (base-context request) :games games))})))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/view.clj
@@ -6,9 +6,9 @@
   Domain-specific view handlers live in `web/<domain>/view.clj`."
   (:require
    [clojure.string :as string]
+   [com.devereux-henley.rts-data-access.contract :as db]
    [com.devereux-henley.rts-web.render :as render]
    [com.devereux-henley.rts-web.skin :as skin]
-   [com.devereux-henley.rts-web.web.game.queries :as queries]
    [integrant.core]
    [selmer.filters]
    [taoensso.timbre :as log]))
@@ -68,12 +68,12 @@
   (fn [handler]
     (fn [request]
       (let [game-eid (get-in request [:parameters :path :game-eid])
-            game     (queries/game-by-eid datalog-connection game-eid)]
+            game     (db/game-by-eid datalog-connection game-eid)]
         (if game
           (handler (assoc request :game-context {:game-eid game-eid
                                                  :game     (assoc game :logo (skin/logo-for-game game-eid))
-                                                 :factions (queries/factions-for-game datalog-connection game-eid)
-                                                 :socials  (queries/socials-for-game datalog-connection game-eid)
+                                                 :factions (db/factions-for-game datalog-connection game-eid)
+                                                 :socials  (db/socials-for-game datalog-connection game-eid)
                                                  :skin     (skin/skin-for-game game-eid)}))
           {:status 404 :body {:type :missing/resource :name "game" :id game-eid}})))))
 
@@ -82,7 +82,7 @@
   (fn [request]
     (let [games (mapv (fn [game]
                         (assoc game :logo (skin/logo-for-game (:eid game))))
-                      (queries/games datalog-connection))]
+                      (db/games datalog-connection))]
       {:status 200
        :body   (render/render-view "game-selector.html"
                                    (assoc (base-context request) :games games))})))


### PR DESCRIPTION
## Summary

Pilot of the SQLite → Datalevin migration for the game domain (epic **rts-nnv**). Introduces `components/rts-web/.../web/game/queries.clj` — one `pull`/`q` per template — and swaps 12 init-keys across `web/game/view.clj`, `web/game/api.clj`, and `web/view.clj` from `domain/get-*` (SQLite) to `queries/*` (Datalevin).

### What changes

- **New `queries.clj`** — 7 template-driven public fns (`games`, `game-by-eid`, `factions{-for-game,-by-eid}`, `units{-for-faction,-for-game,-by-eid}`, plus `game-selector` is just `games`) and 5 enrichment fns (`game-modes-for-game`, `socials-for-game`, `mounts-for-unit`, `items-for-unit`, `spells-{by-keys,for-lore}`, `abilities-by-keys`). Each result builder normalises pulls to the SQLite-era key shape (`:eid`, `:game-eid`, …) and sets the `:type` discriminator so existing rts-domain resource schemas validate.
- **Handler rewires** — `view/faction-list-view`, `view/faction-view`, `view/unit-view`, `view/game-index-view` (web/game/view.clj); `api/get-games`, `api/get-game`, `api/get-faction`, `api/get-factions-collection`, `api/get-unit`, `api/get-units-collection` + the four embed helpers (web/game/api.clj); `view/game-selector-view` and `view/game-context-middleware` (web/view.clj). All inject `:datalog-connection` from the new default-dependencies key.
- **`datalog.contract/q`** now accepts a connection OR a db value (mirrors `pull`), so call sites don't pre-unwrap.
- **`parse-unit-statistics`** is map-in (closes **rts-jmt** behaviour-side). The three SQLite-era callers in `handlers/draft.clj` decode their JSON column at the call site via the new `decode-unit-statistics-json` helper; those decodes vanish when **rts-9ri** migrates draft.

### What deliberately doesn't change (next beads)

- `query/game.clj` + `resources/.../sql/game/` — **rts-khy** retires them after draft also migrates
- `/api` JSON routes — same templated HTML surface
- Live Playwright sweep — **rts-stn** does it next

### Verification

REPL-driven against a seeded patch-8.0 Datalevin store. All 11 game-domain routes return 200 with content matching the SQLite render: faction page shows unit categories + linked units, unit page shows stats / abilities / embedded mounts + items, embed=factions/game-modes/socials all populate.

## Test plan

- [x] `clj-kondo --lint` on changed files — 0 errors, 2 warnings (both pre-existing on `main`)
- [x] `cljfmt fix` — one realignment inside `parse-unit-statistics`, included in the same commit
- [x] `clojure -M:poly check` — clean
- [x] `clojure -M:poly test` — green on rts-domain (80 tests, 140 assertions), all other affected bricks
- [x] Manual route walk: `/view/game/index.html`, `/view/game/:eid/index.html`, `/view/game/:eid/faction/index.html`, `/view/game/:eid/faction/:eid/index.html`, `/view/game/:eid/unit/:eid/index.html`, `/api/game`, `/api/game/:eid?embed=factions&embed=game-modes&embed=socials`, `/api/faction[?game-eid=]`, `/api/faction/:eid?embed=units-by-category`, `/api/unit[?faction-eid=]`, `/api/unit/:eid` — all 200
- [ ] Playwright e2e sweep — deferred to **rts-stn**

🤖 Generated with [Claude Code](https://claude.com/claude-code)