### PR TITLE
Tournament storage cutover: reads/writes + bracket rules on Datalevin (rts-9kp, rts-pij)

### DIFF
--- a/bases/rts-demo/src/com/devereux_henley/rts_demo/core.clj
+++ b/bases/rts-demo/src/com/devereux_henley/rts_demo/core.clj
@@ -49,9 +49,7 @@
     (datalog/transact! conn tx-data)))
 
 (defn- create-tournament!
-  "Create a demo tournament in registration status with a 14-day window.
-   `domain/create-tournament` now writes the full entity (status,
-   registration window, etc.) — there is no separate state blob to set."
+  "Create a demo tournament in registration status with a 14-day window."
   [deps {:keys [eid name description]}]
   (let [opens-at  (LocalDateTime/now)
         closes-at (.plusDays opens-at 14)

--- a/bases/rts-demo/src/com/devereux_henley/rts_demo/core.clj
+++ b/bases/rts-demo/src/com/devereux_henley/rts_demo/core.clj
@@ -1,38 +1,26 @@
 (ns com.devereux-henley.rts-demo.core
-  "Bootstraps a fresh SQLite database with three demo tournaments — one
+  "Bootstraps a fresh Datalevin store with three demo tournaments — one
   single-elimination, one double-elimination, one Swiss — each populated
   with eight entrants and advanced to the last-match state so the new
-  tournament viewer always has a non-trivial bracket to render.
+  tournament viewer always has a non-trivial bracket to render, plus one
+  left in open registration.
 
   Run from the REPL via `(setup!)` or as a one-shot CLI via
   `clojure -M:dev:claude -m com.devereux-henley.rts-demo.core`."
   (:require
    [clojure.java.io :as io]
+   [com.devereux-henley.datalog.contract :as datalog]
    [com.devereux-henley.rts-data-access.contract :as data-access]
    [com.devereux-henley.rts-data.contract :as rts-data]
-   [com.devereux-henley.rts-domain.contract :as domain]
-   [migratus.core :as migratus]
-   [next.jdbc :as jdbc])
+   [com.devereux-henley.rts-domain.contract :as domain])
   (:import
-   [java.time Instant LocalDateTime ZoneId])
+   [java.time LocalDateTime ZoneId])
   (:gen-class))
 
-(def ^:private default-connection-uri "jdbc:sqlite:db/database.db")
+(def ^:private datalog-dir
+  (or (System/getenv "DATALEVIN_DB_DIR") "db/datalevin/"))
 
-(def ^:private connection-uri
-  (or (System/getenv "RTS_DB_CONNECTION_URI") default-connection-uri))
-
-(def ^:private db-spec
-  {:connection-uri connection-uri})
-
-(def ^:private jdbc-spec
-  {:dbtype "sqlite"
-   :dbname (subs connection-uri (count "jdbc:sqlite:"))})
-
-(def ^:private migratus-config
-  {:store         :database
-   :migration-dir rts-data/migration-dir
-   :db            db-spec})
+(def ^:private seed-patch-version "8.0")
 
 (def ^:private warhammer-iii-eid
   #uuid "eea787d7-1065-45eb-a3f6-e26f32c294a1")
@@ -43,41 +31,44 @@
   (mapv #(str "dev-player-" %)
         ["one" "two" "three" "four" "five" "six" "seven" "eight"]))
 
-(defn- delete-database-file!
+(defn- wipe-datalog-dir!
   []
-  (when (= "sqlite" (:dbtype jdbc-spec))
-    (let [file (io/file (:dbname jdbc-spec))]
-      (when (.exists file)
-        (.delete file)))))
+  (let [dir (io/file datalog-dir)]
+    (when (.exists dir)
+      (doseq [child (reverse (file-seq dir))]
+        (.delete ^java.io.File child)))))
+
+(defn- seed-datalog!
+  "Transact every EDN seed file for the demo patch into the store. Demo
+   tournaments only need the `:game` entity to exist for the
+   `:tournament/game` ref, but seeding the full game catalogue keeps the
+   demo store consistent with a real dev environment."
+  [conn]
+  (rts-data/ensure-datalog-patch seed-patch-version)
+  (doseq [[_ tx-data] (rts-data/load-datalog-seed seed-patch-version)]
+    (datalog/transact! conn tx-data)))
 
 (defn- create-tournament!
-  [connection {:keys [eid name description]}]
-  (let [now       (Instant/now)
-        opens-at  (LocalDateTime/now)
+  "Create a demo tournament in registration status with a 14-day window.
+   `domain/create-tournament` now writes the full entity (status,
+   registration window, etc.) — there is no separate state blob to set."
+  [deps {:keys [eid name description]}]
+  (let [opens-at  (LocalDateTime/now)
         closes-at (.plusDays opens-at 14)
-        zone      (ZoneId/of "UTC")]
-    (data-access/create-tournament
-     connection
-     {:eid            eid
-      :game-eid       warhammer-iii-eid
-      :name           name
-      :description    description
-      :created-by-sub organizer-sub
-      :version        1
-      :created-at     now
-      :updated-at     now})
-    (domain/set-tournament-state
-     {:connection connection}
-     eid
-     {:status          "registration"
-      :registration    {:opens-at     (str (.toInstant (.atZone opens-at zone)))
-                        :closes-at    (str (.toInstant (.atZone closes-at zone)))
-                        :timezone     (str zone)
-                        :closed-early false}
-      :phases          []
-      :current-phase   nil
-      :standings       []
-      :qualifier-count nil})
+        zone      (ZoneId/of "UTC")
+        result    (domain/create-tournament
+                   deps
+                   {:eid                    eid
+                    :game-eid               warhammer-iii-eid
+                    :name                   name
+                    :description            description
+                    :created-by-sub         organizer-sub
+                    :version                1
+                    :timezone               zone
+                    :registration-opens-at  opens-at
+                    :registration-closes-at closes-at})]
+    (when (= :tournament/create-error (:type result))
+      (throw (ex-info "Creating tournament failed" {:result result})))
     eid))
 
 (defn- enter-player!
@@ -227,11 +218,10 @@
     :initial-entrants 3}])
 
 (defn- build-tournament!
-  [connection {:keys [eid name description phase-spec roster preferred-winner]}]
-  (let [deps           {:connection connection}
-        phase-type     (-> phase-spec :phases first :phase-type)
+  [deps {:keys [eid name description phase-spec roster preferred-winner]}]
+  (let [phase-type     (-> phase-spec :phases first :phase-type)
         roster         (or roster player-subs)
-        tournament-eid (create-tournament! connection {:eid eid :name name :description description})]
+        tournament-eid (create-tournament! deps {:eid eid :name name :description description})]
     (enter-players! deps tournament-eid roster)
     (configure-phases! deps tournament-eid phase-spec)
     (start! deps tournament-eid)
@@ -244,9 +234,8 @@
 (defn- build-registration-tournament!
   "Creates a tournament left in `registration` status with a partial
    roster so the viewer's registration UI has a live demo target."
-  [connection {:keys [eid name description initial-entrants]}]
-  (let [deps           {:connection connection}
-        tournament-eid (create-tournament! connection {:eid eid :name name :description description})
+  [deps {:keys [eid name description initial-entrants]}]
+  (let [tournament-eid (create-tournament! deps {:eid eid :name name :description description})
         roster         (take initial-entrants player-subs)]
     (enter-players! deps tournament-eid roster)
     {:name             name
@@ -256,18 +245,20 @@
      :registered-count (count roster)}))
 
 (defn setup!
-  "Wipes the SQLite database, reapplies migrations, seeds baseline data,
-  and creates demo tournaments: three advanced to their last-match
-  state (single-elim, double-elim, Swiss), plus one left in open
-  registration. Returns a vector of summary maps describing each
-  tournament."
+  "Wipes the Datalevin store, reseeds the game catalogue, and creates demo
+  tournaments: three advanced to their last-match state (single-elim,
+  double-elim, Swiss), plus one left in open registration. Returns a
+  vector of summary maps describing each tournament."
   []
-  (delete-database-file!)
-  (migratus/migrate migratus-config)
-  (rts-data/seed-db db-spec)
-  (with-open [connection (jdbc/get-connection jdbc-spec)]
-    (into (mapv #(build-tournament! connection %) tournament-specs)
-          (mapv #(build-registration-tournament! connection %) registration-tournament-specs))))
+  (wipe-datalog-dir!)
+  (let [conn (datalog/get-conn datalog-dir data-access/datalog-schema)
+        deps {:datalog-connection conn}]
+    (try
+      (seed-datalog! conn)
+      (into (mapv #(build-tournament! deps %) tournament-specs)
+            (mapv #(build-registration-tournament! deps %) registration-tournament-specs))
+      (finally
+        (datalog/close conn)))))
 
 (defn -main [& _args]
   (let [tournaments (setup!)]

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
@@ -41,12 +41,10 @@
 
 (def unit-entity schema/unit-entity)
 
-;;; ─── Game DB queries (SQLite — tournament-side, draft-lock only) ──────────
+;;; ─── Draft-lock query ──────────────────────────────────────────────────────
 ;;
-;; The draft-lock-info read still hits the SQLite tournament/match/match_game
-;; tables — those move to Datalevin under rts-5b6. Until then, the lookup
-;; effectively reports "never locked" (FK columns are NULL post-rts-9ri /
-;; post-rts-vhi) but the query at least returns a stable empty result.
+;; Reports whether a draft is locked by a recorded game. Currently returns
+;; a stable empty (never-locked) result.
 
 (def get-draft-lock-info query.game/get-draft-lock-info)
 (def draft-lock-info-schema query.game/draft-lock-info-schema)
@@ -142,10 +140,6 @@
 (def get-games-for-match query.tournament/get-games-for-match)
 
 ;;; ─── Tournament Datalog queries + mutations ────────────────────────────────
-;;
-;; The cutover target (rts-5b6): tournaments, phases/rounds, entries,
-;; matches, and games live in Datalevin. The SQLite re-exports above stay
-;; dormant until rts-1it deletes them with the SQL.
 
 (def tournament-by-eid               query.datalog.tournament/tournament-by-eid)
 (def tournaments-for-game            query.datalog.tournament/tournaments-for-game)

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
@@ -7,6 +7,7 @@
    [com.devereux-henley.rts-data-access.query.datalog.replay :as query.datalog.replay]
    [com.devereux-henley.rts-data-access.query.datalog.season :as query.datalog.season]
    [com.devereux-henley.rts-data-access.query.datalog.social-media :as query.datalog.social-media]
+   [com.devereux-henley.rts-data-access.query.datalog.tournament :as query.datalog.tournament]
    [com.devereux-henley.rts-data-access.query.game :as query.game]
    [com.devereux-henley.rts-data-access.query.stats :as query.stats]
    [com.devereux-henley.rts-data-access.query.tournament :as query.tournament]
@@ -139,6 +140,32 @@
 (def update-match-result query.tournament/update-match-result)
 (def create-game query.tournament/create-game)
 (def get-games-for-match query.tournament/get-games-for-match)
+
+;;; ─── Tournament Datalog queries + mutations ────────────────────────────────
+;;
+;; The cutover target (rts-5b6): tournaments, phases/rounds, entries,
+;; matches, and games live in Datalevin. The SQLite re-exports above stay
+;; dormant until rts-1it deletes them with the SQL.
+
+(def tournament-by-eid               query.datalog.tournament/tournament-by-eid)
+(def tournaments-for-game            query.datalog.tournament/tournaments-for-game)
+(def tournaments                     query.datalog.tournament/tournaments)
+(def phases-for-tournament           query.datalog.tournament/phases-for-tournament)
+(def create-tournament!              query.datalog.tournament/create-tournament!)
+(def update-tournament!              query.datalog.tournament/update-tournament!)
+(def set-phases!                     query.datalog.tournament/set-phases!)
+(def entries-for-tournament          query.datalog.tournament/entries-for-tournament)
+(def entry-by-tournament-and-player  query.datalog.tournament/entry-by-tournament-and-player)
+(def create-entry!                   query.datalog.tournament/create-entry!)
+(def delete-entry!                   query.datalog.tournament/delete-entry!)
+(def match-by-eid                    query.datalog.tournament/match-by-eid)
+(def matches-for-tournament          query.datalog.tournament/matches-for-tournament)
+(def matches                         query.datalog.tournament/matches)
+(def matches-for-round               query.datalog.tournament/matches-for-round)
+(def create-match!                   query.datalog.tournament/create-match!)
+(def update-match-result!            query.datalog.tournament/update-match-result!)
+(def create-game!                    query.datalog.tournament/create-game!)
+(def games-for-match                 query.datalog.tournament/games-for-match)
 
 ;;; ─── Stats DB entities ─────────────────────────────────────────────────────
 

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/tournament.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/tournament.clj
@@ -1,19 +1,13 @@
 (ns com.devereux-henley.rts-data-access.query.datalog.tournament
   "Datalevin reads and mutations for the tournament domain — tournaments,
-  their decomposed phases/rounds, entries, matches, and per-match games.
+  phases/rounds, entries, matches, and per-match games.
 
-  Reads return the same unqualified-key shapes the SQLite-era handlers and
-  the pure `rules.tournament` functions already consume: enum keywords are
-  flattened back to strings (`:match/status :complete` → `\"complete\"`),
-  ref sub-maps become flat `*-eid` fields, and instants come back as
-  canonical `java.util.Date` values. This keeps the cutover a swap of the
-  data-access layer rather than a rewrite of the rules.
-
-  The SQLite `tournament_state` JSON blob has no storage analogue here —
-  status, the registration window, `current-phase-index`, and
-  `qualifier-count` live on the tournament entity, phases/rounds are their
-  own entities, and standings are derived by the handler from entries +
-  completed matches (`rules.tournament/recalculate-standings`)."
+  Reads return flat unqualified-key maps: enum keywords flatten to strings
+  (`:match/status :complete` → `\"complete\"`), ref sub-maps become `*-eid`
+  fields, and instants are `java.util.Date`. Status, the registration
+  window, `current-phase-index`, and `qualifier-count` live on the
+  tournament entity; standings are derived (not read) by the handler from
+  entries + completed matches."
   (:require
    [com.devereux-henley.datalog.contract :as dl])
   (:import
@@ -281,9 +275,8 @@
 
 (defn create-tournament!
   "Transact a new tournament in `registration` status. `:league-eid` /
-  `:season-eid` on the spec become real refs (both live in Datalevin), so
-  the linkage the SQLite era couldn't keep is restored. Registration
-  window times are stamped as instants."
+  `:season-eid` on the spec become refs. Registration window times are
+  stamped as instants."
   [conn {:keys [eid name description game-eid league-eid season-eid created-by-sub
                 version created-at updated-at registration-opens-at
                 registration-closes-at timezone]}]
@@ -363,8 +356,7 @@
 
 (defn create-entry!
   "Register a player in a tournament. Returns the created entry, or nil
-  when the player already holds an entry (the caller maps that to a
-  domain error — one entry per player is the SQLite `UNIQUE` invariant)."
+  when the player already holds one (one entry per player)."
   [conn eid player-sub]
   (when-not (entry-by-tournament-and-player conn eid player-sub)
     (let [entry-eid (random-uuid)]
@@ -422,8 +414,8 @@
 (defn create-game!
   "Record a per-game result for a match, owned via `:match/games`. `opts`
   may carry `:replay-eid`, `:uploader-local-alliance-index`,
-  `:player-one-draft-eid`, `:player-two-draft-eid` — replay and drafts are
-  genuine refs into their (already-migrated) Datalevin entities."
+  `:player-one-draft-eid`, `:player-two-draft-eid`, which become refs to
+  the `:replay` and per-side `:draft` entities."
   ([conn match-eid game-index winner-sub]
    (create-game! conn match-eid game-index winner-sub {}))
   ([conn match-eid game-index winner-sub

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/tournament.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/tournament.clj
@@ -1,0 +1,452 @@
+(ns com.devereux-henley.rts-data-access.query.datalog.tournament
+  "Datalevin reads and mutations for the tournament domain — tournaments,
+  their decomposed phases/rounds, entries, matches, and per-match games.
+
+  Reads return the same unqualified-key shapes the SQLite-era handlers and
+  the pure `rules.tournament` functions already consume: enum keywords are
+  flattened back to strings (`:match/status :complete` → `\"complete\"`),
+  ref sub-maps become flat `*-eid` fields, and instants come back as
+  canonical `java.util.Date` values. This keeps the cutover a swap of the
+  data-access layer rather than a rewrite of the rules.
+
+  The SQLite `tournament_state` JSON blob has no storage analogue here —
+  status, the registration window, `current-phase-index`, and
+  `qualifier-count` live on the tournament entity, phases/rounds are their
+  own entities, and standings are derived by the handler from entries +
+  completed matches (`rules.tournament/recalculate-standings`)."
+  (:require
+   [com.devereux-henley.datalog.contract :as dl])
+  (:import
+   [java.time Instant]
+   [java.util Date]))
+
+;;; ─── Coercions ─────────────────────────────────────────────────────────────
+
+(defn- ->date
+  "Coerce an `Instant`/`Date`/nil to the `java.util.Date` Datalevin stores
+  for `:db.type/instant`. Callers stamp times as `Instant`; the boundary
+  converts."
+  ^Date [x]
+  (cond
+    (nil? x)              nil
+    (instance? Date x)    x
+    (instance? Instant x) (Date/from ^Instant x)))
+
+(defn- kw->str
+  "Enum keyword → the string the rules/handlers compare against."
+  [k]
+  (some-> k name))
+
+;;; ─── Pull patterns ─────────────────────────────────────────────────────────
+
+(def ^:private tournament-pattern
+  [:tournament/eid :tournament/name :tournament/description
+   :tournament/created-by-sub :tournament/version
+   :tournament/created-at :tournament/updated-at
+   :tournament/status :tournament/timezone
+   :tournament/registration-opens-at :tournament/registration-closes-at
+   :tournament/registration-closed-early
+   :tournament/current-phase-index :tournament/qualifier-count
+   {:tournament/game [:game/eid]}
+   {:tournament/league [:league/eid]}
+   {:tournament/season [:season/eid]}])
+
+(def ^:private phases-pattern
+  [{:tournament/phases [:tournament-phase/ordinal :tournament-phase/phase-type
+                        {:tournament-phase/rounds [:tournament-round/round-index
+                                                   :tournament-round/format]}]}])
+
+(def ^:private entry-pattern
+  [:tournament-entry/eid :tournament-entry/player-sub :tournament-entry/created-at
+   {:tournament-entry/tournament [:tournament/eid]}])
+
+(def ^:private match-pattern
+  [:match/eid :match/phase-index :match/round-index :match/bracket-type
+   :match/player-one-sub :match/player-two-sub :match/winner-sub
+   :match/status :match/format :match/created-at :match/updated-at
+   {:match/tournament [:tournament/eid]}])
+
+(def ^:private match-game-pattern
+  [:match-game/eid :match-game/game-index :match-game/winner-sub
+   :match-game/uploader-local-alliance-index :match-game/created-at
+   {:match-game/replay [:replay/eid]}
+   {:match-game/player-one-draft [:draft/eid]}
+   {:match-game/player-two-draft [:draft/eid]}
+   {:match/_games [:match/eid]}])
+
+;;; ─── Result builders ──────────────────────────────────────────────────────
+
+(defn- ->tournament
+  [m]
+  (when m
+    (cond-> {:eid                       (:tournament/eid m)
+             :name                      (:tournament/name m)
+             :description               (:tournament/description m)
+             :created-by-sub            (:tournament/created-by-sub m)
+             :version                   (:tournament/version m)
+             :created-at                (:tournament/created-at m)
+             :updated-at                (:tournament/updated-at m)
+             :status                    (kw->str (:tournament/status m))
+             :timezone                  (:tournament/timezone m)
+             :registration-opens-at     (:tournament/registration-opens-at m)
+             :registration-closes-at    (:tournament/registration-closes-at m)
+             :registration-closed-early (boolean (:tournament/registration-closed-early m))
+             :current-phase-index       (:tournament/current-phase-index m)
+             :qualifier-count           (:tournament/qualifier-count m)
+             :game-eid                  (some-> m :tournament/game :game/eid)}
+      (some-> m :tournament/league :league/eid) (assoc :league-eid (-> m :tournament/league :league/eid))
+      (some-> m :tournament/season :season/eid) (assoc :season-eid (-> m :tournament/season :season/eid)))))
+
+(defn- ->phases
+  "Reconstruct the `[{:phase-type … :rounds [{:round-index … :format …}]}]`
+  shape the rules/handlers consume, sorted by phase ordinal then round
+  index so the JSON-array order is restored from the unordered datalog
+  sets."
+  [pulled]
+  (->> (:tournament/phases pulled)
+       (sort-by :tournament-phase/ordinal)
+       (mapv (fn [phase]
+               {:phase-type (kw->str (:tournament-phase/phase-type phase))
+                :rounds     (->> (:tournament-phase/rounds phase)
+                                 (sort-by :tournament-round/round-index)
+                                 (mapv (fn [r]
+                                         {:round-index (:tournament-round/round-index r)
+                                          :format      (:tournament-round/format r)})))}))))
+
+(defn- ->entry
+  [m]
+  (when m
+    {:eid            (:tournament-entry/eid m)
+     :tournament-eid (some-> m :tournament-entry/tournament :tournament/eid)
+     :player-sub     (:tournament-entry/player-sub m)
+     :created-at     (:tournament-entry/created-at m)}))
+
+(defn- ->match
+  [m]
+  (when m
+    {:eid            (:match/eid m)
+     :tournament-eid (some-> m :match/tournament :tournament/eid)
+     :phase-index    (:match/phase-index m)
+     :round-index    (:match/round-index m)
+     :bracket-type   (kw->str (:match/bracket-type m))
+     :player-one-sub (:match/player-one-sub m)
+     :player-two-sub (:match/player-two-sub m)
+     :winner-sub     (:match/winner-sub m)
+     :status         (kw->str (:match/status m))
+     :format         (:match/format m)
+     :created-at     (:match/created-at m)
+     :updated-at     (:match/updated-at m)}))
+
+(defn- ->game
+  [m]
+  (when m
+    {:eid                           (:match-game/eid m)
+     :match-eid                     (some-> m :match/_games first :match/eid)
+     :game-index                    (:match-game/game-index m)
+     :winner-sub                    (:match-game/winner-sub m)
+     :uploader-local-alliance-index (:match-game/uploader-local-alliance-index m)
+     :replay-eid                    (some-> m :match-game/replay :replay/eid)
+     :player-one-draft-eid          (some-> m :match-game/player-one-draft :draft/eid)
+     :player-two-draft-eid          (some-> m :match-game/player-two-draft :draft/eid)
+     :created-at                    (:match-game/created-at m)}))
+
+;;; ─── Tournament reads ──────────────────────────────────────────────────────
+
+(defn tournament-by-eid
+  "Fetch a tournament by eid. Returns nil when not found."
+  [conn eid]
+  (->tournament (dl/pull (dl/db conn) tournament-pattern (dl/lookup-ref :tournament/eid eid))))
+
+(defn tournaments-for-game
+  "All tournaments scoped to a game, newest first (created-at desc)."
+  [conn game-eid]
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?t pattern) ...]
+                 :in $ pattern ?game-eid
+                 :where
+                 [?t :tournament/game ?g]
+                 [?g :game/eid ?game-eid]]
+               db tournament-pattern game-eid)
+         (mapv ->tournament)
+         (sort-by (juxt (comp - (fnil #(.getTime ^Date %) (Date. 0)) :created-at) :eid))
+         vec)))
+
+(defn tournaments
+  "Every tournament in the system."
+  [conn]
+  (->> (dl/q '[:find [(pull ?t pattern) ...]
+               :in $ pattern
+               :where [?t :tournament/eid]]
+             (dl/db conn) tournament-pattern)
+       (mapv ->tournament)
+       vec))
+
+(defn phases-for-tournament
+  "The `[{:phase-type … :rounds […]}]` phase configuration for a tournament,
+  reconstructed from its phase/round entities."
+  [conn eid]
+  (->phases (dl/pull (dl/db conn) phases-pattern (dl/lookup-ref :tournament/eid eid))))
+
+;;; ─── Entry reads ───────────────────────────────────────────────────────────
+
+(defn entries-for-tournament
+  "All entries for a tournament, oldest first (created-at asc)."
+  [conn eid]
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?e pattern) ...]
+                 :in $ pattern ?tour-eid
+                 :where
+                 [?e :tournament-entry/tournament ?t]
+                 [?t :tournament/eid ?tour-eid]]
+               db entry-pattern eid)
+         (mapv ->entry)
+         (sort-by (juxt (comp (fnil #(.getTime ^Date %) (Date. 0)) :created-at) :eid))
+         vec)))
+
+(defn entry-by-tournament-and-player
+  "The entry a player holds in a tournament, or nil."
+  [conn eid player-sub]
+  (let [db (dl/db conn)]
+    (some-> (dl/q '[:find (pull ?e pattern) .
+                    :in $ pattern ?tour-eid ?player-sub
+                    :where
+                    [?e :tournament-entry/tournament ?t]
+                    [?t :tournament/eid ?tour-eid]
+                    [?e :tournament-entry/player-sub ?player-sub]]
+                  db entry-pattern eid player-sub)
+            ->entry)))
+
+;;; ─── Match reads ───────────────────────────────────────────────────────────
+
+(defn match-by-eid
+  "Fetch a match by eid. Returns nil when not found."
+  [conn eid]
+  (->match (dl/pull (dl/db conn) match-pattern (dl/lookup-ref :match/eid eid))))
+
+(defn matches-for-tournament
+  "All matches in a tournament, ordered by (phase-index, round-index)."
+  [conn eid]
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?m pattern) ...]
+                 :in $ pattern ?tour-eid
+                 :where
+                 [?m :match/tournament ?t]
+                 [?t :tournament/eid ?tour-eid]]
+               db match-pattern eid)
+         (mapv ->match)
+         (sort-by (juxt :phase-index :round-index :eid))
+         vec)))
+
+(defn matches
+  "Every match in the system."
+  [conn]
+  (->> (dl/q '[:find [(pull ?m pattern) ...]
+               :in $ pattern
+               :where [?m :match/eid]]
+             (dl/db conn) match-pattern)
+       (mapv ->match)
+       vec))
+
+(defn matches-for-round
+  "Matches in a tournament's specific phase + round."
+  [conn eid phase-index round-index]
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?m pattern) ...]
+                 :in $ pattern ?tour-eid ?phase ?round
+                 :where
+                 [?m :match/tournament ?t]
+                 [?t :tournament/eid ?tour-eid]
+                 [?m :match/phase-index ?phase]
+                 [?m :match/round-index ?round]]
+               db match-pattern eid phase-index round-index)
+         (mapv ->match)
+         (sort-by :eid)
+         vec)))
+
+(defn games-for-match
+  "All games recorded for a match, ordered by game-index."
+  [conn match-eid]
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?g pattern) ...]
+                 :in $ pattern ?match-eid
+                 :where
+                 [?m :match/eid ?match-eid]
+                 [?m :match/games ?g]]
+               db match-game-pattern match-eid)
+         (mapv ->game)
+         (sort-by :game-index)
+         vec)))
+
+;;; ─── Tournament mutations ──────────────────────────────────────────────────
+
+(defn create-tournament!
+  "Transact a new tournament in `registration` status. `:league-eid` /
+  `:season-eid` on the spec become real refs (both live in Datalevin), so
+  the linkage the SQLite era couldn't keep is restored. Registration
+  window times are stamped as instants."
+  [conn {:keys [eid name description game-eid league-eid season-eid created-by-sub
+                version created-at updated-at registration-opens-at
+                registration-closes-at timezone]}]
+  (dl/transact!
+   conn
+   [(cond-> {:tournament/eid                       eid
+             :tournament/name                      name
+             :tournament/description               description
+             :tournament/game                      [:game/eid game-eid]
+             :tournament/created-by-sub            created-by-sub
+             :tournament/version                   (or version 1)
+             :tournament/created-at                (->date created-at)
+             :tournament/updated-at                (->date updated-at)
+             :tournament/status                    :registration
+             :tournament/registration-closed-early false}
+      league-eid             (assoc :tournament/league [:league/eid league-eid])
+      season-eid             (assoc :tournament/season [:season/eid season-eid])
+      timezone               (assoc :tournament/timezone timezone)
+      registration-opens-at  (assoc :tournament/registration-opens-at (->date registration-opens-at))
+      registration-closes-at (assoc :tournament/registration-closes-at (->date registration-closes-at)))])
+  (tournament-by-eid conn eid))
+
+(defn update-tournament!
+  "Patch mutable tournament fields, always touching `updated-at`. Accepts
+  any of `:status` (string, stored as a keyword), `:current-phase-index`,
+  `:qualifier-count`, `:registration-closed-early`. Nil-valued keys are
+  skipped so partial updates only write what they mean to."
+  [conn eid {:keys [status current-phase-index qualifier-count registration-closed-early]}]
+  (dl/transact!
+   conn
+   [(cond-> {:tournament/eid        eid
+             :tournament/updated-at (Date.)}
+      status                            (assoc :tournament/status (keyword status))
+      (some? current-phase-index)       (assoc :tournament/current-phase-index current-phase-index)
+      (some? qualifier-count)           (assoc :tournament/qualifier-count qualifier-count)
+      (some? registration-closed-early) (assoc :tournament/registration-closed-early registration-closed-early))])
+  (tournament-by-eid conn eid))
+
+(defn set-phases!
+  "Replace a tournament's phase configuration. Retracts the existing
+  phase + round entities, then transacts fresh ones from `phases` — a
+  vector of `{:phase-type … :rounds [{:round-index … :format …}]}`. The
+  phase's position in the vector becomes its `:tournament-phase/ordinal`."
+  [conn eid phases]
+  (let [db          (dl/db conn)
+        existing    (dl/pull db [{:tournament/phases [:tournament-phase/eid
+                                                      {:tournament-phase/rounds [:tournament-round/eid]}]}]
+                             (dl/lookup-ref :tournament/eid eid))
+        retract-ops (mapcat (fn [phase]
+                              (cons [:db/retractEntity (dl/lookup-ref :tournament-phase/eid
+                                                                      (:tournament-phase/eid phase))]
+                                    (map (fn [r]
+                                           [:db/retractEntity (dl/lookup-ref :tournament-round/eid
+                                                                             (:tournament-round/eid r))])
+                                         (:tournament-phase/rounds phase))))
+                            (:tournament/phases existing))
+        phase-maps  (map-indexed
+                     (fn [ordinal phase]
+                       {:tournament-phase/eid        (random-uuid)
+                        :tournament-phase/ordinal    ordinal
+                        :tournament-phase/phase-type (keyword (:phase-type phase))
+                        :tournament-phase/rounds
+                        (mapv (fn [r]
+                                {:tournament-round/eid         (random-uuid)
+                                 :tournament-round/round-index (:round-index r)
+                                 :tournament-round/format      (or (:format r) 1)})
+                              (:rounds phase))})
+                     phases)]
+    (dl/transact!
+     conn
+     (concat retract-ops
+             [{:tournament/eid        eid
+               :tournament/phases     (vec phase-maps)
+               :tournament/updated-at (Date.)}]))))
+
+;;; ─── Entry mutations ───────────────────────────────────────────────────────
+
+(defn create-entry!
+  "Register a player in a tournament. Returns the created entry, or nil
+  when the player already holds an entry (the caller maps that to a
+  domain error — one entry per player is the SQLite `UNIQUE` invariant)."
+  [conn eid player-sub]
+  (when-not (entry-by-tournament-and-player conn eid player-sub)
+    (let [entry-eid (random-uuid)]
+      (dl/transact!
+       conn
+       [{:tournament-entry/eid        entry-eid
+         :tournament-entry/tournament [:tournament/eid eid]
+         :tournament-entry/player-sub player-sub
+         :tournament-entry/created-at (Date.)}])
+      (entry-by-tournament-and-player conn eid player-sub))))
+
+(defn delete-entry!
+  "Remove a player's entry from a tournament."
+  [conn eid player-sub]
+  (when-let [entry (entry-by-tournament-and-player conn eid player-sub)]
+    (dl/transact! conn [[:db/retractEntity (dl/lookup-ref :tournament-entry/eid (:eid entry))]])))
+
+;;; ─── Match mutations ───────────────────────────────────────────────────────
+
+(defn create-match!
+  "Create a match within a tournament. Enum-typed `:bracket-type`/`:status`
+  are stored as keywords; the spec carries strings (or omits, defaulting
+  to winners/pending)."
+  [conn eid match-spec]
+  (let [match-eid (random-uuid)
+        now       (Date.)]
+    (dl/transact!
+     conn
+     [{:match/eid            match-eid
+       :match/tournament     [:tournament/eid eid]
+       :match/phase-index    (:phase-index match-spec)
+       :match/round-index    (:round-index match-spec)
+       :match/bracket-type   (keyword (or (:bracket-type match-spec) "winners"))
+       :match/player-one-sub (:player-one-sub match-spec)
+       :match/player-two-sub (:player-two-sub match-spec)
+       :match/status         :pending
+       :match/format         (or (:format match-spec) 1)
+       :match/created-at     now
+       :match/updated-at     now}])
+    (match-by-eid conn match-eid)))
+
+(defn update-match-result!
+  "Mark a match complete with a winner."
+  [conn match-eid winner-sub]
+  (dl/transact!
+   conn
+   [{:match/eid        match-eid
+     :match/winner-sub winner-sub
+     :match/status     :complete
+     :match/updated-at (Date.)}])
+  (match-by-eid conn match-eid))
+
+;;; ─── Game mutations ────────────────────────────────────────────────────────
+
+(defn create-game!
+  "Record a per-game result for a match, owned via `:match/games`. `opts`
+  may carry `:replay-eid`, `:uploader-local-alliance-index`,
+  `:player-one-draft-eid`, `:player-two-draft-eid` — replay and drafts are
+  genuine refs into their (already-migrated) Datalevin entities."
+  ([conn match-eid game-index winner-sub]
+   (create-game! conn match-eid game-index winner-sub {}))
+  ([conn match-eid game-index winner-sub
+    {:keys [replay-eid uploader-local-alliance-index
+            player-one-draft-eid player-two-draft-eid]}]
+   (let [game-eid (random-uuid)
+         game     (cond-> {:match-game/eid        game-eid
+                           :match-game/game-index game-index
+                           :match-game/winner-sub winner-sub
+                           :match-game/created-at (Date.)}
+                    replay-eid                          (assoc :match-game/replay [:replay/eid replay-eid])
+                    (some? uploader-local-alliance-index) (assoc :match-game/uploader-local-alliance-index
+                                                                 uploader-local-alliance-index)
+                    player-one-draft-eid                (assoc :match-game/player-one-draft [:draft/eid player-one-draft-eid])
+                    player-two-draft-eid                (assoc :match-game/player-two-draft [:draft/eid player-two-draft-eid]))]
+     (dl/transact!
+      conn
+      [{:match/eid match-eid :match/games [game]}])
+     {:eid                           game-eid
+      :match-eid                     match-eid
+      :game-index                    game-index
+      :winner-sub                    winner-sub
+      :replay-eid                    replay-eid
+      :uploader-local-alliance-index uploader-local-alliance-index
+      :player-one-draft-eid          player-one-draft-eid
+      :player-two-draft-eid          player-two-draft-eid})))

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
@@ -101,7 +101,6 @@
 (def get-tournaments                              handlers.tournament/get-tournaments)
 (def create-tournament                            handlers.tournament/create-tournament)
 (def get-tournament-state                         handlers.tournament/get-tournament-state)
