### PR TITLE
Harden check-in participant gate against nil user-sub (rts-fng)

### DIFF
--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -1,5 +1,6 @@
 (ns com.devereux-henley.rts-domain.handlers.tournament
   (:require
+   [clojure.string :as str]
    [com.devereux-henley.rts-data-access.contract :as db]
    [com.devereux-henley.rts-domain.handlers.season :as handlers.season]
    [com.devereux-henley.rts-domain.rules.tournament :as rules]
@@ -357,7 +358,11 @@
       (nil? match)
       {:type :tournament/check-in-error :message "Match not found."}
 
-      (not (contains? #{(:player-one-sub match) (:player-two-sub match)} user-sub))
+      (str/blank? user-sub)
+      {:type :tournament/check-in-error :message "Only match participants can check in."}
+
+      (not (contains? (into #{} (remove nil?) [(:player-one-sub match) (:player-two-sub match)])
+                      user-sub))
       {:type :tournament/check-in-error :message "Only match participants can check in."}
 
       (= "complete" (:status match))

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
@@ -765,3 +765,17 @@
                 data-access.contract/record-match-check-in! (fn [& _] (throw (ex-info "must not write" {})))]
     (let [result (handlers.tournament/check-in-player test-deps checkin-match-eid "sigmar_42")]
       (is (= :tournament/checked-in (:type result)) "already-checked player still succeeds after the window closes"))))
+
+(deftest check-in-player-rejects-nil-user-sub
+  ;; A nil user-sub (session with no presence check) must not satisfy the
+  ;; participant gate — even on a bye where player-two-sub is itself nil.
+  (with-redefs [data-access.contract/match-by-eid (fn [_ _] (assoc open-checkin-match :player-two-sub nil))]
+    (let [result (handlers.tournament/check-in-player test-deps checkin-match-eid nil)]
+      (is (= :tournament/check-in-error (:type result)))
+      (is (re-find #"participant" (:message result))))))
+
+(deftest check-in-player-rejects-blank-user-sub
+  (with-redefs [data-access.contract/match-by-eid (fn [_ _] open-checkin-match)]
+    (let [result (handlers.tournament/check-in-player test-deps checkin-match-eid "   ")]
+      (is (= :tournament/check-in-error (:type result)))
+      (is (re-find #"participant" (:message result))))))


### PR DESCRIPTION
## Summary

`check-in-player`'s participant gate was:

```clojure
(contains? #{(:player-one-sub match) (:player-two-sub match)} user-sub)
```

On a bye, `player-two-sub` is `nil`, so the set is `#{p1 nil}`. The web layer reads `(get-in session [:identity :id])` with no presence check, so a `nil` `user-sub` can reach the domain — and `nil` is a member of `#{p1 nil}`, so it **passed** the gate.

Latent today (a bye's check-in window never opens, so the downstream `:window-open?` guard catches it), but the gate's safety rested on that external invariant rather than an explicit check.

## Fix

- Reject a blank/`nil` `user-sub` up front via `str/blank?`.
- Build the participant set with `(remove nil?)` so a `nil` opponent can never admit a `nil` caller.

## Tests

Added two regression tests (`check-in-player-rejects-nil-user-sub`, `check-in-player-rejects-blank-user-sub`). Full `rts-domain` tournament suite: 79 tests, 140 assertions, 0 failures. `cljfmt` and `clj-kondo` clean on changed files.

Closes rts-fng. Follow-up from the rts-928 review (#7, PLAUSIBLE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)