### PR TITLE
Tournament Datalevin schema: decompose tournament_state blob (rts-vt9)

### DIFF
--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog.clj
@@ -41,6 +41,8 @@
    [com.devereux-henley.rts-data-access.schema.datalog.item :as schema.datalog.item]
    [com.devereux-henley.rts-data-access.schema.datalog.league :as schema.datalog.league]
    [com.devereux-henley.rts-data-access.schema.datalog.lore :as schema.datalog.lore]
+   [com.devereux-henley.rts-data-access.schema.datalog.match :as schema.datalog.match]
+   [com.devereux-henley.rts-data-access.schema.datalog.match-game :as schema.datalog.match-game]
    [com.devereux-henley.rts-data-access.schema.datalog.mount :as schema.datalog.mount]
    [com.devereux-henley.rts-data-access.schema.datalog.patch :as schema.datalog.patch]
    [com.devereux-henley.rts-data-access.schema.datalog.replay :as schema.datalog.replay]
@@ -49,6 +51,10 @@
    [com.devereux-henley.rts-data-access.schema.datalog.spell :as schema.datalog.spell]
    [com.devereux-henley.rts-data-access.schema.datalog.spell-lore :as schema.datalog.spell-lore]
    [com.devereux-henley.rts-data-access.schema.datalog.subfaction :as schema.datalog.subfaction]
+   [com.devereux-henley.rts-data-access.schema.datalog.tournament :as schema.datalog.tournament]
+   [com.devereux-henley.rts-data-access.schema.datalog.tournament-entry :as schema.datalog.tournament-entry]
+   [com.devereux-henley.rts-data-access.schema.datalog.tournament-phase :as schema.datalog.tournament-phase]
+   [com.devereux-henley.rts-data-access.schema.datalog.tournament-round :as schema.datalog.tournament-round]
    [com.devereux-henley.rts-data-access.schema.datalog.unit :as schema.datalog.unit]
    [com.devereux-henley.rts-data-access.schema.datalog.unit-category :as schema.datalog.unit-category]
    [com.devereux-henley.rts-data-access.schema.datalog.unit-item :as schema.datalog.unit-item]
@@ -71,6 +77,8 @@
    schema.datalog.item/schema
    schema.datalog.league/schema
    schema.datalog.lore/schema
+   schema.datalog.match/schema
+   schema.datalog.match-game/schema
    schema.datalog.mount/schema
    schema.datalog.patch/schema
    schema.datalog.replay/schema
@@ -79,6 +87,10 @@
    schema.datalog.spell/schema
    schema.datalog.spell-lore/schema
    schema.datalog.subfaction/schema
