### PR TITLE
Colocate tournament view reads + kill detail/phase N+1 (rts-8g0, rts-j5m)

### DIFF
--- a/components/e2e/tests/tournament-walkthrough.spec.js
+++ b/components/e2e/tests/tournament-walkthrough.spec.js
@@ -1,0 +1,67 @@
+// Touches components/e2e so poly test re-runs the brick on PRs that only
+// modify upstream handlers/queries (rts-9w4 workaround).
+//
+// End-to-end organizer walkthrough exercising the colocated/datalog view
+// reads (rts-8g0/j5m): create → configure phase → register → start →
+// generate round → record a result → confirm the detail page renders the
+// bracket (per-match game counts via the nested matches+games pull) and
+// the recomputed standings.
+
+const { test, expect } = require('@playwright/test');
+
+const BASE = process.env.RTS_API_BASE_URL || 'http://127.0.0.1:3001';
+const GAME_EID = 'eea787d7-1065-45eb-a3f6-e26f32c294a1';
+
+function actionHeaders(user) {
+  return { Accept: 'application/htmx+html', 'Content-Type': 'application/json',
+           Cookie: `dev_impersonation=${user}` };
+}
+function htmlHeaders(user) { return { Accept: 'text/html', Cookie: `dev_impersonation=${user}` }; }
+
+async function setupFinalMatch(request) {
+  const eid = crypto.randomUUID();
+  expect((await request.put(`${BASE}/actions/tournament/${eid}?version=1`, {
+    headers: actionHeaders('dev-admin'),
+    data: { 'game-eid': GAME_EID, name: 'Walkthrough Cup', description: 'd', timezone: 'UTC',
+            'registration-opens-at': '2020-01-01T00:00', 'registration-closes-at': '2030-01-01T00:00' },
+  })).status()).toBe(200);
+  expect((await request.put(`${BASE}/api/tournament-phase-configuration?tournament-eid=${eid}`, {
+    headers: { ...htmlHeaders('dev-admin'), 'Content-Type': 'application/json' },
+    data: { phases: [{ 'phase-type': 'single-elimination', rounds: [{ 'round-index': 0, format: 1 }] }],
+            'qualifier-count': 2 },
+  })).status()).toBe(200);
+  await request.post(`${BASE}/actions/tournament/${eid}/entry/me`, { headers: actionHeaders('dev-player-one') });
+  await request.post(`${BASE}/actions/tournament/${eid}/entry/me`, { headers: actionHeaders('dev-player-two') });
+  await request.post(`${BASE}/actions/tournament/${eid}/start`, { headers: actionHeaders('dev-admin') });
+  await request.post(`${BASE}/actions/tournament/${eid}/round`, { headers: actionHeaders('dev-admin') });
+  const html = await (await request.get(`${BASE}/api/match?tournament-eid=${eid}`,
+                                        { headers: htmlHeaders('dev-admin') })).text();
+  const m = html.match(/\/match\/([0-9a-f-]{36})/);
+  expect(m, 'a generated match should exist').not.toBeNull();
+  return { eid, matchEid: m[1] };
+}
+
+test.describe('Tournament walkthrough (colocated views)', () => {
+  test('record a result → detail page shows the bracket and recomputed standings', async ({ page, request }) => {
+    const { eid, matchEid } = await setupFinalMatch(request);
+
+    // Record the (bo1) result for the final.
+    const res = await request.put(`${BASE}/actions/tournament/${eid}/match/${matchEid}/result`, {
+      headers: actionHeaders('dev-admin'),
+      data: { 'winner-sub': 'dev-player-one' },
+    });
+    expect(res.status()).toBe(200);
+
+    // The refactored detail view (nested matches+games pull) renders the bracket + standings.
+    await page.context().addCookies([{ name: 'dev_impersonation', value: 'dev-admin',
+                                       domain: '127.0.0.1', path: '/', sameSite: 'Lax' }]);
+    await page.goto(`${BASE}/view/game/${GAME_EID}/tournament/${eid}/index.html`);
+    await expect(page).toHaveTitle(/Walkthrough Cup/);
+    await expect(page.locator('h3', { hasText: 'Bracket' })).toBeVisible();
+    // Standings recompute from the completed match: winner 1-0, loser 0-1.
+    await expect(page.locator('table.standings-table tbody tr', { hasText: 'dev-player-one' }))
+      .toContainText('1-0');
+    await expect(page.locator('table.standings-table tbody tr', { hasText: 'dev-player-two' }))
+      .toContainText('0-1');
+  });
+});

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
@@ -125,6 +125,7 @@
 (def delete-entry!                   query.datalog.tournament/delete-entry!)
 (def match-by-eid                    query.datalog.tournament/match-by-eid)
 (def matches-for-tournament          query.datalog.tournament/matches-for-tournament)
