### PR TITLE
Datalog schema: :draft/* and :draft-entry/* (rts-vgs)

### DIFF
--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog.clj
@@ -32,6 +32,8 @@
   (:require
    [com.devereux-henley.rts-data-access.schema.datalog.ability :as schema.datalog.ability]
    [com.devereux-henley.rts-data-access.schema.datalog.attribute :as schema.datalog.attribute]
+   [com.devereux-henley.rts-data-access.schema.datalog.draft :as schema.datalog.draft]
+   [com.devereux-henley.rts-data-access.schema.datalog.draft-entry :as schema.datalog.draft-entry]
    [com.devereux-henley.rts-data-access.schema.datalog.faction :as schema.datalog.faction]
    [com.devereux-henley.rts-data-access.schema.datalog.game :as schema.datalog.game]
    [com.devereux-henley.rts-data-access.schema.datalog.game-mode :as schema.datalog.game-mode]
@@ -57,6 +59,8 @@
   (merge
    schema.datalog.ability/schema
    schema.datalog.attribute/schema
+   schema.datalog.draft/schema
+   schema.datalog.draft-entry/schema
    schema.datalog.faction/schema
    schema.datalog.game/schema
    schema.datalog.game-mode/schema

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/draft.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/draft.clj
@@ -1,0 +1,37 @@
+(ns com.devereux-henley.rts-data-access.schema.datalog.draft
+  "Datalevin attributes for the `:draft` entity — a player's army-composition
+  build for a specific `:game-mode` and `:faction`.
+
+  Drafts are user-mutated, so the SQLite-era audit columns
+  (`:draft/created-by-sub`, `:draft/version`, `:draft/created-at`,
+  `:draft/updated-at`) survive the migration; the seed-loader pattern that
+  lets game/faction/unit drop those doesn't apply here.
+
+  Army entries are decomposed out of the SQLite `draft_state` JSON blob
+  into `:draft-entry` entities, owned via the cardinality-many
+  `:draft/entries` ref. To list a draft's entries:
+
+    (datalog/q '[:find (pull ?e […])
+                 :in $ ?draft-eid
+                 :where
+                 [?d :draft/eid ?draft-eid]
+                 [?d :draft/entries ?e]]
+               db draft-eid)
+
+  Entries carry `:draft-entry/section` (`:main` vs `:reinforcements`) and
+  `:draft-entry/ordinal`, so the JSON-era `{:main [...], :reinforcements
+  [...]}` shape is rebuilt by grouping + sorting at the query layer.")
+
+(def schema
+  {:draft/eid            {:db/valueType :db.type/uuid
+                          :db/unique    :db.unique/identity}
+   :draft/name           {:db/valueType :db.type/string}
+   :draft/player-sub     {:db/valueType :db.type/string}
+   :draft/game-mode      {:db/valueType :db.type/ref}
+   :draft/faction        {:db/valueType :db.type/ref}
+   :draft/version        {:db/valueType :db.type/long}
+   :draft/created-by-sub {:db/valueType :db.type/string}
+   :draft/created-at     {:db/valueType :db.type/instant}
+   :draft/updated-at     {:db/valueType :db.type/instant}
+   :draft/entries        {:db/valueType   :db.type/ref
+                          :db/cardinality :db.cardinality/many}})

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/draft_entry.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/draft_entry.clj
@@ -1,0 +1,44 @@
+(ns com.devereux-henley.rts-data-access.schema.datalog.draft-entry
+  "Datalevin attributes for the `:draft-entry` entity — one army slot in a
+  draft. Decomposed out of the SQLite `draft_state.state` JSON blob, where
+  each entry was a map under `:main` / `:reinforcements`.
+
+  `:draft-entry/section` is a keyword enum `#{:main :reinforcements}`
+  (mirrors `:unit/mark`'s SQLite-CHECK-becomes-domain-invariant pattern).
+  `:draft-entry/ordinal` preserves the JSON-array order within a section
+  so rendering stays stable across edits — sets in datalog are unordered,
+  so a per-section `(:draft-entry/ordinal)` sort restores the prior shape.
+
+  `:draft-entry/abilities`, `…/spells`, `…/items` stay as cardinality-many
+  string keys (engine keys), matching how `:unit-mount/granted-ability-keys`
+  and `:unit/lore` handle key references — joins against `:ability/key`,
+  `:spell/key`, `:item/key` happen at the query layer when full resources
+  are needed.
+
+  `:draft-entry/total-cost` is the app-computed total for the unit as
+  configured (mount + level + items). `:draft-entry/engine-cost` is the
+  parser-emitted cost from the replay-parsed flow; a divergence between
+  the two is a data signal, not an error.
+
+  Entries don't carry a back-pointer to their owning draft — the
+  relationship lives on the parent as the cardinality-many
+  `:draft/entries`. To find a parent draft from an entry-eid, query
+  `[?d :draft/entries ?e]` or pull `:draft/_entries`.")
+
+(def schema
+  {:draft-entry/eid         {:db/valueType :db.type/uuid
+                             :db/unique    :db.unique/identity}
+   :draft-entry/unit        {:db/valueType :db.type/ref}
+   :draft-entry/section     {:db/valueType :db.type/keyword}
+   :draft-entry/ordinal     {:db/valueType :db.type/long}
+   :draft-entry/mount       {:db/valueType :db.type/string}
+   :draft-entry/lore        {:db/valueType :db.type/string}
+   :draft-entry/level       {:db/valueType :db.type/long}
+   :draft-entry/abilities   {:db/valueType   :db.type/string
+                             :db/cardinality :db.cardinality/many}
+   :draft-entry/spells      {:db/valueType   :db.type/string
+                             :db/cardinality :db.cardinality/many}
+   :draft-entry/items       {:db/valueType   :db.type/string
+                             :db/cardinality :db.cardinality/many}
+   :draft-entry/total-cost  {:db/valueType :db.type/long}
+   :draft-entry/engine-cost {:db/valueType :db.type/long}})


### PR DESCRIPTION
## Summary

First step of the draft-domain migration (rts-9ri). Two new schema namespaces decomposing the SQLite `draft` + `draft_state` tables into addressable datalevin entities. No behaviour change yet — the existing SQLite path keeps serving drafts; this commit just makes the target shape exist.

### Attributes

| `:draft/`         | `:draft-entry/`       |
| ----------------- | --------------------- |
| eid               | eid                   |
| name              | unit (ref)            |
| player-sub        | section (keyword)     |
| game-mode (ref)   | ordinal               |
| faction (ref)     | mount, lore, level    |
| version           | abilities (many)      |
| created-by-sub    | spells (many)         |
| created-at        | items (many)          |
| updated-at        | total-cost            |
| entries (many ref) | engine-cost          |

### Design notes

- **Audit columns survive.** Drafts are user-mutated, so `version`, `created-by-sub`, `created-at`, `updated-at` carry forward — the seed-loader drop rule that game/faction/unit followed doesn't apply.
- **Parent owns the relationship.** `:draft/entries` is cardinality-many on the draft side, matching the bead's explicit guidance. No `:draft-entry/draft` back-ref needed — `:draft/_entries` (reverse-ref pull) or `[?d :draft/entries ?e]` covers entry → parent navigation.
- **`:draft-entry/section`** is `:db.type/keyword` (`#{:main :reinforcements}`) — mirrors `:unit/mark`'s pattern of turning a SQLite CHECK constraint into a domain-side invariant.
- **`:draft-entry/ordinal`** restores the JSON-array order the SQLite `draft_state.state` blob preserved implicitly; datalog sets are unordered, so a per-section `(sort-by :draft-entry/ordinal)` rebuilds the prior shape at the query layer.
- **Engine-key columns stay strings.** `:draft-entry/abilities`, `…/spells`, `…/items` are cardinality-many strings, matching `:unit-mount/granted-ability-keys` and `:unit/lore`. Joins to full resources happen at the query layer (next bead, rts-6mz).

### Verification

REPL round-trip on the running system after `(datalog.contract/update-schema conn …)`:
- Draft transacted with `[:game-mode/eid uuid]` + `[:faction/eid uuid]` lookup refs.
- Two entries created, one `:main` and one `:reinforcements`, with cardinality-many `:draft-entry/abilities` populated.
- Pull walks `:draft/entries` → `:draft-entry/unit` → `:unit/name` cleanly and returns the expected nested shape.

## Test plan

- [x] `clojure -M:cljfmt check` — clean
- [x] `clj-kondo --lint` on the three touched files — 0 warnings
- [x] `clojure -M:poly check` — clean
- [ ] Per-template queries + handler refactor — rts-6mz
- [ ] Seed migration of existing drafts — rts-t2d
- [ ] Action fragments use datalog mutations — rts-mx3

🤖 Generated with [Claude Code](https://claude.com/claude-code)