### PR TITLE
Organizer Console: dedicated page + Quick Actions shelf (rts-hgs)

### DIFF
--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -88,6 +88,7 @@
             :com.devereux-henley.rts-web.web.tournament.api/update-phase-configuration
             :com.devereux-henley.rts-web.web.tournament.view/create-tournament-view
             :com.devereux-henley.rts-web.web.tournament.view/tournament-view
+            :com.devereux-henley.rts-web.web.tournament.view/organizer-view
             :com.devereux-henley.rts-web.web.tournament.view/tournament-phase-form-view
             :com.devereux-henley.rts-web.web.tournament.view/phase-panel-view
             :com.devereux-henley.rts-web.web.tournament.view/round-row-view

--- a/components/e2e/tests/organizer-console.spec.js
+++ b/components/e2e/tests/organizer-console.spec.js
@@ -48,10 +48,12 @@ async function enter(request, eid, user) {
 }
 
 async function configureSwissPhase(request, eid) {
+  // Two rounds so the first generated round leaves "more rounds remain"
+  // (progress-state "round"), exercising the gating rather than terminal state.
   const res = await request.put(`${BASE}/api/tournament-phase-configuration?tournament-eid=${eid}`, {
     headers: apiHeaders('dev-admin'),
     data: {
-      phases: [{ 'phase-type': 'swiss', rounds: [{ 'round-index': 0, format: 1 }] }],
+      phases: [{ 'phase-type': 'swiss', rounds: [{ 'round-index': 0, format: 1 }, { 'round-index': 1, format: 1 }] }],
     },
   });
   expect(res.status()).toBe(200);
@@ -102,9 +104,9 @@ test.describe('Organizer Console', () => {
     await expect(page.locator('.organizer-only-tag', { hasText: 'Organizer Only' })).toBeVisible();
     await expect(page.locator('.viewer-role-link', { hasText: 'Back to Viewer' })).toBeVisible();
 
-    // Four quick-action cards.
-    await expect(page.locator('.org-action-card-title', { hasText: 'Advance Phase' })).toBeVisible();
-    await expect(page.locator('.org-action-card-title', { hasText: 'Generate Next Round' })).toBeVisible();
+    // Quick-action cards: one collapsed progress control + two placeholders.
+    // A freshly-created tournament is in registration, so progress is inactive.
+    await expect(page.locator('.org-action-card-title', { hasText: 'Progress Tournament' })).toBeVisible();
     await expect(page.locator('.org-action-card-title', { hasText: 'Feature a Match' })).toBeVisible();
     await expect(page.locator('.org-action-card-title', { hasText: 'Open Check-in' })).toBeVisible();
 
@@ -126,7 +128,7 @@ test.describe('Organizer Console', () => {
     ).toBeVisible();
   });
 
-  test('advance phase is gated until the current round fully reports', async ({ page, request }) => {
+  test('progress control is gated until the current round fully reports', async ({ page, request }) => {
     const eid = await createTournament(request);
     await configureSwissPhase(request, eid);
     await enter(request, eid, 'dev-admin');
@@ -136,9 +138,11 @@ test.describe('Organizer Console', () => {
 
     await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/organizer.html`);
 
-    // Round in progress (results unreported) → advance disabled, generate enabled.
-    await expect(page.locator('button', { hasText: 'Advance Phase' })).toBeDisabled();
-    await expect(page.locator('button', { hasText: 'Generate Round' })).toBeEnabled();
+    // Round 0 of a two-round phase is in progress with unreported matches, so
+    // the single progress control reads "Generate Round" but is disabled.
+    const btn = page.locator('.org-shelf button', { hasText: 'Generate Round' });
+    await expect(btn).toBeVisible();
+    await expect(btn).toBeDisabled();
   });
 
   test('non-organizers cannot reach the console', async ({ request }) => {

--- a/components/e2e/tests/organizer-console.spec.js
+++ b/components/e2e/tests/organizer-console.spec.js
@@ -1,0 +1,151 @@
+// Touches components/e2e so poly test re-runs the brick on PRs that only
+// modify upstream handlers/queries. The long-term fix is rts-9w4 (explicit
+// brick deps); until then, every domain-migration PR carries a small
+// e2e touch.
+
+const { test, expect } = require('@playwright/test');
+
+const BASE = process.env.RTS_API_BASE_URL || "http://127.0.0.1:3001";
+const GAME_EID = 'eea787d7-1065-45eb-a3f6-e26f32c294a1';
+
+function actionHeaders(user) {
+  return {
+    Accept: 'application/htmx+html',
+    'Content-Type': 'application/json',
+    Cookie: `dev_impersonation=${user}`,
+  };
+}
+
+function apiHeaders(user) {
+  return {
+    Accept: 'text/html',
+    'Content-Type': 'application/json',
+    Cookie: `dev_impersonation=${user}`,
+  };
+}
+
+async function createTournament(request) {
+  const eid = crypto.randomUUID();
+  const res = await request.put(`${BASE}/actions/tournament/${eid}?version=1`, {
+    headers: actionHeaders('dev-admin'),
+    data: {
+      'game-eid': GAME_EID,
+      name: 'Organizer Console E2E Cup',
+      description: 'Created by e2e test.',
+      timezone: 'UTC',
+      'registration-opens-at': '2020-01-01T00:00',
+      'registration-closes-at': '2030-01-01T00:00',
+    },
+  });
+  expect(res.status()).toBe(200);
+  return eid;
+}
+
+async function enter(request, eid, user) {
+  await request.post(`${BASE}/actions/tournament/${eid}/entry/me`, {
+    headers: actionHeaders(user),
+  });
+}
+
+async function configureSwissPhase(request, eid) {
+  const res = await request.put(`${BASE}/api/tournament-phase-configuration?tournament-eid=${eid}`, {
+    headers: apiHeaders('dev-admin'),
+    data: {
+      phases: [{ 'phase-type': 'swiss', rounds: [{ 'round-index': 0, format: 1 }] }],
+    },
+  });
+  expect(res.status()).toBe(200);
+}
+
+async function startTournament(request, eid) {
+  await request.post(`${BASE}/actions/tournament/${eid}/start`, {
+    headers: actionHeaders('dev-admin'),
+  });
+}
+
+async function generateRound(request, eid) {
+  await request.post(`${BASE}/actions/tournament/${eid}/round`, {
+    headers: actionHeaders('dev-admin'),
+  });
+}
+
+test.describe('Organizer Console', () => {
+  test.beforeEach(async ({ context }) => {
+    await context.addCookies([
+      {
+        name: 'dev_impersonation',
+        value: 'dev-admin',
+        domain: 'localhost',
+        path: '/',
+        httpOnly: true,
+        sameSite: 'Lax',
+      },
+    ]);
+  });
+
+  test('viewer links the organizer to the dedicated console', async ({ page, request }) => {
+    const eid = await createTournament(request);
+    await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/index.html`);
+    const link = page.locator('.viewer-role-link', { hasText: 'Organizer Console' });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute(
+      'href',
+      `/view/game/${GAME_EID}/tournament/${eid}/organizer.html`,
+    );
+  });
+
+  test('console page shows the quick-actions shelf, tabs, and danger zone', async ({ page, request }) => {
+    const eid = await createTournament(request);
+    await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/organizer.html`);
+
+    await expect(page).toHaveTitle(/Organizer · Organizer Console E2E Cup/);
+    await expect(page.locator('.organizer-only-tag', { hasText: 'Organizer Only' })).toBeVisible();
+    await expect(page.locator('.viewer-role-link', { hasText: 'Back to Viewer' })).toBeVisible();
+
+    // Four quick-action cards.
+    await expect(page.locator('.org-action-card-title', { hasText: 'Advance Phase' })).toBeVisible();
+    await expect(page.locator('.org-action-card-title', { hasText: 'Generate Next Round' })).toBeVisible();
+    await expect(page.locator('.org-action-card-title', { hasText: 'Feature a Match' })).toBeVisible();
+    await expect(page.locator('.org-action-card-title', { hasText: 'Open Check-in' })).toBeVisible();
+
+    // Management tabs.
+    await expect(page.locator('[role="tab"]', { hasText: 'Phases' })).toBeVisible();
+    await expect(page.locator('[role="tab"]', { hasText: 'Entrants' })).toBeVisible();
+    await expect(page.locator('[role="tab"]', { hasText: 'Disputes' })).toBeVisible();
+    await expect(page.locator('[role="tab"]', { hasText: 'Settings' })).toBeVisible();
+  });
+
+  test('entrants tab lists registered players', async ({ page, request }) => {
+    const eid = await createTournament(request);
+    await enter(request, eid, 'dev-player-one');
+    await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/organizer.html`);
+
+    await page.locator('#org-tab-entrants').click();
+    await expect(
+      page.locator('#org-panel-entrants table.standings-table tbody tr', { hasText: 'dev-player-one' }),
+    ).toBeVisible();
+  });
+
+  test('advance phase is gated until the current round fully reports', async ({ page, request }) => {
+    const eid = await createTournament(request);
+    await configureSwissPhase(request, eid);
+    await enter(request, eid, 'dev-admin');
+    await enter(request, eid, 'dev-player-one');
+    await startTournament(request, eid);
+    await generateRound(request, eid);
+
+    await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/organizer.html`);
+
+    // Round in progress (results unreported) → advance disabled, generate enabled.
+    await expect(page.locator('button', { hasText: 'Advance Phase' })).toBeDisabled();
+    await expect(page.locator('button', { hasText: 'Generate Round' })).toBeEnabled();
+  });
+
+  test('non-organizers cannot reach the console', async ({ request }) => {
+    const eid = await createTournament(request);
+    const res = await request.get(`${BASE}/view/game/${GAME_EID}/tournament/${eid}/organizer.html`, {
+      headers: actionHeaders('dev-player-one'),
+    });
+    expect(res.status()).toBe(404);
+  });
+});

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
@@ -101,6 +101,7 @@
 
 (def get-tournament-by-eid                        handlers.tournament/get-tournament-by-eid)
 (def tournament-view-model                        handlers.tournament/tournament-view-model)
+(def organizer-view-model                         handlers.tournament/organizer-view-model)
 (def get-tournaments-for-game                     handlers.tournament/get-tournaments-for-game)
 (def get-tournaments                              handlers.tournament/get-tournaments)
 (def create-tournament                            handlers.tournament/create-tournament)

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -868,3 +868,41 @@
        :registration-open   (is-registration-open? state (Instant/now))
        :is-organizer        (= viewer-sub (:created-by-sub tournament))})
     {:type :missing/resource :name "tournament" :id eid}))
+
+(defn- current-round-progress
+  "Summarizes how far the latest round of the active phase has reported:
+   the round index, how many matches it holds, how many have a recorded
+   result, and whether every match has reported. The round-complete? flag
+   is the gate the organizer console uses to enable phase advancement."
+  [matches current-phase]
+  (let [phase-matches (filter #(= current-phase (:phase-index %)) matches)]
+    (if (empty? phase-matches)
+      {:round-index nil :round-total 0 :round-reported 0 :round-complete? false}
+      (let [current-round (apply max (map :round-index phase-matches))
+            round-matches (filter #(= current-round (:round-index %)) phase-matches)
+            total         (count round-matches)
+            reported      (count (filter #(= "complete" (:status %)) round-matches))]
+        {:round-index     current-round
+         :round-total     total
+         :round-reported  reported
+         :round-complete? (= total reported)}))))
+
+(defn organizer-view-model
+  "Builds the organizer-console view-model: everything `tournament-view-model`
+   produces plus the current round's reporting progress and the
+   action-availability flags the Quick Actions shelf reads
+   (`:can-advance-phase?`, `:can-generate-round?`). Returns a
+   `:missing/resource` marker when the tournament doesn't exist."
+  [dependencies eid viewer-sub]
+  (let [model (tournament-view-model dependencies eid viewer-sub)]
+    (if (= :missing/resource (:type model))
+      model
+      (let [state    (:tournament-state model)
+            active?  (= "active" (:status state))
+            progress (current-round-progress (get-matches-for-tournament dependencies eid)
+                                             (:current-phase state))]
+        (merge model
+               progress
+               {:active?             active?
+                :can-advance-phase?  (and active? (:round-complete? progress))
+                :can-generate-round? active?})))))

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -887,11 +887,50 @@
          :round-reported  reported
          :round-complete? (= total reported)}))))
 
+(defn- tournament-progression
+  "Derives what the single 'progress tournament' shelf action does next,
+   given the state, the current round progress, and whether the tournament
+   is active. `generate-next-round` is one operation that seeds the next
+   round and auto-advances the phase when the phase's rounds run out, so the
+   shelf collapses to one control whose meaning depends on position:
+
+     :progress-state   \"round\"    — more rounds remain in the current phase
+                       \"phase\"    — last round of the phase, but more phases follow
+                       \"done\"     — final round of the final phase; nothing to generate
+                       \"inactive\" — tournament isn't active
+     :can-progress?    true when the action can run now: active, not done, and
+                       either no round exists yet (seed the first) or the
+                       current round has fully reported.
+     :next-phase-number 1-based number of the phase a `phase` advance moves into."
+  [state progress active?]
+  (let [current-phase (:current-phase state)
+        phases        (:phases state)
+        phase-config  (when current-phase (get phases current-phase))
+        total-rounds  (count (:rounds phase-config))
+        round-index   (:round-index progress)
+        more-rounds?  (if (nil? round-index)
+                        (pos? total-rounds)
+                        (< (inc round-index) total-rounds))
+        more-phases?  (boolean (when current-phase (get phases (inc current-phase))))
+        state-name    (cond
+                        (not active?) "inactive"
+                        more-rounds?  "round"
+                        more-phases?  "phase"
+                        :else         "done")
+        round-gated?  (and (pos? (:round-total progress))
+                           (not (:round-complete? progress)))]
+    {:progress-state    state-name
+     :done?             (= "done" state-name)
+     :more-phases?      more-phases?
+     :next-phase-number (when current-phase (+ current-phase 2))
+     :can-progress?     (and active?
+                             (not= "done" state-name)
+                             (not round-gated?))}))
+
 (defn organizer-view-model
   "Builds the organizer-console view-model: everything `tournament-view-model`
-   produces plus the current round's reporting progress and the
-   action-availability flags the Quick Actions shelf reads
-   (`:can-advance-phase?`, `:can-generate-round?`). Returns a
+   produces plus the current round's reporting progress and the single
+   `tournament-progression` summary the Quick Actions shelf reads. Returns a
    `:missing/resource` marker when the tournament doesn't exist."
   [dependencies eid viewer-sub]
   (let [model (tournament-view-model dependencies eid viewer-sub)]
@@ -903,6 +942,5 @@
                                              (:current-phase state))]
         (merge model
                progress
-               {:active?             active?
-                :can-advance-phase?  (and active? (:round-complete? progress))
-                :can-generate-round? active?})))))
+               {:active? active?}
+               (tournament-progression state progress active?))))))

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
@@ -466,3 +466,62 @@
   (with-redefs [handlers.tournament/get-tournament-by-eid (fn [_ _] nil)]
     (is (= :missing/resource
            (:type (handlers.tournament/tournament-view-model test-deps test-tournament-eid "owner"))))))
+
+;; --- organizer-view-model ---
+
+(defn- organizer-redefs
+  "Stubs the reads `organizer-view-model` (and the `tournament-view-model` it
+   wraps) makes, for the given status and match list."
+  [status matches]
+  {#'handlers.tournament/get-tournament-by-eid      (fn [_ _] {:eid test-tournament-eid :name "Spring Open" :created-by-sub "owner"})
+   #'handlers.tournament/get-tournament-state       (fn [_ _] {:status       status                         :phases    [{:phase-type "swiss"}] :current-phase 0 :qualifier-count nil
+                                                               :registration {:opens-at nil :closes-at nil} :standings []})
+   #'handlers.tournament/get-entries                (fn [_ _] [{:player-sub "owner"}])
+   #'handlers.tournament/get-matches-for-tournament (fn [_ _] matches)
+   ;; tournament-view-model decorates each match with game counts via a real
+   ;; db read; stub it out so the fixture stays at the handler boundary.
+   #'handlers.tournament/get-games-for-match        (fn [_ _] [])})
+
+(deftest organizer-view-model-gates-advance-on-full-reporting
+  (with-redefs-fn
+    (organizer-redefs "active" [{:phase-index 0 :round-index 0 :status "complete"}
+                                {:phase-index 0 :round-index 1 :status "complete"}
+                                {:phase-index 0 :round-index 1 :status "complete"}
+                                {:phase-index 0 :round-index 1 :status "pending"}
+                                {:phase-index 0 :round-index 1 :status "pending"}])
+    #(let [result (handlers.tournament/organizer-view-model test-deps test-tournament-eid "owner")]
+       (is (true? (:active? result)))
+       (is (= 1 (:round-index result)) "tracks the latest round of the current phase")
+       (is (= 4 (:round-total result)))
+       (is (= 2 (:round-reported result)) "matches the bead's 2/4 example")
+       (is (false? (:round-complete? result)))
+       (is (false? (:can-advance-phase? result)) "advance is gated until the round fully reports")
+       (is (true? (:can-generate-round? result)) "generate is available while active"))))
+
+(deftest organizer-view-model-enables-advance-when-round-complete
+  (with-redefs-fn
+    (organizer-redefs "active" [{:phase-index 0 :round-index 0 :status "complete"}
+                                {:phase-index 0 :round-index 0 :status "complete"}])
+    #(let [result (handlers.tournament/organizer-view-model test-deps test-tournament-eid "owner")]
+       (is (true? (:round-complete? result)))
+       (is (true? (:can-advance-phase? result))))))
+
+(deftest organizer-view-model-disables-actions-when-not-active
+  (with-redefs-fn
+    (organizer-redefs "registration" [])
+    #(let [result (handlers.tournament/organizer-view-model test-deps test-tournament-eid "owner")]
+       (is (false? (:active? result)))
+       (is (false? (:can-advance-phase? result)))
+       (is (false? (:can-generate-round? result))))))
+
+(deftest organizer-view-model-preserves-organizer-flag
+  (with-redefs-fn
+    (organizer-redefs "active" [])
+    #(do
+       (is (true? (:is-organizer (handlers.tournament/organizer-view-model test-deps test-tournament-eid "owner"))))
+       (is (false? (:is-organizer (handlers.tournament/organizer-view-model test-deps test-tournament-eid "stranger")))))))
+
+(deftest organizer-view-model-returns-missing-marker-when-absent
+  (with-redefs [handlers.tournament/get-tournament-by-eid (fn [_ _] nil)]
+    (is (= :missing/resource
+           (:type (handlers.tournament/organizer-view-model test-deps test-tournament-eid "owner"))))))

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
@@ -469,12 +469,22 @@
 
 ;; --- organizer-view-model ---
 
+;; A configured phase carries its rounds, so the progression logic can tell
+;; the last round of a phase from a mid-phase round.
+(def ^:private two-round-swiss
+  [{:phase-type "swiss" :rounds [{:round-index 0} {:round-index 1}]}])
+
+(def ^:private two-phase-config
+  [{:phase-type "single-elimination" :rounds [{:round-index 0}]}
+   {:phase-type "swiss" :rounds [{:round-index 0} {:round-index 1}]}])
+
 (defn- organizer-redefs
   "Stubs the reads `organizer-view-model` (and the `tournament-view-model` it
-   wraps) makes, for the given status and match list."
-  [status matches]
+   wraps) make: status, the configured phase vector, the active phase index,
+   and the match list."
+  [status phases current-phase matches]
   {#'handlers.tournament/get-tournament-by-eid      (fn [_ _] {:eid test-tournament-eid :name "Spring Open" :created-by-sub "owner"})
-   #'handlers.tournament/get-tournament-state       (fn [_ _] {:status       status                         :phases    [{:phase-type "swiss"}] :current-phase 0 :qualifier-count nil
+   #'handlers.tournament/get-tournament-state       (fn [_ _] {:status       status                         :phases    phases :current-phase current-phase :qualifier-count nil
                                                                :registration {:opens-at nil :closes-at nil} :standings []})
    #'handlers.tournament/get-entries                (fn [_ _] [{:player-sub "owner"}])
    #'handlers.tournament/get-matches-for-tournament (fn [_ _] matches)
@@ -482,41 +492,74 @@
    ;; db read; stub it out so the fixture stays at the handler boundary.
    #'handlers.tournament/get-games-for-match        (fn [_ _] [])})
 
-(deftest organizer-view-model-gates-advance-on-full-reporting
+(deftest organizer-view-model-generate-round-state-mid-phase
   (with-redefs-fn
-    (organizer-redefs "active" [{:phase-index 0 :round-index 0 :status "complete"}
-                                {:phase-index 0 :round-index 1 :status "complete"}
-                                {:phase-index 0 :round-index 1 :status "complete"}
-                                {:phase-index 0 :round-index 1 :status "pending"}
-                                {:phase-index 0 :round-index 1 :status "pending"}])
+    ;; round 0 of a two-round phase, 2 of 4 matches reported.
+    (organizer-redefs "active" two-round-swiss 0
+                      [{:phase-index 0 :round-index 0 :status "complete"}
+                       {:phase-index 0 :round-index 0 :status "complete"}
+                       {:phase-index 0 :round-index 0 :status "pending"}
+                       {:phase-index 0 :round-index 0 :status "pending"}])
     #(let [result (handlers.tournament/organizer-view-model test-deps test-tournament-eid "owner")]
-       (is (true? (:active? result)))
-       (is (= 1 (:round-index result)) "tracks the latest round of the current phase")
-       (is (= 4 (:round-total result)))
+       (is (= "round" (:progress-state result)) "more rounds remain in the phase")
        (is (= 2 (:round-reported result)) "matches the bead's 2/4 example")
-       (is (false? (:round-complete? result)))
-       (is (false? (:can-advance-phase? result)) "advance is gated until the round fully reports")
-       (is (true? (:can-generate-round? result)) "generate is available while active"))))
+       (is (= 4 (:round-total result)))
+       (is (false? (:can-progress? result)) "gated until the current round reports")
+       (is (false? (:done? result))))))
 
-(deftest organizer-view-model-enables-advance-when-round-complete
+(deftest organizer-view-model-generate-round-enabled-when-no-round-yet
   (with-redefs-fn
-    (organizer-redefs "active" [{:phase-index 0 :round-index 0 :status "complete"}
-                                {:phase-index 0 :round-index 0 :status "complete"}])
+    (organizer-redefs "active" two-round-swiss 0 [])
     #(let [result (handlers.tournament/organizer-view-model test-deps test-tournament-eid "owner")]
-       (is (true? (:round-complete? result)))
-       (is (true? (:can-advance-phase? result))))))
+       (is (= "round" (:progress-state result)))
+       (is (true? (:can-progress? result)) "the first round can always be seeded"))))
 
-(deftest organizer-view-model-disables-actions-when-not-active
+(deftest organizer-view-model-advance-phase-state-on-last-round
   (with-redefs-fn
-    (organizer-redefs "registration" [])
+    ;; final (only) round of phase 0, fully reported, with a phase 1 to follow.
+    (organizer-redefs "active" two-phase-config 0
+                      [{:phase-index 0 :round-index 0 :status "complete"}
+                       {:phase-index 0 :round-index 0 :status "complete"}])
+    #(let [result (handlers.tournament/organizer-view-model test-deps test-tournament-eid "owner")]
+       (is (= "phase" (:progress-state result)) "last round of the phase, more phases follow")
+       (is (true? (:more-phases? result)))
+       (is (= 2 (:next-phase-number result)) "1-based number of the phase advance moves into")
+       (is (true? (:can-progress? result))))))
+
+(deftest organizer-view-model-advance-phase-gated-until-reported
+  (with-redefs-fn
+    ;; same last-round-of-phase position, but only 2 of 4 reported.
+    (organizer-redefs "active" two-phase-config 0
+                      [{:phase-index 0 :round-index 0 :status "complete"}
+                       {:phase-index 0 :round-index 0 :status "complete"}
+                       {:phase-index 0 :round-index 0 :status "pending"}
+                       {:phase-index 0 :round-index 0 :status "pending"}])
+    #(let [result (handlers.tournament/organizer-view-model test-deps test-tournament-eid "owner")]
+       (is (= "phase" (:progress-state result)))
+       (is (false? (:can-progress? result)) "advance is gated until the final round reports"))))
+
+(deftest organizer-view-model-done-state-on-final-round-of-final-phase
+  (with-redefs-fn
+    ;; only round of the only phase → nothing left to generate.
+    (organizer-redefs "active" [{:phase-type "swiss" :rounds [{:round-index 0}]}] 0
+                      [{:phase-index 0 :round-index 0 :status "pending"}])
+    #(let [result (handlers.tournament/organizer-view-model test-deps test-tournament-eid "owner")]
+       (is (= "done" (:progress-state result)))
+       (is (true? (:done? result)))
+       (is (false? (:can-progress? result)) "no further rounds or phases to generate"))))
+
+(deftest organizer-view-model-inactive-when-not-active
+  (with-redefs-fn
+    (organizer-redefs "registration" [] nil [])
     #(let [result (handlers.tournament/organizer-view-model test-deps test-tournament-eid "owner")]
        (is (false? (:active? result)))
-       (is (false? (:can-advance-phase? result)))
-       (is (false? (:can-generate-round? result))))))
+       (is (= "inactive" (:progress-state result)))
+       (is (false? (:can-progress? result)))
+       (is (false? (:done? result))))))
 
 (deftest organizer-view-model-preserves-organizer-flag
   (with-redefs-fn
-    (organizer-redefs "active" [])
+    (organizer-redefs "active" two-round-swiss 0 [])
     #(do
        (is (true? (:is-organizer (handlers.tournament/organizer-view-model test-deps test-tournament-eid "owner"))))
        (is (false? (:is-organizer (handlers.tournament/organizer-view-model test-deps test-tournament-eid "stranger")))))))

--- a/components/rts-web/resources/rts-web/asset/style/app.css
+++ b/components/rts-web/resources/rts-web/asset/style/app.css
@@ -4273,3 +4273,218 @@ table.standings-table tbody tr td.col-num::before {
 .console-page .replay-submitted-pip--done    { background: var(--color-success-500); color: var(--color-neutral-50); }
 .console-page .replay-submitted-pip--live    { background: var(--color-warning-500); color: var(--color-neutral-50); animation: viewer-pulse-live 1.4s ease-in-out infinite; }
 .console-page .replay-submitted-pip--pending { border: 1px dashed var(--color-border); color: var(--color-text-muted); }
+
+/* ============================================================================
+   ORGANIZER CONSOLE — dedicated page + Quick Actions shelf
+   ============================================================================ */
+
+/* --- Header (breadcrumb · Organizer Only tag · Back to viewer) ----------- */
+.organizer-header {
+  position: relative;
+  padding: var(--space-5) var(--space-8) var(--space-4);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-accent) 8%, var(--color-bg)) 0%, var(--color-bg) 100%);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-accent) 28%, transparent);
+}
+.organizer-header-inner {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-6);
+  flex-wrap: wrap;
+}
+.organizer-header-left { min-width: 0; }
+.organizer-title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+.organizer-title {
+  font-family: var(--font-family-heading);
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  line-height: 1.1;
+  margin: var(--space-1) 0;
+  color: var(--color-text-strong);
+}
+.organizer-only-tag {
+  font-family: var(--font-family-heading);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 3px var(--space-2);
+  color: var(--color-accent);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 45%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+}
+.organizer-status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+  flex-wrap: wrap;
+}
+
+/* --- Quick Actions shelf ------------------------------------------------- */
+.org-shelf {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4);
+}
+.org-action-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-top: 3px solid var(--color-accent);
+}
+.org-action-card--disabled {
+  opacity: 0.6;
+  border-top-color: var(--color-border);
+}
+.org-action-card-icon {
+  font-size: 1.3rem;
+  line-height: 1;
+  color: var(--color-accent);
+}
+.org-action-card-title {
+  font-family: var(--font-family-heading);
+  font-size: 0.95rem;
+  margin: 0;
+  color: var(--color-text-strong);
+}
+.org-action-card-text {
+  font-size: 0.84rem;
+  color: var(--color-text-muted);
+  margin: 0;
+  flex: 1;
+}
+.org-action-card-meta { margin: var(--space-1) 0; }
+.org-progress {
+  font-family: var(--font-family-mono);
+  font-size: 0.74rem;
+  color: var(--color-text-muted);
+}
+.org-progress--ready { color: var(--color-success-500); font-weight: 600; }
+
+/* --- Management panel ---------------------------------------------------- */
+.org-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+.org-phase-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.org-phase-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+.org-phase-row--current {
+  border-left: 3px solid var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 5%, var(--color-surface));
+}
+.org-phase-index {
+  font-family: var(--font-family-heading);
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--color-text-strong);
+}
+.org-phase-type {
+  font-family: var(--font-family-mono);
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  flex: 1;
+}
+.org-phase-badge {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 2px var(--space-2);
+  color: var(--color-accent);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 40%, transparent);
+}
+.org-empty-state {
+  padding: var(--space-6);
+  text-align: center;
+  border: 1px dashed var(--color-border);
+}
+.org-empty-state-title {
+  font-family: var(--font-family-heading);
+  font-size: 0.95rem;
+  color: var(--color-text-strong);
+  margin: 0 0 var(--space-1);
+}
+.org-settings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-3);
+  margin: 0 0 var(--space-4);
+}
+.org-settings-item {
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+.org-settings-item dt {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin-bottom: 2px;
+}
+.org-settings-item dd {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-strong);
+}
+.org-settings-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* --- Danger Zone --------------------------------------------------------- */
+.org-danger-zone {
+  border: 1px solid color-mix(in srgb, var(--color-danger-500) 35%, var(--color-border));
+  padding: var(--space-4) var(--space-5);
+  background: color-mix(in srgb, var(--color-danger-500) 3%, var(--color-surface));
+}
+.org-danger-grid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.org-danger-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  flex-wrap: wrap;
+}
+.org-danger-card--destructive {
+  border-color: color-mix(in srgb, var(--color-danger-500) 45%, transparent);
+}
+.org-danger-card-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.86rem;
+}
+.org-danger-card-text strong { color: var(--color-text-strong); }

--- a/components/rts-web/resources/rts-web/asset/style/app.css
+++ b/components/rts-web/resources/rts-web/asset/style/app.css
@@ -1709,7 +1709,14 @@ h3.draft-category-header {
   gap: var(--space-1);
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
+  /* Tabs scroll horizontally on narrow viewports, but the strip is a
+     heading — never show scrollbar chrome (the active tab's -1px
+     overlap would otherwise trip a 1px scrollbar even when tabs fit). */
   overflow-x: auto;
+  scrollbar-width: none;
+}
+.tourney-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .tourney-tab {

--- a/components/rts-web/resources/rts-web/view/organizer-index.html
+++ b/components/rts-web/resources/rts-web/view/organizer-index.html
@@ -280,7 +280,7 @@
                     <tbody>
                         {% for entry in entries %}
                         <tr class="standings-row standings-row--entry">
-                            <td class="col-num">{{forloop.counter}}</td>
+                            <td class="col-num"></td>
                             <td class="col-player">
                                 <span class="standings-handle">
                                     <span class="standings-handle-text">{{entry.player-sub}}</span>

--- a/components/rts-web/resources/rts-web/view/organizer-index.html
+++ b/components/rts-web/resources/rts-web/view/organizer-index.html
@@ -69,48 +69,65 @@
             </header>
             <div class="org-shelf" role="group" aria-labelledby="quick-actions-heading">
 
-                <!-- Advance Phase — gated on the current round fully reporting -->
-                <article class="org-action-card{% if not can-advance-phase? %} org-action-card--disabled{% endif %}"
-                         aria-labelledby="action-advance-heading">
+                <!-- Progress Tournament — one control over the generate-next-round
+                     state machine: generates the next round within a phase, or
+                     advances to the next phase on a phase's final round. Gated on
+                     the current round fully reporting. -->
+                <article class="org-action-card{% if not can-progress? %} org-action-card--disabled{% endif %}"
+                         aria-labelledby="action-progress-heading">
                     <div class="org-action-card-icon" aria-hidden="true">⏭</div>
-                    <h3 class="org-action-card-title" id="action-advance-heading">Advance Phase</h3>
+                    {% ifequal progress-state "phase" %}
+                    <h3 class="org-action-card-title" id="action-progress-heading">Advance Phase</h3>
                     <p class="org-action-card-text">
-                        Progress the phase state machine once every match in the current round reports.
+                        This is the final round of the current phase. Advancing seeds the
+                        first round of Phase {{next-phase-number}}.
                     </p>
+                    {% endifequal %}
+                    {% ifequal progress-state "round" %}
+                    <h3 class="org-action-card-title" id="action-progress-heading">Generate Next Round</h3>
+                    <p class="org-action-card-text">
+                        Seed the next round of matches from the current standings.
+                    </p>
+                    {% endifequal %}
+                    {% ifequal progress-state "done" %}
+                    <h3 class="org-action-card-title" id="action-progress-heading">Final Round Reached</h3>
+                    <p class="org-action-card-text">
+                        No further rounds or phases remain to generate. The tournament
+                        completes once the current round reports.
+                    </p>
+                    {% endifequal %}
+                    {% ifequal progress-state "inactive" %}
+                    <h3 class="org-action-card-title" id="action-progress-heading">Progress Tournament</h3>
+                    <p class="org-action-card-text">
+                        Generate rounds and advance phases once the tournament is active.
+                    </p>
+                    {% endifequal %}
                     <div class="org-action-card-meta">
                         {% if active? %}
-                            {% if round-total %}<span class="org-progress{% if round-complete? %} org-progress--ready{% endif %}">{{round-reported}}/{{round-total}} reported</span>
-                            {% else %}<span class="org-progress muted">No round in progress</span>{% endif %}
+                            {% if done? %}
+                            <span class="org-progress muted">No rounds remaining</span>
+                            {% else %}
+                                {% if round-total %}<span class="org-progress{% if round-complete? %} org-progress--ready{% endif %}">{{round-reported}}/{{round-total}} reported</span>
+                                {% else %}<span class="org-progress org-progress--ready">Ready</span>{% endif %}
+                            {% endif %}
                         {% else %}
                             <span class="org-progress muted">Tournament not active</span>
                         {% endif %}
                     </div>
+                    {% if done? %}
+                    <button type="button" class="btn btn-secondary btn-sm" disabled aria-disabled="true">
+                        No Rounds Remaining
+                    </button>
+                    {% else %}
                     <form hx-post="/actions/tournament/{{data.eid}}/round" hx-swap="none">
                         <button type="submit" class="btn btn-primary btn-sm"
-                                {% if not can-advance-phase? %}disabled aria-disabled="true"{% endif %}>
-                            Advance Phase
+                                {% if not can-progress? %}disabled aria-disabled="true"{% endif %}>
+                            {% ifequal progress-state "phase" %}Advance to Phase {{next-phase-number}}{% endifequal %}
+                            {% ifequal progress-state "round" %}Generate Round{% endifequal %}
+                            {% ifequal progress-state "inactive" %}Progress{% endifequal %}
                         </button>
                     </form>
-                </article>
-
-                <!-- Generate Next Round — seed the next round from the winners -->
-                <article class="org-action-card{% if not can-generate-round? %} org-action-card--disabled{% endif %}"
-                         aria-labelledby="action-generate-heading">
-                    <div class="org-action-card-icon" aria-hidden="true">⚄</div>
-                    <h3 class="org-action-card-title" id="action-generate-heading">Generate Next Round</h3>
-                    <p class="org-action-card-text">
-                        Seed the next round of matches from the current standings.
-                    </p>
-                    <div class="org-action-card-meta">
-                        {% if active? %}<span class="org-progress org-progress--ready">Ready</span>
-                        {% else %}<span class="org-progress muted">Tournament not active</span>{% endif %}
-                    </div>
-                    <form hx-post="/actions/tournament/{{data.eid}}/round" hx-swap="none">
-                        <button type="submit" class="btn btn-primary btn-sm"
-                                {% if not can-generate-round? %}disabled aria-disabled="true"{% endif %}>
-                            Generate Round
-                        </button>
-                    </form>
+                    {% endif %}
                 </article>
 
                 <!-- Feature a Match — pin to the viewer stream slot (rts-sr1) -->

--- a/components/rts-web/resources/rts-web/view/organizer-index.html
+++ b/components/rts-web/resources/rts-web/view/organizer-index.html
@@ -1,0 +1,394 @@
+{% extends "rts-web/template/entrypoint.html" %}
+
+{% block title %}Organizer · {{data.name}} | {{game.name}} | RTS-UI{% endblock %}
+
+{% block content %}
+<div id="organizer-stage" class="viewer-page organizer-page"
+     hx-get="/view/game/{{game-eid}}/tournament/{{data.eid}}/organizer.html"
+     hx-trigger="{{ triggers.tournament-stage }}"
+     hx-target="this"
+     hx-swap="outerHTML"
+     hx-select="#organizer-stage">
+
+    <!-- ═══════════════════════════════════════════════════════════════ -->
+    <!-- Header: breadcrumb · Organizer Only tag · Back to viewer         -->
+    <!-- ═══════════════════════════════════════════════════════════════ -->
+    <header class="organizer-header" aria-labelledby="organizer-heading">
+        <div class="organizer-header-inner">
+            <div class="organizer-header-left">
+                <nav class="console-breadcrumb" aria-label="Breadcrumb">
+                    <a href="/view/game/{{game-eid}}/tournament/{{data.eid}}/index.html">← {{data.name}}</a>
+                    <span class="console-breadcrumb-sep">/</span>
+                    <span>Organizer Console</span>
+                </nav>
+                <div class="organizer-title-row">
+                    <h1 id="organizer-heading" class="organizer-title">{{data.name}}</h1>
+                    <span class="organizer-only-tag">Organizer Only</span>
+                </div>
+                <div class="organizer-status">
+                    {% ifequal tournament-state.status "active" %}
+                    <span class="viewer-hero-status-live">Live</span>
+                    {% endifequal %}
+                    {% ifequal tournament-state.status "registration" %}
+                    <span class="viewer-hero-status-live viewer-hero-status-live--reg">Registration</span>
+                    {% endifequal %}
+                    {% ifequal tournament-state.status "complete" %}
+                    <span class="viewer-hero-status-live viewer-hero-status-live--done">Complete</span>
+                    {% endifequal %}
+                    {% ifequal tournament-state.status "cancelled" %}
+                    <span class="viewer-hero-status-live viewer-hero-status-live--done">Cancelled</span>
+                    {% endifequal %}
+                    {% if current-phase-label %}
+                    <span class="viewer-hero-status-phase">
+                        Phase {{tournament-state.current-phase|add:1}} of {{phase-count}} ·
+                        <strong>{{current-phase-label}}</strong>
+                        {% if current-round-label %} · {{current-round-label}}{% endif %}
+                    </span>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="organizer-header-right">
+                <a class="viewer-role-link"
+                   href="/view/game/{{game-eid}}/tournament/{{data.eid}}/index.html">
+                    <span class="viewer-role-link-icon" aria-hidden="true">←</span>
+                    Back to Viewer
+                </a>
+            </div>
+        </div>
+    </header>
+
+    <div class="viewer-body">
+
+        <!-- ═══════════════════════════════════════════════════════════ -->
+        <!-- Quick Actions shelf                                          -->
+        <!-- ═══════════════════════════════════════════════════════════ -->
+        <section class="org-shelf-section" aria-labelledby="quick-actions-heading">
+            <header class="section-header">
+                <h2 class="section-header-title" id="quick-actions-heading">Quick Actions</h2>
+                <span class="section-header-subtitle">Run the tournament from here</span>
+            </header>
+            <div class="org-shelf" role="group" aria-labelledby="quick-actions-heading">
+
+                <!-- Advance Phase — gated on the current round fully reporting -->
+                <article class="org-action-card{% if not can-advance-phase? %} org-action-card--disabled{% endif %}"
+                         aria-labelledby="action-advance-heading">
+                    <div class="org-action-card-icon" aria-hidden="true">⏭</div>
+                    <h3 class="org-action-card-title" id="action-advance-heading">Advance Phase</h3>
+                    <p class="org-action-card-text">
+                        Progress the phase state machine once every match in the current round reports.
+                    </p>
+                    <div class="org-action-card-meta">
+                        {% if active? %}
+                            {% if round-total %}<span class="org-progress{% if round-complete? %} org-progress--ready{% endif %}">{{round-reported}}/{{round-total}} reported</span>
+                            {% else %}<span class="org-progress muted">No round in progress</span>{% endif %}
+                        {% else %}
+                            <span class="org-progress muted">Tournament not active</span>
+                        {% endif %}
+                    </div>
+                    <form hx-post="/actions/tournament/{{data.eid}}/round" hx-swap="none">
+                        <button type="submit" class="btn btn-primary btn-sm"
+                                {% if not can-advance-phase? %}disabled aria-disabled="true"{% endif %}>
+                            Advance Phase
+                        </button>
+                    </form>
+                </article>
+
+                <!-- Generate Next Round — seed the next round from the winners -->
+                <article class="org-action-card{% if not can-generate-round? %} org-action-card--disabled{% endif %}"
+                         aria-labelledby="action-generate-heading">
+                    <div class="org-action-card-icon" aria-hidden="true">⚄</div>
+                    <h3 class="org-action-card-title" id="action-generate-heading">Generate Next Round</h3>
+                    <p class="org-action-card-text">
+                        Seed the next round of matches from the current standings.
+                    </p>
+                    <div class="org-action-card-meta">
+                        {% if active? %}<span class="org-progress org-progress--ready">Ready</span>
+                        {% else %}<span class="org-progress muted">Tournament not active</span>{% endif %}
+                    </div>
+                    <form hx-post="/actions/tournament/{{data.eid}}/round" hx-swap="none">
+                        <button type="submit" class="btn btn-primary btn-sm"
+                                {% if not can-generate-round? %}disabled aria-disabled="true"{% endif %}>
+                            Generate Round
+                        </button>
+                    </form>
+                </article>
+
+                <!-- Feature a Match — pin to the viewer stream slot (rts-sr1) -->
+                <article class="org-action-card org-action-card--disabled"
+                         aria-labelledby="action-feature-heading">
+                    <div class="org-action-card-icon" aria-hidden="true">★</div>
+                    <h3 class="org-action-card-title" id="action-feature-heading">Feature a Match</h3>
+                    <p class="org-action-card-text">
+                        Pin a match to the viewer's live-stream slot so spectators follow it.
+                    </p>
+                    <div class="org-action-card-meta">
+                        <span class="org-progress muted">Coming soon</span>
+                    </div>
+                    <button type="button" class="btn btn-secondary btn-sm" disabled aria-disabled="true">
+                        Feature
+                    </button>
+                </article>
+
+                <!-- Open Check-in — prompt the next round's players (check-in child) -->
+                <article class="org-action-card org-action-card--disabled"
+                         aria-labelledby="action-checkin-heading">
+                    <div class="org-action-card-icon" aria-hidden="true">✓</div>
+                    <h3 class="org-action-card-title" id="action-checkin-heading">Open Check-in</h3>
+                    <p class="org-action-card-text">
+                        Send a check-in prompt to the players scheduled for the next round.
+                    </p>
+                    <div class="org-action-card-meta">
+                        <span class="org-progress muted">Coming soon</span>
+                    </div>
+                    <button type="button" class="btn btn-secondary btn-sm" disabled aria-disabled="true">
+                        Open Check-in
+                    </button>
+                </article>
+
+            </div>
+        </section>
+
+        <!-- ═══════════════════════════════════════════════════════════ -->
+        <!-- Management panel (tabbed)                                    -->
+        <!-- ═══════════════════════════════════════════════════════════ -->
+        <section class="org-panel" aria-labelledby="org-panel-heading">
+            <h2 id="org-panel-heading" class="sr-only">Tournament management</h2>
+
+            <div class="tourney-tabs" role="tablist" aria-label="Management sections">
+                <button type="button" role="tab" id="org-tab-phases"
+                        aria-selected="true" aria-controls="org-panel-phases"
+                        class="tourney-tab"
+                        _="on click
+                           add @hidden to <[role=tabpanel]/> in the closest .org-panel
+                           then remove @hidden from #org-panel-phases
+                           then set @aria-selected of <[role=tab]/> in my parentElement to 'false'
+                           then set my @aria-selected to 'true'">
+                    Phases &amp; Rounds
+                </button>
+                <button type="button" role="tab" id="org-tab-entrants"
+                        aria-selected="false" aria-controls="org-panel-entrants"
+                        class="tourney-tab"
+                        _="on click
+                           add @hidden to <[role=tabpanel]/> in the closest .org-panel
+                           then remove @hidden from #org-panel-entrants
+                           then set @aria-selected of <[role=tab]/> in my parentElement to 'false'
+                           then set my @aria-selected to 'true'">
+                    Entrants<span class="tourney-tab-sub">{{entries|length}}</span>
+                </button>
+                <button type="button" role="tab" id="org-tab-disputes"
+                        aria-selected="false" aria-controls="org-panel-disputes"
+                        class="tourney-tab"
+                        _="on click
+                           add @hidden to <[role=tabpanel]/> in the closest .org-panel
+                           then remove @hidden from #org-panel-disputes
+                           then set @aria-selected of <[role=tab]/> in my parentElement to 'false'
+                           then set my @aria-selected to 'true'">
+                    Disputes
+                </button>
+                <button type="button" role="tab" id="org-tab-settings"
+                        aria-selected="false" aria-controls="org-panel-settings"
+                        class="tourney-tab"
+                        _="on click
+                           add @hidden to <[role=tabpanel]/> in the closest .org-panel
+                           then remove @hidden from #org-panel-settings
+                           then set @aria-selected of <[role=tab]/> in my parentElement to 'false'
+                           then set my @aria-selected to 'true'">
+                    Settings
+                </button>
+            </div>
+
+            <!-- ─── Phases & Rounds ─── -->
+            <section id="org-panel-phases" role="tabpanel" aria-labelledby="org-tab-phases"
+                     class="tourney-tab-panel">
+                {% if tournament-state.phases|not-empty? %}
+                <ol class="org-phase-list">
+                    {% for phase in tournament-state.phases %}
+                    <li class="org-phase-row{% ifequal forloop.counter0 tournament-state.current-phase %} org-phase-row--current{% endifequal %}">
+                        <span class="org-phase-index">Phase {{forloop.counter}}</span>
+                        <span class="org-phase-type">{{phase.phase-type}}</span>
+                        {% ifequal forloop.counter0 tournament-state.current-phase %}
+                        <span class="org-phase-badge">Current</span>
+                        {% endifequal %}
+                    </li>
+                    {% endfor %}
+                </ol>
+                {% else %}
+                <p class="muted">No phases configured yet.</p>
+                {% endif %}
+
+                <header class="section-header">
+                    <h3 class="section-header-title">Pending Matches</h3>
+                    <span class="section-header-subtitle">Awaiting results</span>
+                </header>
+                {% if schedule|not-empty? %}
+                <div class="schedule-list">
+                    {% for s in schedule %}
+                    <div class="schedule-row{% if s.up-next? %} schedule-row--next{% else %} schedule-row--upcoming{% endif %}">
+                        <div class="schedule-time">
+                            <span class="schedule-time-label">{{s.phase-label}}</span>
+                            {{s.round-label}}
+                        </div>
+                        <div class="schedule-match">
+                            <div class="schedule-match-pair">
+                                {{s.player-one-sub}}
+                                <span class="schedule-match-pair-vs">vs</span>
+                                {% if s.player-two-sub %}{{s.player-two-sub}}{% else %}TBD{% endif %}
+                            </div>
+                            <div class="schedule-match-meta">Bo{{s.format}}</div>
+                        </div>
+                        <span class="schedule-state{% if s.up-next? %} schedule-state--next{% else %} schedule-state--upcoming{% endif %}">
+                            {% if s.up-next? %}Up Next{% else %}Scheduled{% endif %}
+                        </span>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% else %}
+                <p class="muted">No pending matches.</p>
+                {% endif %}
+            </section>
+
+            <!-- ─── Entrants ─── -->
+            <section id="org-panel-entrants" role="tabpanel" aria-labelledby="org-tab-entrants"
+                     class="tourney-tab-panel" hidden>
+                {% if entries|not-empty? %}
+                <table class="standings-table">
+                    <caption class="sr-only">Registered entrants</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col" class="col-num">#</th>
+                            <th scope="col" class="col-player">Player</th>
+                            <th scope="col" class="col-status">Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for entry in entries %}
+                        <tr class="standings-row standings-row--entry">
+                            <td class="col-num">{{forloop.counter}}</td>
+                            <td class="col-player">
+                                <span class="standings-handle">
+                                    <span class="standings-handle-text">{{entry.player-sub}}</span>
+                                </span>
+                            </td>
+                            <td class="col-status">
+                                <span class="standings-status standings-status--alive">Entered</span>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                {% else %}
+                <p class="muted">No entrants yet.</p>
+                {% endif %}
+            </section>
+
+            <!-- ─── Disputes (rts-j11) ─── -->
+            <section id="org-panel-disputes" role="tabpanel" aria-labelledby="org-tab-disputes"
+                     class="tourney-tab-panel" hidden>
+                <div class="org-empty-state">
+                    <p class="org-empty-state-title">No disputes</p>
+                    <p class="muted">Reported-result disputes will appear here for resolution.</p>
+                </div>
+            </section>
+
+            <!-- ─── Settings ─── -->
+            <section id="org-panel-settings" role="tabpanel" aria-labelledby="org-tab-settings"
+                     class="tourney-tab-panel" hidden>
+                <dl class="org-settings-grid">
+                    <div class="org-settings-item">
+                        <dt>Status</dt>
+                        <dd>{{tournament-state.status}}</dd>
+                    </div>
+                    <div class="org-settings-item">
+                        <dt>Entrants</dt>
+                        <dd>{{entries|length}}</dd>
+                    </div>
+                    {% if tournament-state.qualifier-count %}
+                    <div class="org-settings-item">
+                        <dt>Qualifiers</dt>
+                        <dd>Top {{tournament-state.qualifier-count}} advance</dd>
+                    </div>
+                    {% endif %}
+                    {% if tournament-state.registration.closes-at %}
+                    <div class="org-settings-item">
+                        <dt>Registration closes</dt>
+                        <dd>{{tournament-state.registration.closes-at}}</dd>
+                    </div>
+                    {% endif %}
+                </dl>
+
+                {% ifequal tournament-state.status "registration" %}
+                <div class="org-settings-actions">
+                    <div class="viewer-action-card">
+                        <div class="viewer-action-card-text">Close registration early and lock the entrant list.</div>
+                        <form hx-post="/actions/tournament/{{data.eid}}/close-registration" hx-swap="none">
+                            <button type="submit" class="btn btn-secondary btn-sm">Close Registration</button>
+                        </form>
+                    </div>
+                    <div class="viewer-action-card">
+                        <div class="viewer-action-card-text">Start the tournament and generate the first round.</div>
+                        <form hx-post="/actions/tournament/{{data.eid}}/start" hx-swap="none">
+                            <button type="submit" class="btn btn-primary btn-sm">Start Tournament</button>
+                        </form>
+                    </div>
+                </div>
+                {% endifequal %}
+            </section>
+        </section>
+
+        <!-- ═══════════════════════════════════════════════════════════ -->
+        <!-- Danger Zone                                                  -->
+        <!-- ═══════════════════════════════════════════════════════════ -->
+        {% if active? %}
+        <section class="org-danger-zone" aria-labelledby="danger-heading">
+            <header class="section-header">
+                <h2 class="section-header-title" id="danger-heading">Danger Zone</h2>
+                <span class="section-header-subtitle">Irreversible actions</span>
+            </header>
+            <div class="org-danger-grid">
+                <div class="org-danger-card">
+                    <div class="org-danger-card-text">
+                        <strong>Complete tournament</strong>
+                        <span class="muted">Mark the tournament finished and freeze its standings.</span>
+                    </div>
+                    <form hx-post="/actions/tournament/{{data.eid}}/complete" hx-swap="none">
+                        <button type="submit" class="btn btn-secondary btn-sm">Complete</button>
+                    </form>
+                </div>
+                <div class="org-danger-card org-danger-card--destructive">
+                    <div class="org-danger-card-text">
+                        <strong>Cancel tournament</strong>
+                        <span class="muted">Cancel this tournament. Matches and standings are discarded.</span>
+                    </div>
+                    <form hx-post="/actions/tournament/{{data.eid}}/cancel" hx-swap="none"
+                          hx-confirm="Cancel this tournament? This cannot be undone.">
+                        <button type="submit" class="btn btn-danger btn-sm">Cancel Tournament</button>
+                    </form>
+                </div>
+            </div>
+        </section>
+        {% endif %}
+
+        {% ifequal tournament-state.status "registration" %}
+        <section class="org-danger-zone" aria-labelledby="danger-reg-heading">
+            <header class="section-header">
+                <h2 class="section-header-title" id="danger-reg-heading">Danger Zone</h2>
+                <span class="section-header-subtitle">Irreversible actions</span>
+            </header>
+            <div class="org-danger-grid">
+                <div class="org-danger-card org-danger-card--destructive">
+                    <div class="org-danger-card-text">
+                        <strong>Cancel tournament</strong>
+                        <span class="muted">Cancel this tournament before it begins.</span>
+                    </div>
+                    <form hx-post="/actions/tournament/{{data.eid}}/cancel" hx-swap="none"
+                          hx-confirm="Cancel this tournament? This cannot be undone.">
+                        <button type="submit" class="btn btn-danger btn-sm">Cancel Tournament</button>
+                    </form>
+                </div>
+            </div>
+        </section>
+        {% endifequal %}
+
+    </div>
+</div>
+{% endblock %}

--- a/components/rts-web/resources/rts-web/view/tournament-index.html
+++ b/components/rts-web/resources/rts-web/view/tournament-index.html
@@ -69,9 +69,8 @@
                     </a>
                     {% endif %}
                     {% if is-organizer %}
-                    <a class="viewer-role-link viewer-role-link--disabled"
-                       aria-disabled="true"
-                       title="Organizer console — coming soon">
+                    <a class="viewer-role-link"
+                       href="/view/game/{{game-eid}}/tournament/{{data.eid}}/organizer.html">
                         <span class="viewer-role-link-icon" aria-hidden="true">⚙</span>
                         Organizer Console
                     </a>

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -123,6 +123,10 @@
       {:get {:produces   ["application/htmx+html"]
              :parameters {:path schema.contract/game-and-id-path-parameter}
              :handler    (integrant.core/ref ::web.tournament.view/tournament-view)}}]
+     ["/:eid/organizer.html"
+      {:get {:produces   ["application/htmx+html"]
+             :parameters {:path schema.contract/game-and-id-path-parameter}
+             :handler    (integrant.core/ref ::web.tournament.view/organizer-view)}}]
      ["/:eid/phase.html"
       {:get {:produces   ["application/htmx+html"]
              :parameters {:path schema.contract/game-and-id-path-parameter}

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
@@ -113,6 +113,20 @@
                                                                (-> request :parameters :path :eid)
                                                                (-> request :ory-session :identity :id)))))
 
+(defmethod integrant.core/init-key ::organizer-view
+  [_init-key dependencies]
+  (fn [request]
+    (let [eid   (-> request :parameters :path :eid)
+          model (domain/organizer-view-model dependencies
+                                             eid
+                                             (-> request :ory-session :identity :id))]
+      ;; Non-organizers never see the console — respond as if the
+      ;; tournament were absent rather than leaking its existence.
+      (if (and (not= :missing/resource (:type model))
+               (not (:is-organizer model)))
+        {:status 404 :body {:type :missing/resource :name "tournament" :id eid}}
+        (web.view/render-entity-view request "organizer-index.html" model)))))
+
 ;; ─── Player console (check-in + series) ─────────────────────────────────────
 ;;
 ;; Static demo surface for the new player experience. Until check-in,


### PR DESCRIPTION
Closes rts-hgs. Part of the tournament viewer redesign (rts-ysn) — splits the organizer surface onto its own page.

![Organizer console](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/organizer-console/organizer-console-page.png)

## What

A dedicated organizer page at `/view/game/:game-eid/tournament/:eid/organizer.html`, linked from the viewer (the previously-stubbed "Organizer Console — coming soon" link is now live and organizer-gated).

The page carries:
- **Breadcrumb + "Back to Viewer" + "Organizer Only" tag**, with a status/phase header.
- **Quick Actions shelf** — three cards:
  - **Progress Tournament** — one control over the `generate-next-round` state machine. Its wording follows position, and it's gated until the current round fully reports (`2/4 reported`):
    - *round* — more rounds remain in the phase → "Generate Round"
    - *phase* — final round of the phase with more phases to follow → "Advance to Phase N" (phase text)
    - *done* — final round of the final phase; nothing left to generate → disabled "No Rounds Remaining" / "Final Round Reached"
    - *inactive* — tournament not active
  - **Feature a Match** — placeholder card for the featured-match child (rts-sr1).
  - **Open Check-in** — placeholder card for the check-in child.
- **Tabbed management panel** — Phases & Rounds / Entrants / Disputes / Settings (Disputes is a placeholder for rts-j11).
- **Danger Zone** — Complete / Cancel.

The page self-refreshes off the existing `tournament-stage` HX-Trigger.

## How

- **Domain**: `organizer-view-model` extends `tournament-view-model` with the current round's reporting progress (`current-round-progress`) and a single `tournament-progression` summary (`:progress-state`, `:done?`, `:more-phases?`, `:next-phase-number`, `:can-progress?`) the shelf reads. Exported via `rts-domain.contract`.
- **Web**: `::organizer-view` handler — organizer-only; 404s non-organizers as if the tournament were absent. New `/view` route + `configuration.clj` wiring.
- **Template/CSS**: `view/organizer-index.html` + an organizer-console block in `app.css`. The `.tourney-tabs` strip hides its scrollbar (a heading shouldn't scroll-bar) while keeping horizontal scroll on narrow viewports.

### Note on collapsing the two actions
`generate-next-round` is the single phase state-machine entry point in the domain — it seeds the next round and auto-advances the phase when a phase's rounds run out. The shelf therefore exposes one control whose label/text reflects position rather than two buttons hitting the same endpoint.

## Tests
- Domain: `organizer-view-model` progression states (round / phase-advance / gated / terminal / inactive / organizer flag / missing). Full `tournament-test` ns: 56 tests / 95 assertions green.
- E2E: `organizer-console.spec.js` — viewer link, shelf/tabs/danger render, entrants tab, progress-control gating, non-organizer 404. Full suite: 63 passed.
- `cljfmt` clean · `clj-kondo` 0/0 · `poly check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)