+(def matches-with-games-for-tournament query.datalog.tournament/matches-with-games-for-tournament)
 (def matches                         query.datalog.tournament/matches)
 (def matches-for-round               query.datalog.tournament/matches-for-round)
 (def create-match!                   query.datalog.tournament/create-match!)

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/tournament.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/tournament.clj
@@ -231,6 +231,49 @@
          (sort-by (juxt :phase-index :round-index :eid))
          vec)))
 
+(def ^:private nested-game-pattern
+  [:match-game/eid :match-game/game-index :match-game/winner-sub
+   :match-game/uploader-local-alliance-index :match-game/created-at
+   {:match-game/replay [:replay/eid]}
+   {:match-game/player-one-draft [:draft/eid]}
+   {:match-game/player-two-draft [:draft/eid]}])
+
+(def ^:private match+games-pattern
+  (conj match-pattern {:match/games nested-game-pattern}))
+
+(defn- ->nested-game
+  [match-eid g]
+  {:eid                           (:match-game/eid g)
+   :match-eid                     match-eid
+   :game-index                    (:match-game/game-index g)
+   :winner-sub                    (:match-game/winner-sub g)
+   :uploader-local-alliance-index (:match-game/uploader-local-alliance-index g)
+   :replay-eid                    (some-> g :match-game/replay :replay/eid)
+   :player-one-draft-eid          (some-> g :match-game/player-one-draft :draft/eid)
+   :player-two-draft-eid          (some-> g :match-game/player-two-draft :draft/eid)})
+
+(defn matches-with-games-for-tournament
+  "All matches in a tournament, each carrying its games inline as `:games`
+   (full game maps, sorted by game-index). One query — no per-match N+1.
+   Ordered by (phase-index, round-index)."
+  [conn eid]
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?m pattern) ...]
+                 :in $ pattern ?tour-eid
+                 :where
+                 [?m :match/tournament ?t]
+                 [?t :tournament/eid ?tour-eid]]
+               db match+games-pattern eid)
+         (mapv (fn [m]
+                 (let [match (->match m)]
+                   (assoc match
+                          :games (->> (:match/games m)
+                                      (mapv #(->nested-game (:eid match) %))
+                                      (sort-by :game-index)
+                                      vec)))))
+         (sort-by (juxt :phase-index :round-index :eid))
+         vec)))
+
 (defn matches
   "Every match in the system."
   [conn]

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/share.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/share.clj
@@ -6,6 +6,7 @@
   onto a response (status + body shape, template render) belongs in the
   caller."
   (:require
+   [com.devereux-henley.rts-data-access.contract :as db]
    [com.devereux-henley.rts-domain.contract :as domain]))
 
 (defn get-tournament-by-eid
@@ -43,16 +44,12 @@
   [dependencies tournament-eid phase-index]
   (let [state           (domain/get-tournament-state dependencies tournament-eid)
         phases          (:phases state)
-        raw-matches     (domain/get-matches-for-tournament dependencies tournament-eid)
+        raw-matches     (db/matches-with-games-for-tournament
+                         (:datalog-connection dependencies) tournament-eid)
         qualifier-count (or (:qualifier-count state) (count (:standings state)))
         grouped         (domain/group-matches-by-phase raw-matches phases qualifier-count)
         phase-group-raw (first (filter #(= phase-index (:phase %)) grouped))
-        real-matches    (filter :eid raw-matches)
-        lineups         (into {}
-                              (map (fn [m]
-                                     [(:eid m)
-                                      (domain/get-games-for-match dependencies (:eid m))]))
-                              real-matches)]
+        lineups         (into {} (map (juxt :eid :games)) (filter :eid raw-matches))]
     (when phase-group-raw
       {:tournament-state state
        :phase-group      (attach-lineups-to-matches phase-group-raw lineups)

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
@@ -44,13 +44,12 @@
                                                (map (juxt :eid identity)
                                                     (domain/get-seasons-for-league dependencies leid)))
                                              referenced-leagues))
+          ;; tournaments already carry :status from the entity; only the
+          ;; entry count needs a per-tournament read.
           enriched-tournaments (mapv (fn [t]
-                                       (let [state   (domain/get-tournament-state dependencies (:eid t))
-                                             entries (domain/get-entries dependencies (:eid t))]
-                                         (->> (assoc t
-                                                     :status      (:status state)
-                                                     :entry-count (count entries))
-                                              (enrich-tournament-with-league eid->league eid->season))))
+                                       (->> (assoc t :entry-count
+                                                   (count (domain/get-entries dependencies (:eid t))))
+                                            (enrich-tournament-with-league eid->league eid->season)))
                                      tournaments)
           enriched-leagues     (mapv (fn [l]
                                        (let [current-season (domain/get-current-season-for-league dependencies (:eid l))
@@ -147,10 +146,10 @@
 
 (defn- with-game-counts
   "Adds :p1-games-won and :p2-games-won to a match by counting :winner-sub
-   in the match's games. Bracket cells display these instead of W/L."
-  [dependencies match]
-  (let [games (domain/get-games-for-match dependencies (:eid match))
-        wins  (frequencies (keep :winner-sub games))]
+   in the match's inline `:games` (fetched via one nested pull, no N+1).
+   Bracket cells display these instead of W/L."
+  [match]
+  (let [wins (frequencies (keep :winner-sub (:games match)))]
     (assoc match
            :p1-games-won (get wins (:player-one-sub match) 0)
            :p2-games-won (get wins (:player-two-sub match) 0))))
@@ -359,8 +358,9 @@
              (let [tournament-eid       (:eid data)
                    state                (domain/get-tournament-state dependencies tournament-eid)
                    entries              (domain/get-entries dependencies tournament-eid)
-                   raw-matches          (mapv (partial with-game-counts dependencies)
-                                              (domain/get-matches-for-tournament dependencies tournament-eid))
+                   raw-matches          (mapv with-game-counts
+                                              (db/matches-with-games-for-tournament
+                                               (:datalog-connection dependencies) tournament-eid))
                    phases               (:phases state)
                    qualifier-count      (or (:qualifier-count state) (count (:standings state)))
                    user-sub             (get-in request [:ory-session :identity :id])


### PR DESCRIPTION
Refactors the tournament **HTML views** toward colocated datalog reads and removes the per-match game-count N+1.

## Changes
- **`query/datalog/tournament.clj`** — `matches-with-games-for-tournament`: one nested pull (each match + its games) replacing a `get-games-for-match` query per match.
- **`view.clj` detail view** — fetches via the nested pull; `with-game-counts` is now a pure fn over the inline `:games` (the N+1 `with-game-counts` is gone, per rts-8g0).
- **`share.clj` `build-phase-context`** — same nested pull; drops its own per-match games N+1.
- **`view.clj` competitive list** — reads `:status` straight off the tournament entity, dropping the redundant per-tournament `get-tournament-state` call.
- **`tournament-walkthrough.spec.js`** (new) — create → configure phase → register → start → generate round → record result → assert the detail page renders the bracket + recomputed standings (also re-fires the e2e brick in CI, rts-9w4).

## Scope notes
- The **`/api` resource handlers stay on the domain layer**: they emit `:type`-tagged HAL resources through the model-transformer and have no N+1, so swapping in raw `db/*` reads would break coercion for no benefit.
- **Player check-in/series** remain static-demo scaffolding (real player-console wiring is feature work, not a read refactor); the replay fragments already read via `db/*`.

## Verification
- Full **59-test Playwright suite green** against a live datalog-backed server (tournament detail/bracket, phase panel, competitive list, draft, game-browsing, replay).
- `cljfmt` / `clj-kondo` / `poly check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)