-(def set-tournament-state                         handlers.tournament/set-tournament-state)
 (def create-entry                                 handlers.tournament/create-entry)
 (def delete-entry                                 handlers.tournament/delete-entry)
 (def get-entries                                   handlers.tournament/get-entries)

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/replay.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/replay.clj
@@ -324,7 +324,7 @@
   (if-let [shape-error (schema.contract/explain->message
                         (m/explain schema/record-game-submission-spec submission))]
     (short-circuit-error shape-error)
-    (let [match (db/get-match-by-eid (:connection dependencies) match-eid)]
+    (let [match (db/match-by-eid (:datalog-connection dependencies) match-eid)]
       (cond
         (nil? match)
         (short-circuit-error "Match not found.")
@@ -336,12 +336,12 @@
         (short-circuit-error "Declared winner must match one of the match's players.")
 
         :else
-        (let [conn           (:connection dependencies)
-              existing-games (db/get-games-for-match conn match-eid)
+        (let [conn           (:datalog-connection dependencies)
+              existing-games (db/games-for-match conn match-eid)
               game-index     (count existing-games)]
           (if (>= game-index (:format match))
             (short-circuit-error (format "Match already has its maximum %d games." (:format match)))
-            (let [tournament (db/get-tournament-by-eid conn (:tournament-eid match))
+            (let [tournament (db/tournament-by-eid conn (:tournament-eid match))
                   game-modes (db/game-modes-for-game (:datalog-connection dependencies)
                                                      (:game-eid tournament))
                   now        (Instant/now)
@@ -360,7 +360,7 @@
                     :game-modes      game-modes
                     :uploaded-by-sub uploaded-by-sub
                     :now             now})
-                  stored     (db/create-game
+                  stored     (db/create-game!
                               conn match-eid game-index winner-sub
                               {:replay-eid                    (:eid replay)
                                :uploader-local-alliance-index (:uploader-local-alliance-index replay)

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/replay.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/replay.clj
@@ -370,10 +370,8 @@
                                    {:winner-sub winner-sub})
                   clincher   (rules.tournament/check-match-complete all-games (:format match))]
               (when clincher
-              ;; Route through the public domain function so standings get
-              ;; recalculated and tournament-complete check fires — going
-              ;; straight to db/update-match-result here would leave the
-              ;; state blob stale.
+              ;; Route through the domain function so standings recalculate
+              ;; and the tournament-complete check fires.
                 (handlers.tournament/update-match-result dependencies match-eid clincher))
               (cond-> {:type            :match-record/game-recorded
                        :match-eid       match-eid

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -33,10 +33,8 @@
         (db/tournaments (:datalog-connection dependencies))))
 
 (defn- derive-standings
-  "Standings are not stored — they are computed from the entry set folded
-   with completed match results (`rules/recalculate-standings`). Empty
-   during registration (no field of play yet), matching the SQLite-era
-   blob which only populated standings on `close-registration`."
+  "Computes standings from the entry set folded with completed match
+   results (`rules/recalculate-standings`). Empty during registration."
   [dependencies tournament-eid status]
   (if (= "registration" status)
     []
@@ -49,10 +47,10 @@
       (rules/recalculate-standings base completed))))
 
 (defn get-tournament-state
-  "Reconstructs the tournament state view-model from its entities — the
-   shape the rules engine and templates expect, formerly the
-   `tournament_state` JSON blob. Returns a default initial state when the
-   tournament is absent."
+  "Builds the tournament state map the rules engine and templates consume
+   from its entities (status, registration window, phases, current phase,
+   derived standings, qualifier count). Returns a default initial state
+   when the tournament is absent."
   [dependencies tournament-eid]
   (let [tournament (db/tournament-by-eid (:datalog-connection dependencies) tournament-eid)]
     (if-not tournament

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -2,12 +2,10 @@
   (:require
    [com.devereux-henley.rts-data-access.contract :as db]
    [com.devereux-henley.rts-domain.rules.tournament :as rules]
-   [com.devereux-henley.rts-domain.time :as time]
-   [jsonista.core :as jsonista])
+   [com.devereux-henley.rts-domain.time :as time])
   (:import
-   [java.time Instant]))
-
-(def ^:private json-mapper (jsonista/object-mapper {:decode-key-fn keyword}))
+   [java.time Instant]
+   [java.util Date]))
 
 (defn- tag-tournament
   [tournament]
@@ -20,51 +18,72 @@
 (defn get-tournament-by-eid
   "Fetches a tournament by eid and attaches :type :tournament/tournament."
   [dependencies eid]
-  (tag-tournament (db/get-tournament-by-eid (:connection dependencies) eid)))
+  (tag-tournament (db/tournament-by-eid (:datalog-connection dependencies) eid)))
 
 (defn get-tournaments-for-game
   "Returns all tournaments for a game, each tagged with :type :tournament/tournament."
   [dependencies game-eid]
   (mapv tag-tournament
-        (db/get-tournaments-for-game (:connection dependencies) game-eid)))
+        (db/tournaments-for-game (:datalog-connection dependencies) game-eid)))
 
 (defn get-tournaments
   "Returns every tournament in the system, each tagged with :type :tournament/tournament."
   [dependencies]
   (mapv tag-tournament
-        (db/get-tournaments (:connection dependencies))))
+        (db/tournaments (:datalog-connection dependencies))))
+
+(defn- derive-standings
+  "Standings are not stored — they are computed from the entry set folded
+   with completed match results (`rules/recalculate-standings`). Empty
+   during registration (no field of play yet), matching the SQLite-era
+   blob which only populated standings on `close-registration`."
+  [dependencies tournament-eid status]
+  (if (= "registration" status)
+    []
+    (let [conn      (:datalog-connection dependencies)
+          base      (mapv (fn [e] {:player-sub (:player-sub e)
+                                   :wins       0               :losses 0 :draws 0 :points 0})
+                          (db/entries-for-tournament conn tournament-eid))
+          completed (filterv #(= "complete" (:status %))
+                             (db/matches-for-tournament conn tournament-eid))]
+      (rules/recalculate-standings base completed))))
 
 (defn get-tournament-state
-  "Returns the parsed tournament state map, or a default initial state when none exists."
+  "Reconstructs the tournament state view-model from its entities — the
+   shape the rules engine and templates expect, formerly the
+   `tournament_state` JSON blob. Returns a default initial state when the
+   tournament is absent."
   [dependencies tournament-eid]
-  (if-let [row (db/get-tournament-state (:connection dependencies) tournament-eid)]
-    (jsonista/read-value (:state row) json-mapper)
-    {:status          "registration"
-     :registration    {:opens-at nil :closes-at nil :closed-early false}
-     :phases          []
-     :current-phase   nil
-     :standings       []
-     :qualifier-count nil}))
-
-(defn set-tournament-state
-  "Persists the tournament state as a JSON blob."
-  [dependencies tournament-eid state]
-  (db/upsert-tournament-state
-   (:connection dependencies)
-   tournament-eid
-   (jsonista/write-value-as-string state)))
+  (let [tournament (db/tournament-by-eid (:datalog-connection dependencies) tournament-eid)]
+    (if-not tournament
+      {:status          "registration"
+       :registration    {:opens-at nil :closes-at nil :closed-early false}
+       :phases          []
+       :current-phase   nil
+       :standings       []
+       :qualifier-count nil}
+      (let [status (:status tournament)]
+        {:status          status
+         :registration    {:opens-at     (:registration-opens-at tournament)
+                           :closes-at    (:registration-closes-at tournament)
+                           :timezone     (:timezone tournament)
+                           :closed-early (:registration-closed-early tournament)}
+         :phases          (db/phases-for-tournament (:datalog-connection dependencies) tournament-eid)
+         :current-phase   (:current-phase-index tournament)
+         :standings       (derive-standings dependencies tournament-eid status)
+         :qualifier-count (:qualifier-count tournament)}))))
 
 (defn create-tournament
-  "Creates a new tournament with an initial state blob. When :season-eid is
+  "Creates a new tournament in registration status. When :season-eid is
    supplied, derives :league-eid from the season server-side and rejects
    any caller-supplied :league-eid that disagrees. Both keys are optional —
    tournaments may stand alone."
   [dependencies create-specification]
-  (let [conn       (:connection dependencies)
+  (let [conn       (:datalog-connection dependencies)
         season     (when-let [seid (:season-eid create-specification)]
-                     (db/season-by-eid (:datalog-connection dependencies) seid))
+                     (db/season-by-eid conn seid))
         derived-le (cond
-                     season                            (:league-eid season)
+                     season                             (:league-eid season)
                      (:league-eid create-specification) (:league-eid create-specification)
                      :else                              nil)]
     (cond
@@ -77,31 +96,30 @@
       {:type :tournament/create-error :message "Provided league does not match the season's league."}
 
       :else
-      (let [created-at    (Instant/now)
-            updated-at    created-at
-            tz            (:timezone create-specification)
-            opens-at      (time/to-utc-instant (:registration-opens-at create-specification) tz)
-            closes-at     (time/to-utc-instant (:registration-closes-at create-specification) tz)
-            spec          (-> create-specification
-                              (dissoc :registration-opens-at :registration-closes-at :timezone)
-                              (assoc :created-at created-at)
-                              (assoc :updated-at updated-at)
-                              (cond-> derived-le (assoc :league-eid derived-le))
-                              (cond-> (not derived-le) (dissoc :league-eid)))
-            tournament    (db/create-tournament conn spec)
-            initial-state {:status          "registration"
-                           :registration    {:opens-at     (str opens-at)
-                                             :closes-at    (str closes-at)
-                                             :timezone     (str tz)
-                                             :closed-early false}
-                           :phases          []
-                           :current-phase   nil
-                           :standings       []
-                           :qualifier-count nil}]
-        (set-tournament-state dependencies (:eid tournament) initial-state)
+      (let [created-at (Instant/now)
+            tz         (:timezone create-specification)
+            opens-at   (time/to-utc-instant (:registration-opens-at create-specification) tz)
+            closes-at  (time/to-utc-instant (:registration-closes-at create-specification) tz)
+            spec       (-> create-specification
+                           (assoc :created-at created-at
+                                  :updated-at created-at
+                                  :registration-opens-at opens-at
+                                  :registration-closes-at closes-at)
+                           (cond-> derived-le (assoc :league-eid derived-le))
+                           (cond-> (not derived-le) (dissoc :league-eid)))
+            tournament (db/create-tournament! conn spec)]
         (tag-tournament tournament)))))
 
 ;; ─── Registration ────────────────────────────────────────────────────────────
+
+(defn- ->instant
+  "Coerce a stored registration timestamp (`java.util.Date`) — or a passed
+   `Instant`/nil — to an `Instant` for window comparisons."
+  ^Instant [x]
+  (cond
+    (nil? x)              nil
+    (instance? Instant x) x
+    (instance? Date x)    (.toInstant ^Date x)))
 
 (defn is-registration-open?
   "Returns true if the tournament state allows new registrations.
@@ -109,8 +127,8 @@
   [state now]
   (and (= "registration" (:status state))
        (not (get-in state [:registration :closed-early]))
-       (let [opens-at  (some-> (get-in state [:registration :opens-at]) Instant/parse)
-             closes-at (some-> (get-in state [:registration :closes-at]) Instant/parse)]
+       (let [opens-at  (->instant (get-in state [:registration :opens-at]))
+             closes-at (->instant (get-in state [:registration :closes-at]))]
          (and (or (nil? opens-at)  (not (.isBefore now opens-at)))
               (or (nil? closes-at) (.isBefore now closes-at))))))
 
@@ -121,13 +139,9 @@
         now   (Instant/now)]
     (if-not (is-registration-open? state now)
       {:type :tournament/entry-error :message "Registration is not open."}
-      (try
-        (let [entry (db/create-entry (:connection dependencies) tournament-eid player-sub)]
-          (assoc entry :type :tournament/entry))
-        (catch org.sqlite.SQLiteException e
-          (if (.contains (.getMessage e) "UNIQUE constraint failed")
-            {:type :tournament/entry-error :message "Already entered in this tournament."}
-            (throw e)))))))
+      (if-let [entry (db/create-entry! (:datalog-connection dependencies) tournament-eid player-sub)]
+        (assoc entry :type :tournament/entry)
+        {:type :tournament/entry-error :message "Already entered in this tournament."}))))
 
 (defn delete-entry
   "Removes a player's entry from a tournament. Returns a success or error map."
@@ -136,14 +150,14 @@
     (if-not (= "registration" (:status state))
       {:type :tournament/entry-error :message "Cannot withdraw outside of registration period."}
       (do
-        (db/delete-entry (:connection dependencies) tournament-eid player-sub)
+        (db/delete-entry! (:datalog-connection dependencies) tournament-eid player-sub)
         {:type :tournament/entry-deleted :message "Entry removed from tournament."}))))
 
 (defn get-entries
   "Returns all active entries for a tournament."
   [dependencies tournament-eid]
   (mapv (fn [e] (assoc e :type :tournament/entry))
-        (db/get-entries-for-tournament (:connection dependencies) tournament-eid)))
+        (db/entries-for-tournament (:datalog-connection dependencies) tournament-eid)))
 
 (defn available-transitions
   "Returns the set of valid target statuses for a tournament."
@@ -170,20 +184,21 @@
       :else nil)))
 
 (defn start-tournament
-  "Transitions a tournament from registration to active. Populates the
-   standings list from current entries via `rules/close-registration`.
-   Only the organizer can start. Returns `:tournament/started` on
-   success, `:tournament/start-error` on failure."
+  "Transitions a tournament from registration to active, pointing
+   `current-phase-index` at the first phase when one is configured. Only
+   the organizer can start. Returns `:tournament/started` on success,
+   `:tournament/start-error` on failure."
   [dependencies tournament-eid user-sub]
   (or (organizer-error dependencies tournament-eid user-sub :tournament/start-error)
       (let [state (get-tournament-state dependencies tournament-eid)]
         (if (not= "registration" (:status state))
           {:type    :tournament/start-error
            :message (str "Cannot start: tournament is '" (:status state) "', not 'registration'.")}
-          (let [entries   (get-entries dependencies tournament-eid)
-                new-state (rules/close-registration state entries)]
-            (set-tournament-state dependencies tournament-eid new-state)
-            {:type :tournament/started :state new-state})))))
+          (do
+            (db/update-tournament! (:datalog-connection dependencies) tournament-eid
+                                   {:status              "active"
+                                    :current-phase-index (when (seq (:phases state)) 0)})
+            {:type :tournament/started :state (get-tournament-state dependencies tournament-eid)})))))
 
 (defn complete-tournament
   "Transitions a tournament from active to complete. Only the organizer
@@ -195,9 +210,9 @@
         (if (not= "active" (:status state))
           {:type    :tournament/complete-error
            :message (str "Cannot complete: tournament is '" (:status state) "', not 'active'.")}
-          (let [new-state (assoc state :status "complete")]
-            (set-tournament-state dependencies tournament-eid new-state)
-            {:type :tournament/completed :state new-state})))))
+          (do
+            (db/update-tournament! (:datalog-connection dependencies) tournament-eid {:status "complete"})
+            {:type :tournament/completed :state (get-tournament-state dependencies tournament-eid)})))))
 
 (defn cancel-tournament
   "Cancels a tournament that hasn't already finished. Only the organizer
@@ -209,9 +224,9 @@
         (if (contains? #{"complete" "cancelled"} (:status state))
           {:type    :tournament/cancel-error
            :message (str "Cannot cancel: tournament is already '" (:status state) "'.")}
-          (let [new-state (assoc state :status "cancelled")]
-            (set-tournament-state dependencies tournament-eid new-state)
-            {:type :tournament/cancelled :state new-state})))))
+          (do
+            (db/update-tournament! (:datalog-connection dependencies) tournament-eid {:status "cancelled"})
+            {:type :tournament/cancelled :state (get-tournament-state dependencies tournament-eid)})))))
 
 (defn close-registration-early
   "Sets the closed-early flag on a tournament still in registration,
@@ -224,9 +239,10 @@
       (let [state (get-tournament-state dependencies tournament-eid)]
         (if (not= "registration" (:status state))
           {:type :tournament/registration-close-error :message "Tournament is not in registration status."}
-          (let [new-state (assoc-in state [:registration :closed-early] true)]
-            (set-tournament-state dependencies tournament-eid new-state)
-            {:type :tournament/registration-closed :state new-state})))))
+          (do
+            (db/update-tournament! (:datalog-connection dependencies) tournament-eid
+                                   {:registration-closed-early true})
+            {:type :tournament/registration-closed :state (get-tournament-state dependencies tournament-eid)})))))
 
 ;; ─── Matches ─────────────────────────────────────────────────────────────────
 