+   schema.datalog.tournament/schema
+   schema.datalog.tournament-entry/schema
+   schema.datalog.tournament-phase/schema
+   schema.datalog.tournament-round/schema
    schema.datalog.unit/schema
    schema.datalog.unit-category/schema
    schema.datalog.unit-item/schema

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/match.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/match.clj
@@ -1,30 +1,13 @@
 (ns com.devereux-henley.rts-data-access.schema.datalog.match
-  "Datalevin attributes for the `:match` entity — a head-to-head pairing
-  within a tournament round. Mirrors the SQLite `match` row.
-
-  The match references its tournament via `:match/tournament`; navigate
-  from the tournament with the reverse ref `:match/_tournament`. A
-  match's place in the format is kept as the integer pair
-  `:match/phase-index` + `:match/round-index` (not refs to
-  `:tournament-phase`/`:tournament-round`) because the rules engine groups
-  and pairs matches by these indices — `rules.tournament` does
-  `(group-by :phase-index …)` and `(get phases phase-index)`, so scalar
-  indices are the natural key.
-
-  Enums are promoted to `:db.type/keyword` (membership enforced in the
-  domain layer):
-
-  - `:match/status` `#{:pending :complete}`
-  - `:match/bracket-type` `#{:winners :losers :grand-final}`
-
-  `:match/format` is the best-of count (1/3/5). `:match/player-one-sub`,
-  `…/player-two-sub`, and `…/winner-sub` are Ory subject strings, not refs
-  — there is no player entity. `player-two-sub` is absent on a bye;
-  `winner-sub` is absent until the match completes (`\"draw\"` is a
-  sentinel winner for drawn Swiss/round-robin matches).
-
-  A match owns its games via the cardinality-many `:match/games` ref to
-  `:match-game` entities; to find a game's match, pull `:match/_games`.")
+  "Datalevin attributes for the `:match` entity — a head-to-head pairing in
+  a tournament round. References its tournament via `:match/tournament`;
+  its place in the format is the integer pair `:match/phase-index` +
+  `:match/round-index`. Enums are keywords: `:match/status` `#{:pending
+  :complete}`, `:match/bracket-type` `#{:winners :losers :grand-final}`.
+  `:match/format` is the best-of count. Player and winner subs are Ory
+  subject strings; `player-two-sub` is absent on a bye and `winner-sub`
+  until the match completes (`\"draw\"` marks a drawn match). Owns its
+  games via the cardinality-many `:match/games`.")
 
 (def schema
   {:match/eid            {:db/valueType :db.type/uuid

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/match.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/match.clj
@@ -1,0 +1,44 @@
+(ns com.devereux-henley.rts-data-access.schema.datalog.match
+  "Datalevin attributes for the `:match` entity — a head-to-head pairing
+  within a tournament round. Mirrors the SQLite `match` row.
+
+  The match references its tournament via `:match/tournament`; navigate
+  from the tournament with the reverse ref `:match/_tournament`. A
+  match's place in the format is kept as the integer pair
+  `:match/phase-index` + `:match/round-index` (not refs to
+  `:tournament-phase`/`:tournament-round`) because the rules engine groups
+  and pairs matches by these indices — `rules.tournament` does
+  `(group-by :phase-index …)` and `(get phases phase-index)`, so scalar
+  indices are the natural key.
+
+  Enums are promoted to `:db.type/keyword` (membership enforced in the
+  domain layer):
+
+  - `:match/status` `#{:pending :complete}`
+  - `:match/bracket-type` `#{:winners :losers :grand-final}`
+
+  `:match/format` is the best-of count (1/3/5). `:match/player-one-sub`,
+  `…/player-two-sub`, and `…/winner-sub` are Ory subject strings, not refs
+  — there is no player entity. `player-two-sub` is absent on a bye;
+  `winner-sub` is absent until the match completes (`\"draw\"` is a
+  sentinel winner for drawn Swiss/round-robin matches).
+
+  A match owns its games via the cardinality-many `:match/games` ref to
+  `:match-game` entities; to find a game's match, pull `:match/_games`.")
+
+(def schema
+  {:match/eid            {:db/valueType :db.type/uuid
+                          :db/unique    :db.unique/identity}
+   :match/tournament     {:db/valueType :db.type/ref}
+   :match/phase-index    {:db/valueType :db.type/long}
+   :match/round-index    {:db/valueType :db.type/long}
+   :match/bracket-type   {:db/valueType :db.type/keyword}
+   :match/player-one-sub {:db/valueType :db.type/string}
+   :match/player-two-sub {:db/valueType :db.type/string}
+   :match/winner-sub     {:db/valueType :db.type/string}
+   :match/status         {:db/valueType :db.type/keyword}
+   :match/format         {:db/valueType :db.type/long}
+   :match/created-at     {:db/valueType :db.type/instant}
+   :match/updated-at     {:db/valueType :db.type/instant}
+   :match/games          {:db/valueType   :db.type/ref
+                          :db/cardinality :db.cardinality/many}})

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/match_game.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/match_game.clj
@@ -1,22 +1,10 @@
 (ns com.devereux-henley.rts-data-access.schema.datalog.match-game
   "Datalevin attributes for the `:match-game` entity — a single game within
-  a best-of-N `:match`. Mirrors the SQLite `match_game` row.
-
-  Games are owned by their match via the cardinality-many `:match/games`
-  ref; to find a game's match, pull `:match/_games`.
-  `:match-game/game-index` is the 0-based position in the series and
-  `:match-game/winner-sub` the Ory subject of the game winner.
-
-  The replay and per-side drafts are now genuine datalog refs
-  (`:match-game/replay` → `:replay`, `:match-game/player-one-draft` /
-  `…/player-two-draft` → `:draft`). Under SQLite these were integer FKs to
-  `draft(id)` / `replay(id)`; once draft (rts-9ri) and replay (rts-23h)
-  moved to Datalevin those FKs went permanently NULL. Modelling them as
-  refs here restores the link the replay-submission flow already builds.
-
-  `:match-game/uploader-local-alliance-index` records which alliance
-  (0/1) the uploading player occupied in the parsed replay, so the
-  per-side drafts can be mapped back to the right player.")
+  a best-of-N `:match`, owned via `:match/games`. `:game-index` is its
+  0-based position in the series. `:match-game/replay` refs the parsed
+  `:replay`; `:player-one-draft` / `:player-two-draft` ref the per-side
+  `:draft`s. `:uploader-local-alliance-index` records which alliance (0/1)
+  the uploader played, mapping the per-side drafts back to each player.")
 
 (def schema
   {:match-game/eid                           {:db/valueType :db.type/uuid

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/match_game.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/match_game.clj
@@ -1,0 +1,30 @@
+(ns com.devereux-henley.rts-data-access.schema.datalog.match-game
+  "Datalevin attributes for the `:match-game` entity — a single game within
+  a best-of-N `:match`. Mirrors the SQLite `match_game` row.
+
+  Games are owned by their match via the cardinality-many `:match/games`
+  ref; to find a game's match, pull `:match/_games`.
+  `:match-game/game-index` is the 0-based position in the series and
+  `:match-game/winner-sub` the Ory subject of the game winner.
+
+  The replay and per-side drafts are now genuine datalog refs
+  (`:match-game/replay` → `:replay`, `:match-game/player-one-draft` /
+  `…/player-two-draft` → `:draft`). Under SQLite these were integer FKs to
+  `draft(id)` / `replay(id)`; once draft (rts-9ri) and replay (rts-23h)
+  moved to Datalevin those FKs went permanently NULL. Modelling them as
+  refs here restores the link the replay-submission flow already builds.
+
+  `:match-game/uploader-local-alliance-index` records which alliance
+  (0/1) the uploading player occupied in the parsed replay, so the
+  per-side drafts can be mapped back to the right player.")
+
+(def schema
+  {:match-game/eid                           {:db/valueType :db.type/uuid
+                                              :db/unique    :db.unique/identity}
+   :match-game/game-index                    {:db/valueType :db.type/long}
+   :match-game/winner-sub                    {:db/valueType :db.type/string}
+   :match-game/replay                        {:db/valueType :db.type/ref}
+   :match-game/uploader-local-alliance-index {:db/valueType :db.type/long}
+   :match-game/player-one-draft              {:db/valueType :db.type/ref}
+   :match-game/player-two-draft              {:db/valueType :db.type/ref}
+   :match-game/created-at                    {:db/valueType :db.type/instant}})

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament.clj
@@ -1,0 +1,64 @@
+(ns com.devereux-henley.rts-data-access.schema.datalog.tournament
+  "Datalevin attributes for the `:tournament` entity — a player-organized
+  competition scoped to a single `:game`, optionally nested under a
+  `:league`/`:season`.
+
+  Tournaments are user-mutated, so the SQLite-era audit columns
+  (`:tournament/created-by-sub`, `:tournament/version`,
+  `:tournament/created-at`, `:tournament/updated-at`) survive the
+  migration. Soft-delete (`deleted_at`) is dropped — datalog retracts the
+  entity instead.
+
+  ## State blob decomposition
+
+  The SQLite `tournament_state.state` JSON blob is folded onto this entity
+  and its owned children rather than persisted as an opaque document:
+
+  - `:status` → `:tournament/status` (keyword enum, see below)
+  - `:registration` → `:tournament/registration-opens-at`,
+    `…/registration-closes-at`, `…/timezone`,
+    `…/registration-closed-early`
+  - `:current-phase` → `:tournament/current-phase-index`
+  - `:qualifier-count` → `:tournament/qualifier-count`
+  - `:phases` → the cardinality-many `:tournament/phases` ref to
+    `:tournament-phase` entities (which in turn own `:tournament-round`s)
+  - `:standings` → NOT stored. Standings are derived at the query layer
+    from `:tournament-entry` participants + completed `:match` results
+    (see `rules.tournament/recalculate-standings`), so there is no
+    snapshot to drift.
+
+  `:tournament/status` is a keyword enum `#{:registration :active
+  :complete :cancelled}` (mirrors `:unit/mark`'s SQLite-CHECK-becomes-
+  domain-invariant pattern; the membership set is enforced in the domain
+  layer, not by Datalevin).
+
+  Entries and matches are NOT owned forward — they reference the
+  tournament (`:tournament-entry/tournament`, `:match/tournament`) and are
+  navigated via the reverse refs `:tournament-entry/_tournament` /
+  `:match/_tournament`. They are created, queried, and retracted
+  independently, so reverse ownership keeps those operations from having
+  to read-modify-write a parent collection. Phases, by contrast, are
+  configuration replaced wholesale, so they hang off the forward
+  cardinality-many `:tournament/phases`.")
+
+(def schema
+  {:tournament/eid                       {:db/valueType :db.type/uuid
+                                          :db/unique    :db.unique/identity}
+   :tournament/name                      {:db/valueType :db.type/string}
+   :tournament/description               {:db/valueType :db.type/string}
+   :tournament/game                      {:db/valueType :db.type/ref}
+   :tournament/league                    {:db/valueType :db.type/ref}
+   :tournament/season                    {:db/valueType :db.type/ref}
+   :tournament/created-by-sub            {:db/valueType :db.type/string}
+   :tournament/version                   {:db/valueType :db.type/long}
+   :tournament/created-at                {:db/valueType :db.type/instant}
+   :tournament/updated-at                {:db/valueType :db.type/instant}
+   :tournament/status                    {:db/valueType :db.type/keyword}
+   :tournament/registration-opens-at     {:db/valueType :db.type/instant}
+   :tournament/registration-closes-at    {:db/valueType :db.type/instant}
+   :tournament/timezone                  {:db/valueType :db.type/string}
+   :tournament/registration-closed-early {:db/valueType :db.type/boolean}
+   :tournament/current-phase-index       {:db/valueType :db.type/long}
+   :tournament/qualifier-count           {:db/valueType :db.type/long}
+   :tournament/phases                    {:db/valueType   :db.type/ref
+                                          :db/cardinality :db.cardinality/many}})

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament.clj
@@ -1,45 +1,15 @@
 (ns com.devereux-henley.rts-data-access.schema.datalog.tournament
-  "Datalevin attributes for the `:tournament` entity — a player-organized
-  competition scoped to a single `:game`, optionally nested under a
-  `:league`/`:season`.
+  "Datalevin attributes for the `:tournament` entity — a competition scoped
+  to a `:game`, optionally nested under a `:league`/`:season`.
 
-  Tournaments are user-mutated, so the SQLite-era audit columns
-  (`:tournament/created-by-sub`, `:tournament/version`,
-  `:tournament/created-at`, `:tournament/updated-at`) survive the
-  migration. Soft-delete (`deleted_at`) is dropped — datalog retracts the
-  entity instead.
-
-  ## State blob decomposition
-
-  The SQLite `tournament_state.state` JSON blob is folded onto this entity
-  and its owned children rather than persisted as an opaque document:
-
-  - `:status` → `:tournament/status` (keyword enum, see below)
-  - `:registration` → `:tournament/registration-opens-at`,
-    `…/registration-closes-at`, `…/timezone`,
-    `…/registration-closed-early`
-  - `:current-phase` → `:tournament/current-phase-index`
-  - `:qualifier-count` → `:tournament/qualifier-count`
-  - `:phases` → the cardinality-many `:tournament/phases` ref to
-    `:tournament-phase` entities (which in turn own `:tournament-round`s)
-  - `:standings` → NOT stored. Standings are derived at the query layer
-    from `:tournament-entry` participants + completed `:match` results
-    (see `rules.tournament/recalculate-standings`), so there is no
-    snapshot to drift.
-
-  `:tournament/status` is a keyword enum `#{:registration :active
-  :complete :cancelled}` (mirrors `:unit/mark`'s SQLite-CHECK-becomes-
-  domain-invariant pattern; the membership set is enforced in the domain
-  layer, not by Datalevin).
-
-  Entries and matches are NOT owned forward — they reference the
-  tournament (`:tournament-entry/tournament`, `:match/tournament`) and are
-  navigated via the reverse refs `:tournament-entry/_tournament` /
-  `:match/_tournament`. They are created, queried, and retracted
-  independently, so reverse ownership keeps those operations from having
-  to read-modify-write a parent collection. Phases, by contrast, are
-  configuration replaced wholesale, so they hang off the forward
-  cardinality-many `:tournament/phases`.")
+  `:tournament/status` is a keyword enum `#{:registration :active :complete
+  :cancelled}`; `:current-phase-index` points at the active phase and
+  `:qualifier-count` caps how many entrants advance. Phases hang off the
+  cardinality-many `:tournament/phases`. Entries and matches reference the
+  tournament via `:tournament-entry/tournament` / `:match/tournament`.
+  Standings are computed from entries + completed matches
+  (`rules.tournament/recalculate-standings`), so they are not an attribute
+  here.")
 
 (def schema
   {:tournament/eid                       {:db/valueType :db.type/uuid

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament_entry.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament_entry.clj
@@ -1,0 +1,22 @@
+(ns com.devereux-henley.rts-data-access.schema.datalog.tournament-entry
+  "Datalevin attributes for the `:tournament-entry` entity — a player's
+  registration in a tournament. Mirrors the SQLite `tournament_entry` row
+  (`tournament_id`, `player_sub`).
+
+  The entry references its tournament via `:tournament-entry/tournament`;
+  navigate from the tournament with the reverse ref
+  `:tournament-entry/_tournament`. The SQLite `UNIQUE(tournament_id, player_sub)`
+  constraint has no direct Datalevin equivalent — one-entry-per-player is
+  enforced in the domain layer at registration time (the same place the
+  `:draft` migration enforces its invariants).
+
+  Entries are the source of truth for who participates: standings are
+  derived by seeding `rules.tournament/recalculate-standings` with the
+  entry player-subs and folding in completed `:match` results.")
+
+(def schema
+  {:tournament-entry/eid        {:db/valueType :db.type/uuid
+                                 :db/unique    :db.unique/identity}
+   :tournament-entry/tournament {:db/valueType :db.type/ref}
+   :tournament-entry/player-sub {:db/valueType :db.type/string}
+   :tournament-entry/created-at {:db/valueType :db.type/instant}})

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament_entry.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament_entry.clj
@@ -1,18 +1,8 @@
 (ns com.devereux-henley.rts-data-access.schema.datalog.tournament-entry
   "Datalevin attributes for the `:tournament-entry` entity — a player's
-  registration in a tournament. Mirrors the SQLite `tournament_entry` row
-  (`tournament_id`, `player_sub`).
-
-  The entry references its tournament via `:tournament-entry/tournament`;
-  navigate from the tournament with the reverse ref
-  `:tournament-entry/_tournament`. The SQLite `UNIQUE(tournament_id, player_sub)`
-  constraint has no direct Datalevin equivalent — one-entry-per-player is
-  enforced in the domain layer at registration time (the same place the
-  `:draft` migration enforces its invariants).
-
-  Entries are the source of truth for who participates: standings are
-  derived by seeding `rules.tournament/recalculate-standings` with the
-  entry player-subs and folding in completed `:match` results.")
+  registration in a tournament, referencing it via
+  `:tournament-entry/tournament`. One entry per player is enforced in the
+  domain layer at registration time.")
 
 (def schema
   {:tournament-entry/eid        {:db/valueType :db.type/uuid

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament_phase.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament_phase.clj
@@ -1,24 +1,9 @@
 (ns com.devereux-henley.rts-data-access.schema.datalog.tournament-phase
-  "Datalevin attributes for the `:tournament-phase` entity — one stage in a
-  tournament's format (e.g. a Swiss phase followed by a single-elimination
-  cut). Decomposed out of the SQLite `tournament_state.state` JSON blob,
-  where phases were a vector under `:phases`.
-
-  `:tournament-phase/ordinal` preserves the JSON-array position, which is
-  the integer the rest of the system uses as the phase index
-  (`:tournament/current-phase-index`, `:match/phase-index`). Sets in
-  datalog are unordered, so an `ordinal` sort restores the prior shape.
-
-  `:tournament-phase/phase-type` is a keyword enum `#{:swiss :round-robin
-  :single-elimination :double-elimination}` (membership enforced in the
-  domain layer, not by Datalevin).
-
-  A phase owns its rounds via the cardinality-many
-  `:tournament-phase/rounds` ref. The blob also stamped runtime fields
-  onto each round (`:status`, `:match-eids`); those are intentionally not
-  modelled — `rules.tournament/group-matches-by-phase` derives per-round
-  state and membership from the `:match` entities themselves (grouped by
-  `:match/round-index`), so storing them would only invite drift.")
+  "Datalevin attributes for the `:tournament-phase` entity — one stage of a
+  tournament's format. `:ordinal` is its position in the tournament (the
+  phase index). `:phase-type` is a keyword enum `#{:swiss :round-robin
+  :single-elimination :double-elimination}`. Owns its rounds via the
+  cardinality-many `:tournament-phase/rounds`.")
 
 (def schema
   {:tournament-phase/eid        {:db/valueType :db.type/uuid

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament_phase.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament_phase.clj
@@ -1,0 +1,29 @@
+(ns com.devereux-henley.rts-data-access.schema.datalog.tournament-phase
+  "Datalevin attributes for the `:tournament-phase` entity — one stage in a
+  tournament's format (e.g. a Swiss phase followed by a single-elimination
+  cut). Decomposed out of the SQLite `tournament_state.state` JSON blob,
+  where phases were a vector under `:phases`.
+
+  `:tournament-phase/ordinal` preserves the JSON-array position, which is
+  the integer the rest of the system uses as the phase index
+  (`:tournament/current-phase-index`, `:match/phase-index`). Sets in
+  datalog are unordered, so an `ordinal` sort restores the prior shape.
+
+  `:tournament-phase/phase-type` is a keyword enum `#{:swiss :round-robin
+  :single-elimination :double-elimination}` (membership enforced in the
+  domain layer, not by Datalevin).
+
+  A phase owns its rounds via the cardinality-many
+  `:tournament-phase/rounds` ref. The blob also stamped runtime fields
+  onto each round (`:status`, `:match-eids`); those are intentionally not
+  modelled — `rules.tournament/group-matches-by-phase` derives per-round
+  state and membership from the `:match` entities themselves (grouped by
+  `:match/round-index`), so storing them would only invite drift.")
+
+(def schema
+  {:tournament-phase/eid        {:db/valueType :db.type/uuid
+                                 :db/unique    :db.unique/identity}
+   :tournament-phase/ordinal    {:db/valueType :db.type/long}
+   :tournament-phase/phase-type {:db/valueType :db.type/keyword}
+   :tournament-phase/rounds     {:db/valueType   :db.type/ref
+                                 :db/cardinality :db.cardinality/many}})

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament_round.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament_round.clj
@@ -1,0 +1,25 @@
+(ns com.devereux-henley.rts-data-access.schema.datalog.tournament-round
+  "Datalevin attributes for the `:tournament-round` entity — one round of
+  play within a `:tournament-phase`. Decomposed out of the SQLite
+  `tournament_state.state` JSON blob, where rounds were a vector under each
+  phase's `:rounds`.
+
+  `:tournament-round/round-index` is the round's position within its phase
+  (0-based); it doubles as the ordinal, since rounds are always referenced
+  by this index (`:match/round-index`, qualifier cuts). `…/format` is the
+  best-of count (1/3/5) every match generated for the round inherits.
+
+  Rounds carry no `:status` or match list — whether a round has been
+  generated and which matches belong to it is derived from the `:match`
+  entities (those with a matching `:match/phase-index` +
+  `:match/round-index`), so the round entity stays pure configuration.
+
+  Rounds are owned by their phase via the cardinality-many
+  `:tournament-phase/rounds`; to find a round's phase, pull
+  `:tournament-phase/_rounds`.")
+
+(def schema
+  {:tournament-round/eid         {:db/valueType :db.type/uuid
+                                  :db/unique    :db.unique/identity}
+   :tournament-round/round-index {:db/valueType :db.type/long}
+   :tournament-round/format      {:db/valueType :db.type/long}})

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament_round.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/tournament_round.clj
@@ -1,22 +1,7 @@
 (ns com.devereux-henley.rts-data-access.schema.datalog.tournament-round
-  "Datalevin attributes for the `:tournament-round` entity — one round of
-  play within a `:tournament-phase`. Decomposed out of the SQLite
-  `tournament_state.state` JSON blob, where rounds were a vector under each
-  phase's `:rounds`.
-
-  `:tournament-round/round-index` is the round's position within its phase
-  (0-based); it doubles as the ordinal, since rounds are always referenced
-  by this index (`:match/round-index`, qualifier cuts). `…/format` is the
-  best-of count (1/3/5) every match generated for the round inherits.
-
-  Rounds carry no `:status` or match list — whether a round has been
-  generated and which matches belong to it is derived from the `:match`
-  entities (those with a matching `:match/phase-index` +
-  `:match/round-index`), so the round entity stays pure configuration.
-
-  Rounds are owned by their phase via the cardinality-many
-  `:tournament-phase/rounds`; to find a round's phase, pull
-  `:tournament-phase/_rounds`.")
+  "Datalevin attributes for the `:tournament-round` entity — one round
+  within a `:tournament-phase`. `:round-index` is its position (0-based);
+  `:format` is the best-of count every match in the round inherits.")
 
 (def schema
   {:tournament-round/eid         {:db/valueType :db.type/uuid


### PR DESCRIPTION
First step of the tournament-domain migration (rts-5b6, the largest/last domain). Adds the Datalevin attribute schemas that decompose the SQLite `tournament_state` JSON blob into queryable entities. **Schema only** — no read/write layer, handler, or view changes yet; those land in follow-up PRs (rts-9kp, rts-pij, view refactors). The new attributes are purely additive, so the running system is unaffected until code writes them.

## Entities

| Entity | Notes |
|---|---|
| `:tournament/*` | Folds the blob's `status`, `registration`, `current-phase-index`, `qualifier-count` onto the entity. Owns `:tournament/phases`. Audit columns survive (user-mutated); soft-delete dropped in favor of retraction. |
| `:tournament-phase/*` | `ordinal` + `phase-type` (kw enum) + owned `rounds`. |
| `:tournament-round/*` | `round-index` + `format`. Pure config — round state/membership is derived from matches, never stored. |
| `:tournament-entry/*` | References its tournament (`:tournament-entry/tournament`). |
| `:match/*` | References its tournament; `phase-index`/`round-index` kept as **integer indices** (the rules engine groups/pairs by them, not by ref). Owns `:match/games`. `status` + `bracket-type` promoted to `:db.type/keyword`. |
| `:match-game/*` | `replay` + per-side `draft` modelled as real datalog refs — restoring the link that went NULL when draft (rts-9ri) and replay (rts-23h) migrated and `match_game` was left behind in SQLite. |

## Design decisions

- **Standings are derived, not stored** — `rules.tournament/recalculate-standings` computes wins/losses/draws/points from the entry set + completed matches, so there is no snapshot to drift.
- **Round `:status`/`:match-eids` from the blob are not modelled** — `group-matches-by-phase` already derives per-round state from the `:match` entities.
- **Enums → `:db.type/keyword`** with membership enforced in the domain layer (matches the `:unit/mark` pattern).

## Verification

- Merged schema gains 50 new attrs; `clj-kondo` and `cljfmt` clean; `poly check` OK.
- System boots against a fresh store with the new schema.
- A full tournament tree (tournament → phases → rounds, entries, matches → games) round-trips through `transact!` + a nested `pull` + reverse refs (`:match/_tournament`, `:tournament-entry/_tournament`) in the REPL.

Note: filed a separate P2 bug for a pre-existing Datalevin `:db.type/idoc` reopen failure (`code-30781`) on `:replay/parsed-data` — surfaced while restarting the system here, unrelated to this schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)