### PR TITLE
unit-view: single data-access fetch + domain shaping (workshop instance)

### DIFF
--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
@@ -70,6 +70,7 @@
 (def units-for-game       query.datalog.game/units-for-game)
 (def units-for-faction    query.datalog.game/units-for-faction)
 (def unit-by-eid          query.datalog.game/unit-by-eid)
+(def unit-detail          query.datalog.game/unit-detail)
 (def units-by-keys        query.datalog.game/units-by-keys)
 (def subfactions-by-keys  query.datalog.game/subfactions-by-keys)
 (def game-modes-for-game  query.datalog.game/game-modes-for-game)

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/game.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/game.clj
@@ -433,6 +433,37 @@
                         (dl/db conn) ability-pattern (vec ability-keys))]
       (into {} (map (fn [m] [(:ability/key m) (->ability m)])) results))))
 
+(defn unit-detail
+  "Single cohesive fetch for the unit detail view: the unit (with its
+  decoded `:unit-statistics` doc) plus everything keyed off it — resolved
+  abilities, draftable spells, mounts, and items. Returns nil when the
+  unit doesn't exist.
+
+  Ability and spell keys are read straight off the stats doc. Spells
+  resolve by lore (`spells-for-lore`) when the unit has a `:lore`, else
+  by the doc's `draftable-spells` keys. Resolved abilities/spells are
+  ordered to match the unit's key order; an unresolved key surfaces as a
+  bare `{:key k}` so the caller can fall back on it. All shaping for the
+  template (stat parsing, name fallbacks, not-empty) stays with the
+  caller — this returns raw resolved data."
+  [conn eid]
+  (when-let [unit (unit-by-eid conn eid)]
+    (let [stats        (:unit-statistics unit)
+          ability-keys (vec (get stats "abilities"))
+          spell-keys   (mapv #(get % "key") (get stats "draftable-spells"))
+          lore-key     (:lore unit)
+          key->ability (abilities-by-keys conn ability-keys)
+          abilities    (mapv (fn [k] (or (get key->ability k) {:key k})) ability-keys)
+          spells       (if lore-key
+                         (spells-for-lore conn lore-key)
+                         (let [key->spell (spells-by-keys conn spell-keys)]
+                           (mapv (fn [k] (or (get key->spell k) {:key k})) spell-keys)))]
+      (assoc unit
+             :abilities abilities
+             :draftable-spells spells
+             :mounts (mounts-for-unit conn eid)
+             :items  (items-for-unit conn eid)))))
+
 (defn unit-level-costs
   "All veteran-rank cost rows as a sorted `{level -> row}` map."
   [conn]

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
@@ -57,6 +57,7 @@
 (def get-socials-for-game                       handlers.game/get-socials-for-game)
 (def get-units-for-game                         handlers.game/get-units-for-game)
 (def get-unit-by-eid                            handlers.game/get-unit-by-eid)
+(def unit-view-model                            handlers.game/unit-view-model)
 (def get-units-for-faction                      handlers.game/get-units-for-faction)
 (def get-units                                  handlers.game/get-units)
 (def get-game-mode-by-eid                       handlers.game/get-game-mode-by-eid)

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/game.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/game.clj
@@ -1,6 +1,7 @@
 (ns com.devereux-henley.rts-domain.handlers.game
   (:require
-   [com.devereux-henley.rts-data-access.contract :as db]))
+   [com.devereux-henley.rts-data-access.contract :as db]
+   [com.devereux-henley.rts-domain.handlers.draft :as handlers.draft]))
 
 (defn get-game-by-eid
   [dependencies eid]
@@ -60,3 +61,29 @@
   [dependencies game-eid]
   (mapv (fn [mode] (assoc mode :type :game/game-mode))
         (db/game-modes-for-game (:datalog-connection dependencies) game-eid)))
+
+(defn- ->ability-row
+  [a]
+  {:eid (:eid a) :name (:name a) :description (:description a)})
+
+(defn- ->spell-row
+  [s]
+  {:eid (:eid s) :name (or (:name s) (:key s)) :mana-cost (:mana-cost s) :cost (:cost s)})
+
+(defn unit-view-model
+  "Builds the unit detail view-model from a single `db/unit-detail` fetch:
+   the unit fields, the parsed statline, and resolved abilities, draftable
+   spells, mounts, and items projected to their template shapes. Returns a
+   `:missing/resource` marker when the unit doesn't exist so the web layer
+   renders a 404."
+  [dependencies eid]
+  (if-let [unit (db/unit-detail (:datalog-connection dependencies) eid)]
+    (let [{:keys [stats]} (handlers.draft/parse-unit-statistics (:unit-statistics unit))]
+      (assoc unit
+             :type             :game/unit
+             :unit-statistics  stats
+             :abilities        (not-empty (mapv ->ability-row (:abilities unit)))
+             :draftable-spells (not-empty (mapv ->spell-row (:draftable-spells unit)))
+             :mounts           (not-empty (:mounts unit))
+             :items            (not-empty (:items unit))))
+    {:type :missing/resource :name "unit" :id eid}))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/game/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/game/view.clj
@@ -41,57 +41,17 @@
            "faction.html"
            (fn [_data _request] {})))
 
