### PR TITLE
Draft migration script: SQLite → Datalevin (rts-t2d)

### DIFF
--- a/development/src/migrate_draft.clj
+++ b/development/src/migrate_draft.clj
@@ -1,0 +1,184 @@
+(ns migrate-draft
+  "Offline dev tool: read every active SQLite draft + its JSON `draft_state`
+  blob and write the equivalent `:draft` + `:draft-entry` entities into
+  Datalevin. One-shot — re-running upserts (all keys are
+  `:db.unique/identity`) so this is also the migration recipe for prod.
+
+  Run against the live system after `(claude-workspace/go!)`:
+
+    (require 'migrate-draft :reload)
+    (migrate-draft/migrate!)            ; uses the running conn + dev SQLite
+    (migrate-draft/verify!)             ; round-trip counts SQLite vs datalog
+
+  Drafts without a `draft_state` row are still migrated (just no
+  entries) — the SQLite app creates the row lazily on first edit.
+
+  This namespace is dev-only; it is **not** loaded by the API base."
+  (:require
+   [com.devereux-henley.datalog.contract :as datalog]
+   [com.devereux-henley.rts-api.db :as rts-db]
+   [integrant.repl.state :as ig-state]
+   [jsonista.core :as jsonista]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as rs])
+  (:import
+   [java.time Instant]
+   [java.util Date UUID]))
+
+;;; ─── Helpers ──────────────────────────────────────────────────────────────
+
+(def ^:private state-object-mapper
+  (jsonista/object-mapper {:decode-key-fn keyword}))
+
+(def ^:private jdbc-opts
+  {:builder-fn rs/as-unqualified-kebab-maps})
+
+(defn- ->uuid
+  [s]
+  (when s (UUID/fromString s)))
+
+(defn- ->long
+  "Coerce a value to long. Legacy state entries from before schema
+  enforcement stored some ints as strings (`\"500\"`, `\"0\"`); this
+  normalises them. Returns nil for nil input."
+  [v]
+  (cond
+    (nil? v)     nil
+    (integer? v) (long v)
+    (string? v)  (Long/parseLong v)
+    :else        (long v)))
+
+(defn- parse-instant
+  [s]
+  (when s (Date/from (Instant/parse s))))
+
+(defn- assoc-some
+  "Like `assoc`, but skips keys whose value is nil or an empty string."
+  [m k v]
+  (if (or (nil? v) (= "" v))
+    m
+    (assoc m k v)))
+
+;;; ─── Entry → tx-data ─────────────────────────────────────────────────────
+
+(defn- ->entry-tx
+  "Turn one decoded JSON state-entry into a `:draft-entry/*` tx map.
+  `section` is `:main` or `:reinforcements`; `ordinal` preserves the
+  source array position."
+  [section ordinal {:keys [entry-eid unit-eid mount lore level
+                           abilities spells items
+                           total-cost engine-cost]}]
+  (cond-> {:draft-entry/eid     (or (->uuid entry-eid) (random-uuid))
+           :draft-entry/unit    [:unit/eid (->uuid unit-eid)]
+           :draft-entry/section section
+           :draft-entry/ordinal ordinal
+           :draft-entry/level   (or (->long level) 0)}
+    mount               (assoc :draft-entry/mount mount)
+    lore                (assoc :draft-entry/lore lore)
+    (seq abilities)     (assoc :draft-entry/abilities (vec abilities))
+    (seq spells)        (assoc :draft-entry/spells (vec spells))
+    (seq items)         (assoc :draft-entry/items (vec items))
+    (some? total-cost)  (assoc :draft-entry/total-cost (->long total-cost))
+    (some? engine-cost) (assoc :draft-entry/engine-cost (->long engine-cost))))
+
+(defn- ->draft-tx
+  "Turn one SQLite draft row (joined with its optional state blob and the
+  parent game-mode / faction eids) into a `:draft/*` tx map carrying its
+  entries inline under `:draft/entries`."
+  [{:keys [eid name player-sub version created-by-sub created-at updated-at
+           faction-eid game-mode-eid state]}]
+  (let [parsed (when state (jsonista/read-value state state-object-mapper))
+        main   (->> (:main parsed)
+                    (map-indexed (fn [i e] (->entry-tx :main i e))))
+        reinf  (->> (:reinforcements parsed)
+                    (map-indexed (fn [i e] (->entry-tx :reinforcements i e))))]
+    (cond-> {:draft/eid            (->uuid eid)
+             :draft/player-sub     player-sub
+             :draft/game-mode      [:game-mode/eid (->uuid game-mode-eid)]
+             :draft/faction        [:faction/eid (->uuid faction-eid)]
+             :draft/version        version
+             :draft/created-by-sub created-by-sub
+             :draft/created-at     (parse-instant created-at)
+             :draft/updated-at     (parse-instant updated-at)
+             :draft/entries        (vec (concat main reinf))}
+      name (assoc-some :draft/name name))))
+
+;;; ─── Orchestrator ─────────────────────────────────────────────────────────
+
+(def ^:private read-drafts-sql
+  "SELECT d.eid, d.name, d.player_sub, d.version,
+          d.created_by_sub, d.created_at, d.updated_at,
+          f.eid  AS faction_eid,
+          gm.eid AS game_mode_eid,
+          ds.state
+     FROM draft d
+     JOIN faction   f  ON f.id  = d.faction_id
+     JOIN game_mode gm ON gm.id = d.game_mode_id
+     LEFT JOIN draft_state ds ON ds.draft_id = d.id
+    WHERE d.deleted_at IS NULL
+    ORDER BY d.id")
+
+(defn- read-rows
+  [db-spec]
+  (jdbc/execute! db-spec [read-drafts-sql] jdbc-opts))
+
+(defn- conn-or-throw
+  []
+  (or (get ig-state/system :com.devereux-henley.rts-api.datalog/connection)
+      (throw (ex-info "Datalevin conn not in integrant.repl.state/system — call (claude-workspace/go!) first" {}))))
+
+(defn migrate!
+  "Migrate every active SQLite draft into Datalevin. Returns a summary
+  map `{:drafts n :entries n}`. Idempotent — re-runs upsert via the
+  `:db.unique/identity` on `:draft/eid` and `:draft-entry/eid`."
+  ([] (migrate! {}))
+  ([{:keys [db-spec conn]
+     :or   {db-spec rts-db/db-spec
+            conn    (conn-or-throw)}}]
+   (let [rows        (read-rows db-spec)
+         txs         (mapv ->draft-tx rows)
+         entry-count (transduce (map #(count (:draft/entries %))) + 0 txs)]
+     (println (format "Migrating %d draft(s), %d entry(ies) …"
+                      (count txs) entry-count))
+     (datalog/transact! conn txs)
+     (println "Done.")
+     {:drafts (count txs) :entries entry-count})))
+
+(defn verify!
+  "Cross-check counts after a migration. Compares the SQLite draft row
+  count against the Datalevin `[?d :draft/eid]` count, and the sum of
+  JSON entries against the `[?e :draft-entry/eid]` count."
+  ([] (verify! {}))
+  ([{:keys [db-spec conn]
+     :or   {db-spec rts-db/db-spec
+            conn    (conn-or-throw)}}]
+   (let [sqlite-drafts  (-> (jdbc/execute-one!
+                             db-spec
+                             ["SELECT COUNT(*) AS c FROM draft WHERE deleted_at IS NULL"]
+                             jdbc-opts)
+                            :c)
+         sqlite-entries (transduce
+                         (map (fn [{:keys [state]}]
+                                (if state
+                                  (let [p (jsonista/read-value state state-object-mapper)]
+                                    (+ (count (:main p)) (count (:reinforcements p))))
+                                  0)))
+                         +
+                         0
+                         (read-rows db-spec))
+         db             (datalog/db conn)
+         dl-drafts      (or (datalog/q '[:find (count ?d) . :where [?d :draft/eid]] db) 0)
+         dl-entries     (or (datalog/q '[:find (count ?e) . :where [?e :draft-entry/eid]] db) 0)]
+     (println (format "SQLite:   %4d drafts, %4d entries" sqlite-drafts sqlite-entries))
+     (println (format "Datalog:  %4d drafts, %4d entries" dl-drafts dl-entries))
+     {:sqlite/drafts   sqlite-drafts
+      :sqlite/entries  sqlite-entries
+      :datalog/drafts  dl-drafts
+      :datalog/entries dl-entries
+      :match?          (and (= sqlite-drafts dl-drafts)
+                            (= sqlite-entries dl-entries))})))
+
+(comment
+  ;; After `(claude-workspace/go!)` + `(claude-workspace/seed-datalog!)`:
+  (migrate!)
+  (verify!))


### PR DESCRIPTION
## Summary

One-shot dev tool that reads every active SQLite `draft` + its JSON `draft_state` blob and upserts the equivalent `:draft` / `:draft-entry` entities into Datalevin. Idempotent (every key is `:db.unique/identity`), so the same recipe is the production migration script.

Two public fns:

- **`migrate!`** — joins `draft` + `draft_state` + `faction` + `game_mode`, parses the JSON state into per-section entry tx maps, batches the whole thing into a single `datalog/transact!`. Section keyword (`:main` / `:reinforcements`) and per-section ordinal preserve the JSON-array order.
- **`verify!`** — round-trip counts. Reads the SQLite draft count + sum of state entries, queries the same from Datalevin, reports `:match?`. Helps confirm a clean cutover.

### Two production-shape gotchas surfaced

- **Legacy state entries from before schema enforcement** stored some ints as strings (`:level "0"`, `:total-cost "500"`). Added a `->long` coercion at the entry boundary so the `:db.type/long` attributes don't reject the tx.
- **next.jdbc's default builder** gives table-prefixed keys (`:draft_state/state`, not `:state`). Switched to `as-unqualified-kebab-maps` — the same builder the dump tool uses — so the SQL aliases destructure cleanly.

### Verified end-to-end on the dev DB

```
Migrating 32 draft(s), 144 entry(ies) …
Done.
SQLite:     32 drafts,  144 entries
Datalog:    32 drafts,  144 entries  ; match? true
```

Spot-pull on `"Trial of the Everchosen R3 G1"` returns the expected 10 `:main` + 12 `:reinforcements` entries, with mount keys (`"mount_steam_tank"`), total-cost (2700), level (0), and unit refs (`Master Engineer`) all preserved.

The migration tool stays dev-only — not loaded by the API base — and will be retired alongside the SQLite path once **rts-kxn** deletes the JSON-state code.

## Test plan

- [x] `clojure -M:cljfmt fix` — clean (one realignment included in same commit)
- [x] `clj-kondo --lint development/src/migrate_draft.clj` — 0 errors, 0 warnings
- [x] `clojure -M:poly check` — clean
- [x] REPL: `(migrate!)` then `(verify!)` produces match on the dev DB
- [x] Spot-pull on a migrated draft returns the expected nested shape (game-mode, faction, sectioned entries with mount + cost + unit refs)
- [ ] Per-template queries + handler refactor — rts-6mz
- [ ] Action fragments use datalog mutations — rts-mx3
- [ ] Playwright sweep — rts-9c4

🤖 Generated with [Claude Code](https://claude.com/claude-code)