@@ -236,29 +252,29 @@
   (let [state (get-tournament-state dependencies tournament-eid)]
     (if (not= "active" (:status state))
       {:type :tournament/match-error :message "Tournament must be active to create matches."}
-      (tag-match (db/create-match (:connection dependencies) tournament-eid match-spec)))))
+      (tag-match (db/create-match! (:datalog-connection dependencies) tournament-eid match-spec)))))
 
 (defn get-match-by-eid
   "Fetches a match by eid."
   [dependencies match-eid]
-  (tag-match (db/get-match-by-eid (:connection dependencies) match-eid)))
+  (tag-match (db/match-by-eid (:datalog-connection dependencies) match-eid)))
 
 (defn get-matches
   "Returns every match in the system, each tagged with :type :tournament/match."
   [dependencies]
-  (mapv tag-match (db/get-matches (:connection dependencies))))
+  (mapv tag-match (db/matches (:datalog-connection dependencies))))
 
 (defn get-matches-for-tournament
   "Returns all matches for a tournament."
   [dependencies tournament-eid]
   (mapv tag-match
-        (db/get-matches-for-tournament (:connection dependencies) tournament-eid)))
+        (db/matches-for-tournament (:datalog-connection dependencies) tournament-eid)))
 
 (defn get-matches-for-round
   "Returns matches for a specific phase and round."
   [dependencies tournament-eid phase-index round-index]
   (mapv tag-match
-        (db/get-matches-for-round (:connection dependencies) tournament-eid phase-index round-index)))
+        (db/matches-for-round (:datalog-connection dependencies) tournament-eid phase-index round-index)))
 
 (defn- double-elim-complete?
   "Returns true when a double-elimination phase has a completed grand-final
@@ -272,15 +288,14 @@
          all-matches)))
 
 (defn- recalculate-and-check-completion
-  "Recalculates standings after a match completes. If phases are configured
-   and all matches in all phases are done with no more rounds remaining,
-   auto-completes the tournament. Without phase configuration, no
-   auto-completion occurs."
+  "Recomputes the (derived) standings after a match completes and, when
+   phases are configured and every match across all phases is done with no
+   more rounds remaining, auto-completes the tournament. Standings are
+   derived from entities, so the only write here is the completion flip."
   [dependencies tournament-eid]
   (let [state         (get-tournament-state dependencies tournament-eid)
         all-matches   (get-matches-for-tournament dependencies tournament-eid)
-        completed     (filter #(= "complete" (:status %)) all-matches)
-        new-standings (rules/recalculate-standings (:standings state) completed)
+        new-standings (:standings state)
         has-phases    (seq (:phases state))
         complete?     (when has-phases
                         (let [all-done    (every? #(= "complete" (:status %)) all-matches)
@@ -295,17 +310,16 @@
                             (let [phase-matches (filter #(= phase-index (:phase-index %)) all-matches)
                                   max-round     (if (empty? phase-matches) -1 (apply max (map :round-index phase-matches)))
                                   rounds-left   (get-in phase [:rounds (inc max-round)])]
-                              (and all-done (nil? rounds-left))))))
-        new-state     (cond-> (assoc state :standings new-standings)
-                        complete? (assoc :status "complete"))]
-    (set-tournament-state dependencies tournament-eid new-state)
+                              (and all-done (nil? rounds-left))))))]
+    (when complete?
+      (db/update-tournament! (:datalog-connection dependencies) tournament-eid {:status "complete"}))
     {:standings           new-standings
      :tournament-complete (boolean complete?)}))
 
 (defn update-match-result
-  "Records a match result and recalculates standings in the state blob."
+  "Records a match result and recalculates standings from entities."
   [dependencies match-eid winner-sub]
-  (let [match (db/get-match-by-eid (:connection dependencies) match-eid)]
+  (let [match (db/match-by-eid (:datalog-connection dependencies) match-eid)]
     (cond
       (nil? match)
       {:type :tournament/match-error :message "Match not found."}
@@ -315,7 +329,7 @@
 
       :else
       (do
-        (db/update-match-result (:connection dependencies) match-eid winner-sub)
+        (db/update-match-result! (:datalog-connection dependencies) match-eid winner-sub)
         (let [{:keys [standings tournament-complete]}
               (recalculate-and-check-completion dependencies (:tournament-eid match))]
           (cond-> {:type      :tournament/match-result-recorded
@@ -329,7 +343,7 @@
   "Records a game within a match. If the match win threshold is reached,
    the match auto-completes and standings are recalculated."
   [dependencies match-eid winner-sub]
-  (let [match (db/get-match-by-eid (:connection dependencies) match-eid)]
+  (let [match (db/match-by-eid (:datalog-connection dependencies) match-eid)]
     (cond
       (nil? match)
       {:type :tournament/match-error :message "Match not found."}
@@ -338,15 +352,16 @@
       {:type :tournament/match-error :message "Match is already complete."}
 
       :else
-      (let [existing-games (db/get-games-for-match (:connection dependencies) match-eid)
+      (let [conn           (:datalog-connection dependencies)
+            existing-games (db/games-for-match conn match-eid)
             game-index     (count existing-games)
-            _              (db/create-game (:connection dependencies) match-eid game-index winner-sub)
+            _              (db/create-game! conn match-eid game-index winner-sub)
             all-games      (conj (vec existing-games) {:winner-sub winner-sub})
             match-winner   (rules/check-match-complete all-games (:format match))]
         (if match-winner
           ;; Match complete — update match, recalculate standings, check tournament completion
           (do
-            (db/update-match-result (:connection dependencies) match-eid match-winner)
+            (db/update-match-result! conn match-eid match-winner)
             (let [{:keys [standings tournament-complete]}
                   (recalculate-and-check-completion dependencies (:tournament-eid match))]
               (cond-> {:type       :tournament/match-completed
@@ -364,7 +379,7 @@
 (defn get-games-for-match
   "Returns all games for a match."
   [dependencies match-eid]
-  (db/get-games-for-match (:connection dependencies) match-eid))
+  (db/games-for-match (:datalog-connection dependencies) match-eid))
 
 ;; ─── Phase management ────────────────────────────────────────────────────────
 
@@ -383,12 +398,11 @@
       (let [state (get-tournament-state dependencies tournament-eid)]
         (if (not= "registration" (:status state))
           {:type :tournament/phase-error :message "Phases can only be configured during registration."}
-          (let [new-state (-> state
-                              (assoc :phases (:phases phase-config))
-                              (assoc :qualifier-count (:qualifier-count phase-config)))]
-            (set-tournament-state dependencies tournament-eid new-state)
+          (let [conn (:datalog-connection dependencies)]
+            (db/set-phases! conn tournament-eid (:phases phase-config))
+            (db/update-tournament! conn tournament-eid {:qualifier-count (:qualifier-count phase-config)})
             {:type  :tournament/phase-configured
-             :state new-state}))))))
+             :state (get-tournament-state dependencies tournament-eid)}))))))
 
 (defn- generate-pairings
   "Dispatches pairing generation based on phase type. Used by non-double-elim
@@ -406,8 +420,8 @@
    Bye matches (nil player-two-sub) are auto-completed with player-one as winner."
   [dependencies tournament-eid phase-index round-index bracket-type format pairings]
   (mapv (fn [pairing]
-          (let [match (db/create-match
-                       (:connection dependencies)
+          (let [match (db/create-match!
+                       (:datalog-connection dependencies)
                        tournament-eid
                        (assoc pairing
                               :phase-index phase-index
@@ -415,7 +429,7 @@
                               :bracket-type bracket-type
                               :format format))]
             (if (nil? (:player-two-sub pairing))
-              (do (db/update-match-result (:connection dependencies) (:eid match) (:player-one-sub pairing))
+              (do (db/update-match-result! (:datalog-connection dependencies) (:eid match) (:player-one-sub pairing))
                   (assoc match :status "complete" :winner-sub (:player-one-sub pairing)))
               match)))
         pairings))
@@ -488,7 +502,8 @@
       {:type :tournament/phase-error :message "Only the tournament organizer can generate rounds."}
 
       :else
-      (let [state           (get-tournament-state dependencies tournament-eid)
+      (let [conn            (:datalog-connection dependencies)
+            state           (get-tournament-state dependencies tournament-eid)
             phase-index     (:current-phase state)
             phase           (get-in state [:phases phase-index])
             all-matches     (get-matches-for-tournament dependencies tournament-eid)
@@ -511,11 +526,10 @@
                     next-phase       (get-in state [:phases next-phase-index])]
                 (if (nil? next-phase)
                   {:type :tournament/phase-error :message "All phases complete. No more rounds to generate."}
-                  (let [format    (round-format next-phase 0)
-                        pairings  (generate-pairings (:phase-type next-phase) (:standings state) all-matches qualified)
-                        matches   (create-round-matches dependencies tournament-eid next-phase-index 0 "winners" format pairings)
-                        new-state (assoc state :current-phase next-phase-index)]
-                    (set-tournament-state dependencies tournament-eid new-state)
+                  (let [format   (round-format next-phase 0)
+                        pairings (generate-pairings (:phase-type next-phase) (:standings state) all-matches qualified)
+                        matches  (create-round-matches dependencies tournament-eid next-phase-index 0 "winners" format pairings)]
+                    (db/update-tournament! conn tournament-eid {:current-phase-index next-phase-index})
                     {:type           :tournament/round-generated
                      :round          0
                      :phase          next-phase-index
@@ -542,11 +556,10 @@
                     next-phase       (get-in state [:phases next-phase-index])]
                 (if (nil? next-phase)
                   {:type :tournament/phase-error :message "All phases complete. No more rounds to generate."}
-                  (let [format    (round-format next-phase 0)
-                        pairings  (generate-pairings (:phase-type next-phase) (:standings state) all-matches qualified)
-                        matches   (create-round-matches dependencies tournament-eid next-phase-index 0 "winners" format pairings)
-                        new-state (assoc state :current-phase next-phase-index)]
-                    (set-tournament-state dependencies tournament-eid new-state)
+                  (let [format   (round-format next-phase 0)
+                        pairings (generate-pairings (:phase-type next-phase) (:standings state) all-matches qualified)
+                        matches  (create-round-matches dependencies tournament-eid next-phase-index 0 "winners" format pairings)]
+                    (db/update-tournament! conn tournament-eid {:current-phase-index next-phase-index})
                     {:type           :tournament/round-generated
                      :round          0
                      :phase          next-phase-index
@@ -555,21 +568,17 @@
 
               ;; Generate next round in current phase
               :else
-              (let [format    (or (:format round-config) 1)
-                    pairings  (if (and (= "single-elimination" (:phase-type phase))
-                                       (pos? next-round))
-                                ;; Subsequent SE rounds advance the bracket
-                                ;; from the previous round's winners; only
-                                ;; round 0 seeds from standings.
-                                (rules/advance-winners-bracket-round
-                                 (filter #(= (dec next-round) (:round-index %))
-                                         phase-matches))
-                                (generate-pairings (:phase-type phase) (:standings state) all-matches qualified))
-                    matches   (create-round-matches dependencies tournament-eid phase-index next-round "winners" format pairings)
-                    new-state (update-in state [:phases phase-index :rounds next-round]
-                                         assoc :match-eids (mapv :eid matches)
-                                         :status "active")]
-                (set-tournament-state dependencies tournament-eid new-state)
+              (let [format   (or (:format round-config) 1)
+                    pairings (if (and (= "single-elimination" (:phase-type phase))
+                                      (pos? next-round))
+                               ;; Subsequent SE rounds advance the bracket
+                               ;; from the previous round's winners; only
+                               ;; round 0 seeds from standings.
+                               (rules/advance-winners-bracket-round
+                                (filter #(= (dec next-round) (:round-index %))
+                                        phase-matches))
+                               (generate-pairings (:phase-type phase) (:standings state) all-matches qualified))
+                    matches  (create-round-matches dependencies tournament-eid phase-index next-round "winners" format pairings)]
                 {:type    :tournament/round-generated
                  :round   next-round
                  :phase   phase-index

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/replay_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/replay_test.clj
@@ -8,17 +8,14 @@
   (:import
    [java.util UUID]))
 
-;; The submit flow auto-creates one draft per side per game from the
-;; parsed replay. The handful of new data-access fns it pulls in are
-;; defaulted here to safe no-ops so the validation-focused tests don't
-;; need to know about them; the persistence-flow tests below override
-;; the relevant stubs to assert draft side-effects.
-;;
-;; When a match clinches, record-game-from-parsed delegates to
-;; handlers.tournament/update-match-result so standings recalculate —
-;; which pulls in the tournament-state + all-matches stubs below;
-;; defaulted to a minimal empty state with no phases so
-;; recalculate-and-check-completion is a no-op for these tests.
+;; The submit flow auto-creates one draft per side per game from the parsed
+;; replay; the data-access fns it pulls in are defaulted here to safe
+;; no-ops, and the persistence-flow tests below override the relevant stubs
+;; to assert draft side-effects. When a match clinches,
+;; record-game-from-parsed delegates to
+;; handlers.tournament/update-match-result, which reads the tournament's
+;; state + matches — defaulted to an empty no-phase state so completion
+;; checking is a no-op for these tests.
 (use-fixtures :each
   (fn [t]
     (with-redefs [data-access.contract/tournament-by-eid      (fn [_ _] {:name "Practice" :game-eid (UUID/randomUUID) :status "active"})
@@ -136,12 +133,11 @@
       (is (re-find #"maximum" (:message r))))))
 
 (deftest record-game-resolves-mount-from-parsed-key-suffix
-  ;; Regression: the mount-needing filter previously checked against the
-  ;; resolved-rows-map keys, but the mount-suffixed parser key
-  ;; (e.g. `..._sorcerer_prophet_fire_great_taurus`) never lives there —
-  ;; only its un-mounted prefix does. The filter must consult the
-  ;; engine-emitted keys directly so `get-mounts-for-unit` is hit for
-  ;; rows that have a mounted variant in the parsed game.
+  ;; The mount-needing filter consults the engine-emitted keys directly: a
+  ;; mount-suffixed parser key (e.g. `..._sorcerer_prophet_fire_great_taurus`)
+  ;; never appears in the resolved-rows map — only its un-mounted prefix
+  ;; does — so `mounts-for-unit` is hit for rows whose parsed key carries a
+  ;; mount variant.
   (let [stored-states     (atom [])
         unit-eid          (UUID/randomUUID)
         faction-eid       (UUID/randomUUID)
@@ -173,14 +169,6 @@
                   data-access.contract/game-modes-for-game  (fn [_ _] [{:eid (UUID/randomUUID) :name "Land Battle"}])
                   data-access.contract/subfactions-by-keys  (fn [_ _] [{:key "wh3_dlc23_chd_legion_of_azgorh" :faction-eid faction-eid}])
                   data-access.contract/units-by-keys        (fn [_ _] [{:eid unit-eid :key base-key :cost 900}])
-                  data-access.contract/mounts-for-unit      (fn [_ eid]
-                                                              (when (= eid unit-eid)
-                                                                [{:key "mount_great_taurus" :name "Great Taurus" :cost 300}
-                                                                 {:key "mount_lammasu" :name "Lammasu" :cost 200}]))
-                  ;; compute-unit-total-cost (transitively reached from
-                  ;; replay via parsed-unit->entry) hits the datalog
-                  ;; mounts + level-cost reads, so mirror the SQLite
-                  ;; stubs above on the datalog names.
                   data-access.contract/mounts-for-unit      (fn [_ eid]
                                                               (when (= eid unit-eid)
                                                                 [{:key "mount_great_taurus" :name "Great Taurus" :cost 300}

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/replay_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/replay_test.clj
@@ -21,17 +21,17 @@
 ;; recalculate-and-check-completion is a no-op for these tests.
 (use-fixtures :each
   (fn [t]
-    (with-redefs [data-access.contract/get-tournament-by-eid      (fn [_ _] {:name "Practice" :game-eid (UUID/randomUUID)})
-                  data-access.contract/game-modes-for-game        (fn [_ _] [{:eid (UUID/randomUUID) :name "Land Battle"}])
-                  data-access.contract/subfactions-by-keys        (fn [_ _] [])
-                  data-access.contract/units-by-keys              (fn [_ _] [])
-                  data-access.contract/mounts-for-unit            (fn [_ _] [])
-                  data-access.contract/unit-level-costs           (fn [_] {})
-                  data-access.contract/create-draft!              (fn [_ spec] (assoc spec :version 1))
-                  data-access.contract/add-entries!               (fn [_ _ _] nil)
-                  data-access.contract/get-tournament-state       (fn [_ _] nil)
-                  data-access.contract/upsert-tournament-state    (fn [_ _ _] nil)
-                  data-access.contract/get-matches-for-tournament (fn [_ _] [])]
+    (with-redefs [data-access.contract/tournament-by-eid      (fn [_ _] {:name "Practice" :game-eid (UUID/randomUUID) :status "active"})
+                  data-access.contract/game-modes-for-game    (fn [_ _] [{:eid (UUID/randomUUID) :name "Land Battle"}])
+                  data-access.contract/subfactions-by-keys    (fn [_ _] [])
+                  data-access.contract/units-by-keys          (fn [_ _] [])
+                  data-access.contract/mounts-for-unit        (fn [_ _] [])
+                  data-access.contract/unit-level-costs       (fn [_] {})
+                  data-access.contract/create-draft!          (fn [_ spec] (assoc spec :version 1))
+                  data-access.contract/add-entries!           (fn [_ _ _] nil)
+                  data-access.contract/phases-for-tournament  (fn [_ _] [])
+                  data-access.contract/entries-for-tournament (fn [_ _] [])
+                  data-access.contract/matches-for-tournament (fn [_ _] [])]
       (t))))
 
 (def ^:private match-eid (UUID/fromString "00000000-0000-4000-8000-000000000001"))
@@ -110,27 +110,27 @@
    :uploaded-by-sub "sigmar_42"})
 
 (deftest record-game-rejects-missing-match
-  (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] nil)]
+  (with-redefs [data-access.contract/match-by-eid (fn [_ _] nil)]
     (let [r (handlers.replay/record-game-from-parsed deps match-eid (valid-submission "sigmar_42"))]
       (is (= :match-record/error (:type r)))
       (is (= "Match not found." (:message r))))))
 
 (deftest record-game-rejects-already-complete
-  (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] (assoc bo1-match :status "complete"))]
+  (with-redefs [data-access.contract/match-by-eid (fn [_ _] (assoc bo1-match :status "complete"))]
     (let [r (handlers.replay/record-game-from-parsed deps match-eid (valid-submission "sigmar_42"))]
       (is (= :match-record/error (:type r)))
       (is (= "Match is already complete." (:message r))))))
 
 (deftest record-game-rejects-unknown-winner-sub
-  (with-redefs [data-access.contract/get-match-by-eid    (fn [_ _] bo1-match)
-                data-access.contract/get-games-for-match (fn [_ _] [])]
+  (with-redefs [data-access.contract/match-by-eid    (fn [_ _] bo1-match)
+                data-access.contract/games-for-match (fn [_ _] [])]
     (let [r (handlers.replay/record-game-from-parsed deps match-eid (valid-submission "stranger"))]
       (is (= :match-record/error (:type r)))
       (is (re-find #"one of the match's players" (:message r))))))
 
 (deftest record-game-rejects-when-series-full
-  (with-redefs [data-access.contract/get-match-by-eid    (fn [_ _] bo1-match)
-                data-access.contract/get-games-for-match (fn [_ _] [{:winner-sub "sigmar_42"}])]
+  (with-redefs [data-access.contract/match-by-eid    (fn [_ _] bo1-match)
+                data-access.contract/games-for-match (fn [_ _] [{:winner-sub "sigmar_42"}])]
     (let [r (handlers.replay/record-game-from-parsed deps match-eid (valid-submission "sigmar_42"))]
       (is (= :match-record/error (:type r)))
       (is (re-find #"maximum" (:message r))))))
@@ -164,35 +164,35 @@
                                                                                                :key           mounted-key
                                                                                                :level         0
                                                                                                :spells        []}]}]}]}]
-    (with-redefs [data-access.contract/get-match-by-eid      (fn [_ _] bo1-match)
-                  data-access.contract/get-games-for-match   (fn [_ _] [])
-                  data-access.contract/create-replay!        (fn [_ spec] (assoc spec :id 1))
-                  data-access.contract/create-game           (fn [_ _ gi w _] {:game-index gi :winner-sub w})
-                  data-access.contract/update-match-result   (fn [_ _ _] nil)
-                  data-access.contract/get-tournament-by-eid (fn [_ _] {:name "Mount Cup" :game-eid (UUID/randomUUID)})
-                  data-access.contract/game-modes-for-game   (fn [_ _] [{:eid (UUID/randomUUID) :name "Land Battle"}])
-                  data-access.contract/subfactions-by-keys   (fn [_ _] [{:key "wh3_dlc23_chd_legion_of_azgorh" :faction-eid faction-eid}])
-                  data-access.contract/units-by-keys         (fn [_ _] [{:eid unit-eid :key base-key :cost 900}])
-                  data-access.contract/mounts-for-unit       (fn [_ eid]
-                                                               (when (= eid unit-eid)
-                                                                 [{:key "mount_great_taurus" :name "Great Taurus" :cost 300}
-                                                                  {:key "mount_lammasu" :name "Lammasu" :cost 200}]))
+    (with-redefs [data-access.contract/match-by-eid         (fn [_ _] bo1-match)
+                  data-access.contract/games-for-match      (fn [_ _] [])
+                  data-access.contract/create-replay!       (fn [_ spec] (assoc spec :id 1))
+                  data-access.contract/create-game!         (fn [_ _ gi w _] {:game-index gi :winner-sub w})
+                  data-access.contract/update-match-result! (fn [_ _ _] nil)
+                  data-access.contract/tournament-by-eid    (fn [_ _] {:name "Mount Cup" :game-eid (UUID/randomUUID)})
+                  data-access.contract/game-modes-for-game  (fn [_ _] [{:eid (UUID/randomUUID) :name "Land Battle"}])
+                  data-access.contract/subfactions-by-keys  (fn [_ _] [{:key "wh3_dlc23_chd_legion_of_azgorh" :faction-eid faction-eid}])
+                  data-access.contract/units-by-keys        (fn [_ _] [{:eid unit-eid :key base-key :cost 900}])
+                  data-access.contract/mounts-for-unit      (fn [_ eid]
+                                                              (when (= eid unit-eid)
+                                                                [{:key "mount_great_taurus" :name "Great Taurus" :cost 300}
+                                                                 {:key "mount_lammasu" :name "Lammasu" :cost 200}]))
                   ;; compute-unit-total-cost (transitively reached from
                   ;; replay via parsed-unit->entry) hits the datalog
                   ;; mounts + level-cost reads, so mirror the SQLite
                   ;; stubs above on the datalog names.
-                  data-access.contract/mounts-for-unit       (fn [_ eid]
-                                                               (when (= eid unit-eid)
-                                                                 [{:key "mount_great_taurus" :name "Great Taurus" :cost 300}
-                                                                  {:key "mount_lammasu" :name "Lammasu" :cost 200}]))
-                  data-access.contract/unit-level-costs      (fn [_] {0 {:level   0 :fixed-cost 0   :cost-multiplier 1.0
-                                                                         :fatigue 0 :melee-cp   0.0 :missile-cp      0.0}})
-                  data-access.contract/abilities-by-keys     (fn [_ _] {})
-                  data-access.contract/spells-by-keys        (fn [_ _] {})
-                  data-access.contract/items-for-unit        (fn [_ _] [])
-                  data-access.contract/create-draft!         (fn [_ spec] (assoc spec :version 1))
-                  data-access.contract/add-entries!          (fn [_ draft-eid entries]
-                                                               (swap! stored-states into (map #(assoc % :draft-eid draft-eid) entries)))]
+                  data-access.contract/mounts-for-unit      (fn [_ eid]
+                                                              (when (= eid unit-eid)
+                                                                [{:key "mount_great_taurus" :name "Great Taurus" :cost 300}
+                                                                 {:key "mount_lammasu" :name "Lammasu" :cost 200}]))
+                  data-access.contract/unit-level-costs     (fn [_] {0 {:level   0 :fixed-cost 0   :cost-multiplier 1.0
+                                                                        :fatigue 0 :melee-cp   0.0 :missile-cp      0.0}})
+                  data-access.contract/abilities-by-keys    (fn [_ _] {})
+                  data-access.contract/spells-by-keys       (fn [_ _] {})
+                  data-access.contract/items-for-unit       (fn [_ _] [])
+                  data-access.contract/create-draft!        (fn [_ spec] (assoc spec :version 1))
+                  data-access.contract/add-entries!         (fn [_ draft-eid entries]
+                                                              (swap! stored-states into (map #(assoc % :draft-eid draft-eid) entries)))]
       (handlers.replay/record-game-from-parsed
        deps match-eid
        {:parsed          parsed-with-mount
@@ -222,35 +222,35 @@
         match-completed (atom nil)
         emp-faction-eid (UUID/randomUUID)
         chd-faction-eid (UUID/randomUUID)]
-    (with-redefs [data-access.contract/get-match-by-eid      (fn [_ _] bo1-match)
-                  data-access.contract/get-games-for-match   (fn [_ _] [])
-                  data-access.contract/create-replay!        (fn [_ spec]
-                                                               (swap! stored-replays conj spec)
-                                                               spec)
-                  data-access.contract/create-game           (fn [_ _meid game-index winner-sub opts]
-                                                               (let [g (merge {:game-index game-index
-                                                                               :winner-sub winner-sub
-                                                                               :replay-eid (:replay-eid opts)}
-                                                                              (select-keys opts
-                                                                                           [:player-one-draft-eid
-                                                                                            :player-two-draft-eid]))]
-                                                                 (swap! stored-games conj g)
-                                                                 g))
-                  data-access.contract/update-match-result   (fn [_ _ winner] (reset! match-completed winner))
-                  data-access.contract/get-tournament-by-eid (fn [_ _] {:name "Spring Open" :game-eid (UUID/randomUUID)})
-                  data-access.contract/game-modes-for-game   (fn [_ _] [{:eid (UUID/randomUUID) :name "Land Battle"}])
-                  data-access.contract/subfactions-by-keys   (fn [_ keys]
-                                                               (let [k (first keys)]
-                                                                 (cond
-                                                                   (= k "wh_main_emp_empire")
-                                                                   [{:key k :faction-eid emp-faction-eid}]
-                                                                   (= k "wh3_dlc23_chd_legion_of_azgorh")
-                                                                   [{:key k :faction-eid chd-faction-eid}]
-                                                                   :else [])))
-                  data-access.contract/create-draft!         (fn [_ spec]
-                                                               (swap! stored-drafts conj spec)
-                                                               (assoc spec :version 1))
-                  data-access.contract/add-entries!          (fn [_ _ _] nil)]
+    (with-redefs [data-access.contract/match-by-eid         (fn [_ _] bo1-match)
+                  data-access.contract/games-for-match      (fn [_ _] [])
+                  data-access.contract/create-replay!       (fn [_ spec]
+                                                              (swap! stored-replays conj spec)
+                                                              spec)
+                  data-access.contract/create-game!         (fn [_ _meid game-index winner-sub opts]
+                                                              (let [g (merge {:game-index game-index
+                                                                              :winner-sub winner-sub
+                                                                              :replay-eid (:replay-eid opts)}
+                                                                             (select-keys opts
+                                                                                          [:player-one-draft-eid
+                                                                                           :player-two-draft-eid]))]
+                                                                (swap! stored-games conj g)
+                                                                g))
+                  data-access.contract/update-match-result! (fn [_ _ winner] (reset! match-completed winner))
+                  data-access.contract/tournament-by-eid    (fn [_ _] {:name "Spring Open" :game-eid (UUID/randomUUID)})
+                  data-access.contract/game-modes-for-game  (fn [_ _] [{:eid (UUID/randomUUID) :name "Land Battle"}])
+                  data-access.contract/subfactions-by-keys  (fn [_ keys]
+                                                              (let [k (first keys)]
+                                                                (cond
+                                                                  (= k "wh_main_emp_empire")
+                                                                  [{:key k :faction-eid emp-faction-eid}]
+                                                                  (= k "wh3_dlc23_chd_legion_of_azgorh")
+                                                                  [{:key k :faction-eid chd-faction-eid}]
+                                                                  :else [])))
+                  data-access.contract/create-draft!        (fn [_ spec]
+                                                              (swap! stored-drafts conj spec)
+                                                              (assoc spec :version 1))
+                  data-access.contract/add-entries!         (fn [_ _ _] nil)]
       (let [result (handlers.replay/record-game-from-parsed
                     deps match-eid (valid-submission "sigmar_42"))]
         (testing "one replay row persisted"

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
@@ -9,12 +9,10 @@
 
 (def ^:private test-tournament-eid (UUID/fromString "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 (def ^:private test-game-eid (UUID/fromString "eea787d7-1065-45eb-a3f6-e26f32c294a1"))
-;; The cutover routes every tournament read/write through the Datalevin
-;; connection; the SQLite `:connection` is no longer touched here.
+;; Tournament reads/writes go through the Datalevin connection.
 (def ^:private test-deps {:datalog-connection nil})
 
-;; A tournament *entity* as the datalog data-access layer returns it —
-;; status/registration/phase fields live on the row now, not in a JSON blob.
+;; A tournament entity as the datalog data-access layer returns it.
 (def ^:private test-tournament
   {:eid                       test-tournament-eid
    :name                      "Test Tournament"

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
@@ -4,107 +4,128 @@
    [com.devereux-henley.rts-data-access.contract :as data-access.contract]
    [com.devereux-henley.rts-domain.handlers.tournament :as handlers.tournament])
   (:import
-   [java.time Instant]
+   [java.time Instant LocalDateTime ZoneId]
    [java.util UUID]))
 
 (def ^:private test-tournament-eid (UUID/fromString "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
 (def ^:private test-game-eid (UUID/fromString "eea787d7-1065-45eb-a3f6-e26f32c294a1"))
-(def ^:private test-deps {:connection nil})
+;; The cutover routes every tournament read/write through the Datalevin
+;; connection; the SQLite `:connection` is no longer touched here.
+(def ^:private test-deps {:datalog-connection nil})
 
+;; A tournament *entity* as the datalog data-access layer returns it —
+;; status/registration/phase fields live on the row now, not in a JSON blob.
 (def ^:private test-tournament
-  {:id       1             :eid            test-tournament-eid :name    "Test Tournament" :description "A test."
-   :game-eid test-game-eid :created-by-sub "dev-admin"         :version 1})
+  {:eid                       test-tournament-eid
+   :name                      "Test Tournament"
+   :description               "A test."
+   :game-eid                  test-game-eid
+   :created-by-sub            "dev-admin"
+   :version                   1
+   :status                    "registration"
+   :registration-opens-at     nil
+   :registration-closes-at    nil
+   :timezone                  "UTC"
+   :registration-closed-early false
+   :current-phase-index       nil
+   :qualifier-count           nil})
 
 (def ^:private test-entry
-  {:id         1           :eid        (UUID/randomUUID) :tournament-eid test-tournament-eid
-   :player-sub "dev-admin" :created-at (Instant/now)     :deleted-at     nil})
+  {:eid        (UUID/randomUUID) :tournament-eid test-tournament-eid
+   :player-sub "dev-admin"       :created-at     (Instant/now)})
 
 ;; ─── get-tournament-by-eid ───────────────────────────────────────────────────
 
 (deftest get-tournament-by-eid-assigns-type
-  (with-redefs [data-access.contract/get-tournament-by-eid (fn [_ _] test-tournament)]
+  (with-redefs [data-access.contract/tournament-by-eid (fn [_ _] test-tournament)]
     (let [result (handlers.tournament/get-tournament-by-eid test-deps test-tournament-eid)]
       (is (= :tournament/tournament (:type result))))))
 
 (deftest get-tournament-by-eid-preserves-fields
-  (with-redefs [data-access.contract/get-tournament-by-eid (fn [_ _] test-tournament)]
+  (with-redefs [data-access.contract/tournament-by-eid (fn [_ _] test-tournament)]
     (let [result (handlers.tournament/get-tournament-by-eid test-deps test-tournament-eid)]
       (is (= test-tournament-eid (:eid result)))
       (is (= "Test Tournament" (:name result))))))
 
 (deftest get-tournament-by-eid-returns-nil-when-not-found
-  (with-redefs [data-access.contract/get-tournament-by-eid (fn [_ _] nil)]
+  (with-redefs [data-access.contract/tournament-by-eid (fn [_ _] nil)]
     (is (nil? (handlers.tournament/get-tournament-by-eid test-deps test-tournament-eid)))))
 
 ;; ─── get-tournaments-for-game ────────────────────────────────────────────────
 
 (deftest get-tournaments-for-game-assigns-type-to-each
-  (with-redefs [data-access.contract/get-tournaments-for-game
+  (with-redefs [data-access.contract/tournaments-for-game
                 (fn [_ _] [test-tournament (assoc test-tournament :name "Second")])]
     (let [results (handlers.tournament/get-tournaments-for-game test-deps test-game-eid)]
       (is (every? #(= :tournament/tournament (:type %)) results)))))
 
 (deftest get-tournaments-for-game-returns-all-results
-  (with-redefs [data-access.contract/get-tournaments-for-game
+  (with-redefs [data-access.contract/tournaments-for-game
                 (fn [_ _] [test-tournament (assoc test-tournament :name "Second")])]
     (is (= 2 (count (handlers.tournament/get-tournaments-for-game test-deps test-game-eid))))))
 
 (deftest get-tournaments-for-game-empty-result
-  (with-redefs [data-access.contract/get-tournaments-for-game (fn [_ _] [])]
+  (with-redefs [data-access.contract/tournaments-for-game (fn [_ _] [])]
     (is (= [] (handlers.tournament/get-tournaments-for-game test-deps test-game-eid)))))
 
-;; ─── get-tournament-state ────────────────────────────────────────────────────
+;; ─── get-tournament-state (reconstructed from entities) ──────────────────────
 
-(deftest get-tournament-state-parses-json
-  (with-redefs [data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state "{\"status\":\"registration\"}" :updated-at (Instant/now)})]
+(deftest get-tournament-state-reconstructs-from-entity
+  (with-redefs [data-access.contract/tournament-by-eid      (fn [_ _] test-tournament)
+                data-access.contract/phases-for-tournament  (fn [_ _] [])
+                data-access.contract/entries-for-tournament (fn [_ _] [])
+                data-access.contract/matches-for-tournament (fn [_ _] [])]
     (let [result (handlers.tournament/get-tournament-state test-deps test-tournament-eid)]
-      (is (= "registration" (:status result))))))
+      (is (= "registration" (:status result)))
+      (is (= [] (:phases result))))))
 
-(deftest get-tournament-state-returns-default-when-nil
-  (with-redefs [data-access.contract/get-tournament-state (fn [_ _] nil)]
+(deftest get-tournament-state-returns-default-when-absent
+  (with-redefs [data-access.contract/tournament-by-eid (fn [_ _] nil)]
     (let [result (handlers.tournament/get-tournament-state test-deps test-tournament-eid)]
       (is (= "registration" (:status result)))
       (is (= [] (:phases result))))))
 
 ;; ─── is-registration-open? ──────────────────────────────────────────────────
+;;
+;; Reconstructed state carries the registration window as instants/dates
+;; (never strings), so the predicate is exercised with `Instant` values.
 
 (deftest is-registration-open-true-when-within-window
   (let [state {:status       "registration"
-               :registration {:opens-at     "2020-01-01T00:00:00Z"
-                              :closes-at    "2030-01-01T00:00:00Z"
+               :registration {:opens-at     (Instant/parse "2020-01-01T00:00:00Z")
+                              :closes-at    (Instant/parse "2030-01-01T00:00:00Z")
                               :closed-early false}}
         now   (Instant/parse "2025-06-01T00:00:00Z")]
     (is (true? (handlers.tournament/is-registration-open? state now)))))
 
 (deftest is-registration-open-false-before-window
   (let [state {:status       "registration"
-               :registration {:opens-at     "2026-01-01T00:00:00Z"
-                              :closes-at    "2030-01-01T00:00:00Z"
+               :registration {:opens-at     (Instant/parse "2026-01-01T00:00:00Z")
+                              :closes-at    (Instant/parse "2030-01-01T00:00:00Z")
                               :closed-early false}}
         now   (Instant/parse "2025-06-01T00:00:00Z")]
     (is (false? (handlers.tournament/is-registration-open? state now)))))
 
 (deftest is-registration-open-false-after-window
   (let [state {:status       "registration"
-               :registration {:opens-at     "2020-01-01T00:00:00Z"
-                              :closes-at    "2025-01-01T00:00:00Z"
+               :registration {:opens-at     (Instant/parse "2020-01-01T00:00:00Z")
+                              :closes-at    (Instant/parse "2025-01-01T00:00:00Z")
                               :closed-early false}}
         now   (Instant/parse "2025-06-01T00:00:00Z")]
     (is (false? (handlers.tournament/is-registration-open? state now)))))
 
 (deftest is-registration-open-false-when-closed-early
   (let [state {:status       "registration"
-               :registration {:opens-at     "2020-01-01T00:00:00Z"
-                              :closes-at    "2030-01-01T00:00:00Z"
+               :registration {:opens-at     (Instant/parse "2020-01-01T00:00:00Z")
+                              :closes-at    (Instant/parse "2030-01-01T00:00:00Z")
                               :closed-early true}}
         now   (Instant/parse "2025-06-01T00:00:00Z")]
     (is (false? (handlers.tournament/is-registration-open? state now)))))
 
 (deftest is-registration-open-false-when-status-not-registration
   (let [state {:status       "active"
-               :registration {:opens-at     "2020-01-01T00:00:00Z"
-                              :closes-at    "2030-01-01T00:00:00Z"
+               :registration {:opens-at     (Instant/parse "2020-01-01T00:00:00Z")
+                              :closes-at    (Instant/parse "2030-01-01T00:00:00Z")
                               :closed-early false}}
         now   (Instant/parse "2025-06-01T00:00:00Z")]
     (is (false? (handlers.tournament/is-registration-open? state now)))))
@@ -118,17 +139,30 @@
 ;; ─── create-entry ────────────────────────────────────────────────────────────
 
 (deftest create-entry-returns-entry-when-open
-  (with-redefs [data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state "{\"status\":\"registration\",\"registration\":{\"opens-at\":\"2020-01-01T00:00:00Z\",\"closes-at\":\"2030-01-01T00:00:00Z\",\"closed-early\":false}}" :updated-at (Instant/now)})
-                data-access.contract/create-entry
+  (with-redefs [handlers.tournament/get-tournament-state
+                (fn [_ _] {:status       "registration"
+                           :registration {:opens-at nil :closes-at nil :closed-early false}})
+                data-access.contract/create-entry!
                 (fn [_ _ _] test-entry)]
     (let [result (handlers.tournament/create-entry test-deps test-tournament-eid "dev-admin")]
       (is (= :tournament/entry (:type result)))
       (is (= "dev-admin" (:player-sub result))))))
 
+(deftest create-entry-returns-error-when-duplicate
+  (with-redefs [handlers.tournament/get-tournament-state
+                (fn [_ _] {:status       "registration"
+                           :registration {:opens-at nil :closes-at nil :closed-early false}})
+                ;; create-entry! returns nil when the player already holds an entry
+                data-access.contract/create-entry!
+                (fn [_ _ _] nil)]
+    (let [result (handlers.tournament/create-entry test-deps test-tournament-eid "dev-admin")]
+      (is (= :tournament/entry-error (:type result)))
+      (is (= "Already entered in this tournament." (:message result))))))
+
 (deftest create-entry-returns-error-when-closed
-  (with-redefs [data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state "{\"status\":\"active\",\"registration\":{\"opens-at\":\"2020-01-01T00:00:00Z\",\"closes-at\":\"2025-01-01T00:00:00Z\",\"closed-early\":false}}" :updated-at (Instant/now)})]
+  (with-redefs [handlers.tournament/get-tournament-state
+                (fn [_ _] {:status       "active"
+                           :registration {:opens-at nil :closes-at nil :closed-early false}})]
     (let [result (handlers.tournament/create-entry test-deps test-tournament-eid "dev-admin")]
       (is (= :tournament/entry-error (:type result)))
       (is (= "Registration is not open." (:message result))))))
@@ -136,162 +170,161 @@
 ;; ─── delete-entry ────────────────────────────────────────────────────────────
 
 (deftest delete-entry-returns-success-during-registration
-  (with-redefs [data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state "{\"status\":\"registration\"}" :updated-at (Instant/now)})
-                data-access.contract/delete-entry         (fn [_ _ _] nil)]
+  (with-redefs [handlers.tournament/get-tournament-state (fn [_ _] {:status "registration"})
+                data-access.contract/delete-entry!       (fn [_ _ _] nil)]
     (let [result (handlers.tournament/delete-entry test-deps test-tournament-eid "dev-admin")]
       (is (= :tournament/entry-deleted (:type result))))))
 
 (deftest delete-entry-returns-error-when-not-registration-status
-  (with-redefs [data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state "{\"status\":\"active\"}" :updated-at (Instant/now)})]
+  (with-redefs [handlers.tournament/get-tournament-state (fn [_ _] {:status "active"})]
     (let [result (handlers.tournament/delete-entry test-deps test-tournament-eid "dev-admin")]
       (is (= :tournament/entry-error (:type result))))))
 
 ;; ─── get-entries ─────────────────────────────────────────────────────────────
 
 (deftest get-entries-assigns-type-to-each
-  (with-redefs [data-access.contract/get-entries-for-tournament
+  (with-redefs [data-access.contract/entries-for-tournament
                 (fn [_ _] [test-entry (assoc test-entry :player-sub "dev-player-one")])]
     (let [results (handlers.tournament/get-entries test-deps test-tournament-eid)]
       (is (every? #(= :tournament/entry (:type %)) results)))))
 
 (deftest get-entries-returns-all-results
-  (with-redefs [data-access.contract/get-entries-for-tournament
+  (with-redefs [data-access.contract/entries-for-tournament
                 (fn [_ _] [test-entry (assoc test-entry :player-sub "dev-player-one")])]
     (is (= 2 (count (handlers.tournament/get-entries test-deps test-tournament-eid))))))
 
 (deftest get-entries-empty-result
-  (with-redefs [data-access.contract/get-entries-for-tournament (fn [_ _] [])]
+  (with-redefs [data-access.contract/entries-for-tournament (fn [_ _] [])]
     (is (= [] (handlers.tournament/get-entries test-deps test-tournament-eid)))))
 
 ;; ─── State transition handlers ──────────────────────────────────────────────
+;;
+;; Lifecycle handlers read the reconstructed state, write a targeted field
+;; via `update-tournament!`, then re-read for the returned `:state`. The
+;; tests back `tournament-by-eid` + `update-tournament!` with an atom so the
+;; post-write re-read reflects the mutation; phases/entries/matches are
+;; stubbed as needed for the standings derivation.
 
-(def ^:private registration-state-json
-  "{\"status\":\"registration\",\"registration\":{\"opens-at\":\"2020-01-01T00:00:00Z\",\"closes-at\":\"2030-01-01T00:00:00Z\",\"closed-early\":false},\"standings\":[],\"phases\":[]}")
+(defn- active-with [tournament-atom & {:keys [phases entries matches]}]
+  {#'data-access.contract/tournament-by-eid      (fn [_ _] @tournament-atom)
+   #'data-access.contract/update-tournament!     (fn [_ _ attrs] (swap! tournament-atom merge attrs) @tournament-atom)
+   #'data-access.contract/phases-for-tournament  (fn [_ _] (or phases []))
+   #'data-access.contract/entries-for-tournament (fn [_ _] (or entries []))
+   #'data-access.contract/matches-for-tournament (fn [_ _] (or matches []))})
 
 ;; ─── start-tournament ────────────────────────────────────────────────────────
 
-(deftest start-tournament-populates-standings
-  (with-redefs [data-access.contract/get-tournament-by-eid   (fn [_ _] test-tournament)
-                data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state registration-state-json :updated-at (Instant/now)})
-                data-access.contract/get-entries-for-tournament
-                (fn [_ _] [{:player-sub "p1"} {:player-sub "p2"}])
-                data-access.contract/upsert-tournament-state (fn [_ _ _] nil)]
-    (let [result (handlers.tournament/start-tournament test-deps test-tournament-eid "dev-admin")]
-      (is (= :tournament/started (:type result)))
-      (is (= "active" (get-in result [:state :status])))
-      (is (= 2 (count (get-in result [:state :standings])))))))
+(deftest start-tournament-activates-and-points-at-first-phase
+  (let [t (atom (assoc test-tournament :status "registration"))]
+    (with-redefs-fn (active-with t
+                                 :phases [{:phase-type "swiss" :rounds [{:round-index 0 :format 1}]}]
+                                 :entries [{:player-sub "p1"} {:player-sub "p2"}])
+      (fn []
+        (let [result (handlers.tournament/start-tournament test-deps test-tournament-eid "dev-admin")]
+          (is (= :tournament/started (:type result)))
+          (is (= "active" (get-in result [:state :status])))
+          (is (= 0 (get-in result [:state :current-phase])))
+          (is (= 2 (count (get-in result [:state :standings])))))))))
 
 (deftest start-tournament-rejects-non-organizer
-  (with-redefs [data-access.contract/get-tournament-by-eid (fn [_ _] test-tournament)]
+  (with-redefs [data-access.contract/tournament-by-eid (fn [_ _] test-tournament)]
     (let [result (handlers.tournament/start-tournament test-deps test-tournament-eid "not-the-organizer")]
       (is (= :tournament/start-error (:type result)))
       (is (re-find #"organizer" (:message result))))))
 
 (deftest start-tournament-rejects-wrong-status
-  (with-redefs [data-access.contract/get-tournament-by-eid (fn [_ _] test-tournament)
-                data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state "{\"status\":\"active\"}" :updated-at (Instant/now)})]
-    (let [result (handlers.tournament/start-tournament test-deps test-tournament-eid "dev-admin")]
-      (is (= :tournament/start-error (:type result))))))
+  (let [t (atom (assoc test-tournament :status "active"))]
+    (with-redefs-fn (active-with t)
+      (fn []
+        (let [result (handlers.tournament/start-tournament test-deps test-tournament-eid "dev-admin")]
+          (is (= :tournament/start-error (:type result))))))))
 
 (deftest start-tournament-not-found
-  (with-redefs [data-access.contract/get-tournament-by-eid (fn [_ _] nil)]
+  (with-redefs [data-access.contract/tournament-by-eid (fn [_ _] nil)]
     (let [result (handlers.tournament/start-tournament test-deps test-tournament-eid "dev-admin")]
       (is (= :tournament/start-error (:type result))))))
 
 ;; ─── complete-tournament ─────────────────────────────────────────────────────
 
 (deftest complete-tournament-moves-active-to-complete
-  (with-redefs [data-access.contract/get-tournament-by-eid   (fn [_ _] test-tournament)
-                data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state "{\"status\":\"active\"}" :updated-at (Instant/now)})
-                data-access.contract/upsert-tournament-state (fn [_ _ _] nil)]
-    (let [result (handlers.tournament/complete-tournament test-deps test-tournament-eid "dev-admin")]
-      (is (= :tournament/completed (:type result)))
-      (is (= "complete" (get-in result [:state :status]))))))
+  (let [t (atom (assoc test-tournament :status "active"))]
+    (with-redefs-fn (active-with t)
+      (fn []
+        (let [result (handlers.tournament/complete-tournament test-deps test-tournament-eid "dev-admin")]
+          (is (= :tournament/completed (:type result)))
+          (is (= "complete" (get-in result [:state :status]))))))))
 
 (deftest complete-tournament-rejects-non-active
-  (with-redefs [data-access.contract/get-tournament-by-eid (fn [_ _] test-tournament)
-                data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state registration-state-json :updated-at (Instant/now)})]
-    (let [result (handlers.tournament/complete-tournament test-deps test-tournament-eid "dev-admin")]
-      (is (= :tournament/complete-error (:type result))))))
+  (let [t (atom (assoc test-tournament :status "registration"))]
+    (with-redefs-fn (active-with t)
+      (fn []
+        (let [result (handlers.tournament/complete-tournament test-deps test-tournament-eid "dev-admin")]
+          (is (= :tournament/complete-error (:type result))))))))
 
 ;; ─── cancel-tournament ───────────────────────────────────────────────────────
 
 (deftest cancel-tournament-from-registration
-  (with-redefs [data-access.contract/get-tournament-by-eid   (fn [_ _] test-tournament)
-                data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state registration-state-json :updated-at (Instant/now)})
-                data-access.contract/upsert-tournament-state (fn [_ _ _] nil)]
-    (let [result (handlers.tournament/cancel-tournament test-deps test-tournament-eid "dev-admin")]
-      (is (= :tournament/cancelled (:type result)))
-      (is (= "cancelled" (get-in result [:state :status]))))))
+  (let [t (atom (assoc test-tournament :status "registration"))]
+    (with-redefs-fn (active-with t)
+      (fn []
+        (let [result (handlers.tournament/cancel-tournament test-deps test-tournament-eid "dev-admin")]
+          (is (= :tournament/cancelled (:type result)))
+          (is (= "cancelled" (get-in result [:state :status]))))))))
 
 (deftest cancel-tournament-from-active
-  (with-redefs [data-access.contract/get-tournament-by-eid   (fn [_ _] test-tournament)
-                data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state "{\"status\":\"active\"}" :updated-at (Instant/now)})
-                data-access.contract/upsert-tournament-state (fn [_ _ _] nil)]
-    (let [result (handlers.tournament/cancel-tournament test-deps test-tournament-eid "dev-admin")]
-      (is (= :tournament/cancelled (:type result))))))
+  (let [t (atom (assoc test-tournament :status "active"))]
+    (with-redefs-fn (active-with t)
+      (fn []
+        (let [result (handlers.tournament/cancel-tournament test-deps test-tournament-eid "dev-admin")]
+          (is (= :tournament/cancelled (:type result))))))))
 
 (deftest cancel-tournament-rejects-already-finished
-  (with-redefs [data-access.contract/get-tournament-by-eid (fn [_ _] test-tournament)
-                data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state "{\"status\":\"complete\"}" :updated-at (Instant/now)})]
-    (let [result (handlers.tournament/cancel-tournament test-deps test-tournament-eid "dev-admin")]
-      (is (= :tournament/cancel-error (:type result))))))
+  (let [t (atom (assoc test-tournament :status "complete"))]
+    (with-redefs-fn (active-with t)
+      (fn []
+        (let [result (handlers.tournament/cancel-tournament test-deps test-tournament-eid "dev-admin")]
+          (is (= :tournament/cancel-error (:type result))))))))
 
 ;; ─── close-registration-early ────────────────────────────────────────────────
 
 (deftest close-registration-early-sets-flag
-  (with-redefs [data-access.contract/get-tournament-by-eid   (fn [_ _] test-tournament)
-                data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state registration-state-json :updated-at (Instant/now)})
-                data-access.contract/upsert-tournament-state (fn [_ _ _] nil)]
-    (let [result (handlers.tournament/close-registration-early test-deps test-tournament-eid "dev-admin")]
-      (is (= :tournament/registration-closed (:type result)))
-      (is (true? (get-in result [:state :registration :closed-early]))))))
+  (let [t (atom (assoc test-tournament :status "registration"))]
+    (with-redefs-fn (active-with t)
+      (fn []
+        (let [result (handlers.tournament/close-registration-early test-deps test-tournament-eid "dev-admin")]
+          (is (= :tournament/registration-closed (:type result)))
+          (is (true? (get-in result [:state :registration :closed-early]))))))))
 
 (deftest close-registration-early-rejects-non-organizer
-  (with-redefs [data-access.contract/get-tournament-by-eid (fn [_ _] test-tournament)]
+  (with-redefs [data-access.contract/tournament-by-eid (fn [_ _] test-tournament)]
     (let [result (handlers.tournament/close-registration-early test-deps test-tournament-eid "not-the-organizer")]
       (is (= :tournament/registration-close-error (:type result))))))
 
 (deftest close-registration-early-rejects-wrong-status
-  (with-redefs [data-access.contract/get-tournament-by-eid (fn [_ _] test-tournament)
-                data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state "{\"status\":\"active\"}" :updated-at (Instant/now)})]
-    (let [result (handlers.tournament/close-registration-early test-deps test-tournament-eid "dev-admin")]
-      (is (= :tournament/registration-close-error (:type result))))))
+  (let [t (atom (assoc test-tournament :status "active"))]
+    (with-redefs-fn (active-with t)
+      (fn []
+        (let [result (handlers.tournament/close-registration-early test-deps test-tournament-eid "dev-admin")]
+          (is (= :tournament/registration-close-error (:type result))))))))
 
 ;; ─── create-match ────────────────────────────────────────────────────────────
 
-(def ^:private active-state-json
-  "{\"status\":\"active\",\"standings\":[{\"player-sub\":\"p1\",\"wins\":0,\"losses\":0,\"draws\":0,\"points\":0},{\"player-sub\":\"p2\",\"wins\":0,\"losses\":0,\"draws\":0,\"points\":0}],\"phases\":[]}")
-
 (def ^:private test-match
-  {:id          1   :eid         (UUID/randomUUID) :tournament-eid test-tournament-eid
-   :phase-index 0   :round-index 0                 :player-one-sub "p1"                :player-two-sub "p2"
-   :winner-sub  nil :status      "pending"         :created-at     (Instant/now)       :updated-at     (Instant/now)})
+  {:eid         (UUID/randomUUID) :tournament-eid test-tournament-eid
+   :phase-index 0                 :round-index    0                   :player-one-sub "p1"      :player-two-sub "p2"
+   :winner-sub  nil               :status         "pending"           :bracket-type   "winners" :format         1
+   :created-at  (Instant/now)     :updated-at     (Instant/now)})
 
 (deftest create-match-returns-match-when-active
-  (with-redefs [data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state active-state-json :updated-at (Instant/now)})
-                data-access.contract/create-match
-                (fn [_ _ _] test-match)]
+  (with-redefs [handlers.tournament/get-tournament-state (fn [_ _] {:status "active"})
+                data-access.contract/create-match!       (fn [_ _ _] test-match)]
     (let [result (handlers.tournament/create-match test-deps test-tournament-eid
                                                    {:phase-index 0 :round-index 0 :player-one-sub "p1" :player-two-sub "p2"})]
       (is (= :tournament/match (:type result)))
       (is (= "p1" (:player-one-sub result))))))
 
 (deftest create-match-rejects-when-not-active
-  (with-redefs [data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state registration-state-json :updated-at (Instant/now)})]
+  (with-redefs [handlers.tournament/get-tournament-state (fn [_ _] {:status "registration"})]
     (let [result (handlers.tournament/create-match test-deps test-tournament-eid
                                                    {:phase-index 0 :round-index 0 :player-one-sub "p1" :player-two-sub "p2"})]
       (is (= :tournament/match-error (:type result))))))
@@ -299,18 +332,18 @@
 ;; ─── get-match-by-eid ────────────────────────────────────────────────────────
 
 (deftest get-match-by-eid-assigns-type
-  (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] test-match)]
+  (with-redefs [data-access.contract/match-by-eid (fn [_ _] test-match)]
     (let [result (handlers.tournament/get-match-by-eid test-deps (:eid test-match))]
       (is (= :tournament/match (:type result))))))
 
 (deftest get-match-by-eid-returns-nil-when-not-found
-  (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] nil)]
+  (with-redefs [data-access.contract/match-by-eid (fn [_ _] nil)]
     (is (nil? (handlers.tournament/get-match-by-eid test-deps (UUID/randomUUID))))))
 
 ;; ─── get-matches-for-tournament ──────────────────────────────────────────────
 
 (deftest get-matches-for-tournament-assigns-type
-  (with-redefs [data-access.contract/get-matches-for-tournament
+  (with-redefs [data-access.contract/matches-for-tournament
                 (fn [_ _] [test-match (assoc test-match :player-one-sub "p3")])]
     (let [results (handlers.tournament/get-matches-for-tournament test-deps test-tournament-eid)]
       (is (every? #(= :tournament/match (:type %)) results))
@@ -319,25 +352,25 @@
 ;; ─── update-match-result ─────────────────────────────────────────────────────
 
 (deftest update-match-result-updates-standings
-  (with-redefs [data-access.contract/get-match-by-eid        (fn [_ _] test-match)
-                data-access.contract/update-match-result     (fn [_ _ _] nil)
-                data-access.contract/get-matches-for-tournament
-                (fn [_ _] [(assoc test-match :status "complete" :winner-sub "p1")])
-                data-access.contract/get-tournament-state
-                (fn [_ _] {:id 1 :state active-state-json :updated-at (Instant/now)})
-                data-access.contract/upsert-tournament-state (fn [_ _ _] nil)]
+  (with-redefs [data-access.contract/match-by-eid           (fn [_ _] test-match)
+                data-access.contract/update-match-result!   (fn [_ _ _] nil)
+                data-access.contract/tournament-by-eid      (fn [_ _] (assoc test-tournament :status "active"))
+                data-access.contract/phases-for-tournament  (fn [_ _] [])
+                data-access.contract/entries-for-tournament (fn [_ _] [{:player-sub "p1"} {:player-sub "p2"}])
+                data-access.contract/matches-for-tournament
+                (fn [_ _] [(assoc test-match :status "complete" :winner-sub "p1")])]
     (let [result (handlers.tournament/update-match-result test-deps (:eid test-match) "p1")]
       (is (= :tournament/match-result-recorded (:type result)))
       (is (= 2 (count (:standings result))))
       (is (= 3 (:points (first (filter #(= "p1" (:player-sub %)) (:standings result)))))))))
 
 (deftest update-match-result-rejects-non-pending
-  (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] (assoc test-match :status "complete"))]
+  (with-redefs [data-access.contract/match-by-eid (fn [_ _] (assoc test-match :status "complete"))]
     (let [result (handlers.tournament/update-match-result test-deps (:eid test-match) "p1")]
       (is (= :tournament/match-error (:type result))))))
 
 (deftest update-match-result-not-found
-  (with-redefs [data-access.contract/get-match-by-eid (fn [_ _] nil)]
+  (with-redefs [data-access.contract/match-by-eid (fn [_ _] nil)]
     (let [result (handlers.tournament/update-match-result test-deps (UUID/randomUUID) "p1")]
       (is (= :tournament/match-error (:type result))))))
 
@@ -350,24 +383,22 @@
   (let [captured (atom nil)]
     (with-redefs [data-access.contract/season-by-eid
                   (fn [_ _] {:eid test-season-eid :league-eid test-league-eid})
-                  data-access.contract/create-tournament
+                  data-access.contract/create-tournament!
                   (fn [_ spec]
                     (reset! captured spec)
                     (assoc test-tournament :eid (:eid spec)
                            :league-eid test-league-eid
-                           :season-eid test-season-eid))
-                  data-access.contract/upsert-tournament-state (fn [_ _ _] nil)
-                  data-access.contract/get-tournament-by-eid   (fn [_ _] test-tournament)]
+                           :season-eid test-season-eid))]
       (handlers.tournament/create-tournament
        test-deps
        {:eid                    (UUID/randomUUID)
         :game-eid               test-game-eid
         :season-eid             test-season-eid
-        :name                   "Spring Cup"                                          :description "x"
-        :timezone               (java.time.ZoneId/of "UTC")
-        :registration-opens-at  (java.time.LocalDateTime/parse "2026-04-01T00:00:00")
-        :registration-closes-at (java.time.LocalDateTime/parse "2030-04-30T23:59:00")
-        :created-by-sub         "dev-admin"                                           :version     1})
+        :name                   "Spring Cup"                                :description "x"
+        :timezone               (ZoneId/of "UTC")
+        :registration-opens-at  (LocalDateTime/parse "2026-04-01T00:00:00")
+        :registration-closes-at (LocalDateTime/parse "2030-04-30T23:59:00")
+        :created-by-sub         "dev-admin"                                 :version     1})
       (is (= test-league-eid (:league-eid @captured))
           "league-eid should be derived server-side from the season"))))
 
@@ -381,9 +412,9 @@
                    :league-eid             (UUID/fromString "33333333-3333-3333-3333-333333333333")
                    :season-eid             test-season-eid
                    :name                   "x"                                                      :description "x"
-                   :timezone               (java.time.ZoneId/of "UTC")
-                   :registration-opens-at  (java.time.LocalDateTime/parse "2026-04-01T00:00:00")
-                   :registration-closes-at (java.time.LocalDateTime/parse "2030-04-30T23:59:00")
+                   :timezone               (ZoneId/of "UTC")
+                   :registration-opens-at  (LocalDateTime/parse "2026-04-01T00:00:00")
+                   :registration-closes-at (LocalDateTime/parse "2030-04-30T23:59:00")
                    :created-by-sub         "dev-admin"                                              :version     1})]
       (is (= :tournament/create-error (:type result))))))
 
@@ -393,7 +424,7 @@
 ;; handler just preserves whatever the data layer hands it.
 
 (deftest get-tournament-passes-non-nil-league-season-eids-through
-  (with-redefs [data-access.contract/get-tournament-by-eid
+  (with-redefs [data-access.contract/tournament-by-eid
                 (fn [_ _] (assoc test-tournament :league-eid test-league-eid :season-eid test-season-eid))]
     (let [result (handlers.tournament/get-tournament-by-eid test-deps test-tournament-eid)]
       (is (= test-league-eid (:league-eid result)))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
@@ -959,7 +959,7 @@
    `viewer-sub` is one of its participants. Returns `[:ok match]` or
    `[:error fragment]` so the calling handler stays branch-flat."
   [dependencies match-eid tournament-eid viewer-sub]
-  (let [match (db/get-match-by-eid (:connection dependencies) match-eid)]
+  (let [match (db/match-by-eid (:datalog-connection dependencies) match-eid)]
     (cond
       (nil? match)
       [:error (error-fragment "Match not found.")]
@@ -1068,7 +1068,7 @@
           (case (:type result)
             :match-record/game-recorded
             (let [tournament  (domain/get-tournament-by-eid dependencies tournament-eid)
-                  fresh-match (-> (db/get-match-by-eid (:connection dependencies) match-eid)
+                  fresh-match (-> (db/match-by-eid (:datalog-connection dependencies) match-eid)
                                   (assoc :game-eid (:game-eid tournament)))]
               {:status  200
                :headers {"Content-Type"            "text/html; charset=utf-8"


### PR DESCRIPTION
Second step of the tournament migration (rts-5b6), **stacked on #122** (the schema). Cuts the tournament domain over from SQLite + the `tournament_state` JSON blob to the Datalevin entities #122 defines — end to end. Base this on #122; once #122 merges, GitHub retargets this to `main`.

## What changed

- **`query/datalog/tournament.clj`** (new) — the datalog read/write layer for tournaments, phases/rounds, entries, matches, and games. Returns the same unqualified-key shapes the SQLite layer did (string enums, `*-eid` refs, `Date` instants), so the pure rules engine consumes it unchanged.
- **`handlers/tournament.clj`** — `get-tournament-state` now **reconstructs** the state view-model from entities; standings are **derived** (`rules/recalculate-standings`), not stored. Every former `set-tournament-state` write became a targeted entity write (`update-tournament!`, `set-phases!`, `update-match-result!`, …).
- **`rules/tournament.clj`** — unchanged (rts-pij): it operates on the reconstructed state + match maps, so bracket generation/advancement "reads from the db" by virtue of the reconstruction.
- **`handlers/replay.clj` + `web/tournament/view.clj`** — the match_game + match reads on the replay-submission path move to the datalog connection, restoring the replay/draft refs that went NULL when those domains migrated ahead of tournament.
- **`contract.clj` (data-access + domain)** — datalog re-exports added; the dead `set-tournament-state` re-export dropped. The SQLite tournament re-exports stay **dormant** until rts-1it deletes them with the SQL.
- **`rts-demo`** — ported to open a Datalevin connection, seed the datalog catalogue, and drive the demo tournaments through the new domain API.

## Notes

- **No one-shot migration script** (rts-9kp's `migrate_tournament.clj`): the project isn't deployed, so a fresh empty store is the target. rts-9kp's intent reduces to the entity-decomposition write path, which is implemented here.
- SQLite tournament/match/match_game/tournament_state tables and the `query/tournament.clj` layer are left in place (dormant) for **rts-1it** to delete.

## Verification

- **102** rts-domain unit tests green (rewired tournament + replay handler tests, unchanged rules tests).
- Full **58-test Playwright e2e suite** green against a live datalog-backed server: tournament lifecycle, bracket generation across single/double-elim/Swiss, replay submission, plus draft/league/season/game browsing with **no regressions**.
- REPL round-trip of the full data-access layer (create → phases → entries → matches → games → reads).
- `cljfmt` + `clj-kondo` (dependency-cached, CI-equivalent) clean; `poly check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)