-(defn- resolve-spells
-  "Spell resolution for unit detail: lore-based wizards pull from the
-  `spell-lore` table; fixed-list casters resolve `draftable-spells` keys
-  against the spell table."
-  [conn lore-key draftable-spells]
-  (if lore-key
-    (mapv (fn [{:keys [eid key name mana-cost cost]}]
-            {:eid eid :key key :name name :mana-cost mana-cost :cost cost})
-          (db/spells-for-lore conn lore-key))
-    (let [key->spell (db/spells-by-keys conn draftable-spells)]
-      (mapv (fn [k]
-              (let [spell (get key->spell k)]
-                {:name      (or (:name spell) k)
-                 :eid       (:eid spell)
-                 :mana-cost (:mana-cost spell)
-                 :cost      (:cost spell)}))
-            draftable-spells))))
-
-(defn- resolve-abilities
-  "Resolve ability keys against the ability table, preserving the input
-  order so the rendered list matches the order the unit lists them."
-  [conn ability-keys]
-  (let [key->ability (db/abilities-by-keys conn ability-keys)]
-    (mapv (fn [k]
-            (let [a (get key->ability k)]
-              {:name        (:name a)
-               :eid         (:eid a)
-               :description (:description a)}))
-          ability-keys)))
-
 (defmethod integrant.core/init-key ::unit-view
-  [_init-key {:keys [datalog-connection]}]
+  [_init-key dependencies]
   (partial web.view/standard-entity-view-handler
-           (fn [eid]
-             (or (db/unit-by-eid datalog-connection eid)
-                 {:type :missing/resource :name "unit" :id eid}))
+           (fn [eid] (domain/unit-view-model dependencies eid))
            "unit.html"
+           ;; The model carries the unit fields (rendered under `data`); lift
+           ;; the presentation lists to the top level the template reads, and
+           ;; add the optional unit-card asset path.
            (fn [data _request]
-             (let [{:keys [stats abilities draftable-spells]} (domain/parse-unit-statistics (:unit-statistics data))
-                   lore-key                                   (:lore data)
-                   resolved-spells                            (resolve-spells datalog-connection lore-key draftable-spells)
-                   resolved-abilities                         (resolve-abilities datalog-connection abilities)
-                   mounts                                     (db/mounts-for-unit datalog-connection (:eid data))
-                   items                                      (db/items-for-unit datalog-connection (:eid data))
-                   portrait-stem                              (:eid data)]
-               {:unit-statistics  stats
-                :abilities        (not-empty resolved-abilities)
-                :draftable-spells (not-empty resolved-spells)
-                :mounts           (not-empty mounts)
-                :items            (not-empty items)
-                :lore             lore-key
-                :unit-card        (when (io/resource
-                                         (str "rts-web/asset/card/unit/" portrait-stem ".png"))
-                                    (str "/card/unit/" portrait-stem ".png"))}))))
+             (let [portrait-stem (:eid data)]
+               (assoc (select-keys data [:unit-statistics :abilities :draftable-spells :mounts :items])
+                      :unit-card (when (io/resource
+                                        (str "rts-web/asset/card/unit/" portrait-stem ".png"))
+                                   (str "/card/unit/" portrait-stem ".png")))))))


### PR DESCRIPTION
A workshop instance of the **"one fetch fn per view"** pattern, applied to the unit detail view (`game.view/unit-view`) so we can evaluate the shape before rolling it across the space.

## 3-layer split (db raw → domain shapes → view calls domain)
- **db** — `query.datalog.game/unit-detail` (`db/unit-detail`): one cohesive **raw** fetch — unit + decoded stats + resolved abilities, draftable spells, mounts, items. Ability/spell keys read straight off the decomposed `unit-statistics`; spells resolve by lore or by key. No presentation shaping.
- **domain** — `handlers.game/unit-view-model`: shapes the raw fetch into the view-model (parsed statline + projected list rows); returns a `:missing/resource` marker when the unit is absent.
- **web** — `game.view/unit-view`: calls `domain/unit-view-model`, lifts the presentation lists to the top-level context the template reads, adds the `unit-card` asset path.

The `resolve-spells` / `resolve-abilities` helpers and the 6-call orchestration **leave the web layer**.

## Verification
- New output **byte-identical** to the prior logic across **800 units** (0 mismatches) — covers lore-caster, fixed-spell, mounted, and item branches.
- Full **58-test** Playwright suite green; `cljfmt` / `clj-kondo` / `poly check` clean.

## Open design question (before rollout)
`standard-entity-view-handler` merges `{:data <model>}` + `extra-data-fn`; templates read unit scalar fields under `data.*` but the lists at top level. This instance bridges that with a per-view lift in `extra-data-fn`. If we roll this out, decide whether to keep the per-view lift or evolve `standard-entity-view-handler` to take a single view-model + an explicit `data`-key set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)