### PR TITLE
Extract shared window-open? predicate with both bounds (rts-68o)

### DIFF
--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -121,16 +121,23 @@
     (instance? Instant x) x
     (instance? Date x)    (.toInstant ^Date x)))
 
+(defn- window-open?
+  "True when `now` falls inside the half-open interval `[opens-at, closes-at)`:
+   at or after the lower bound and strictly before the upper. A nil bound is
+   open-ended on that side. All arguments are `Instant`s."
+  [^Instant now ^Instant opens-at ^Instant closes-at]
+  (and (or (nil? opens-at)  (not (.isBefore now opens-at)))
+       (or (nil? closes-at) (.isBefore now closes-at))))
+
 (defn is-registration-open?
   "Returns true if the tournament state allows new registrations.
    Checks status, time window, and closed-early flag."
   [state now]
   (and (= "registration" (:status state))
        (not (get-in state [:registration :closed-early]))
-       (let [opens-at  (->instant (get-in state [:registration :opens-at]))
-             closes-at (->instant (get-in state [:registration :closes-at]))]
-         (and (or (nil? opens-at)  (not (.isBefore now opens-at)))
-              (or (nil? closes-at) (.isBefore now closes-at))))))
+       (window-open? now
+                     (->instant (get-in state [:registration :opens-at]))
+                     (->instant (get-in state [:registration :closes-at])))))
 
 (defn create-entry
   "Creates a tournament entry for a player. Returns the entry or an error map."
@@ -295,18 +302,17 @@
    `:window-open?` false. `:both-checked?` is the signal the series lobby
    reveals its code."
   [match now]
-  (let [opens-at       (:check-in-opens-at match)
-        closes-at      (:check-in-closes-at match)
-        p1-at          (:player-one-checked-at match)
-        p2-at          (:player-two-checked-at match)
-        opened?        (some? opens-at)
-        closes-at-inst (->instant closes-at)]
+  (let [opens-at  (:check-in-opens-at match)
+        closes-at (:check-in-closes-at match)
+        p1-at     (:player-one-checked-at match)
+        p2-at     (:player-two-checked-at match)
+        opened?   (some? opens-at)]
     {:opens-at              opens-at
      :closes-at             closes-at
      :opened?               opened?
      :window-open?          (boolean (and opened?
                                           (= "pending" (:status match))
-                                          (or (nil? closes-at-inst) (.isBefore now closes-at-inst))))
+                                          (window-open? now (->instant opens-at) (->instant closes-at))))
      :player-one-checked?   (some? p1-at)
      :player-two-checked?   (some? p2-at)
      :player-one-checked-at p1-at

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
@@ -611,6 +611,15 @@
     (is (true? (:opened? s)))
     (is (false? (:window-open? s)))))
 
+(deftest check-in-state-future-open-not-yet-open
+  ;; A future opens-at (scheduled-open path) must report the window closed until
+  ;; now reaches the lower bound — the shared window-open? predicate enforces it.
+  (let [m (assoc checkin-match :check-in-opens-at (minutes-from-now 10)
+                 :check-in-closes-at (minutes-from-now 25))
+        s (handlers.tournament/check-in-state m (Instant/now))]
+    (is (true? (:opened? s)) "the window is configured")
+    (is (false? (:window-open? s)) "but not open until now reaches opens-at")))
+
 (deftest check-in-state-both-checked-signals-lobby
   (let [m (assoc checkin-match
                  :check-in-opens-at (minutes-from-now 0) :check-in-closes-at (minutes-from-now 10)


### PR DESCRIPTION
## Summary

`is-registration-open?` enforced both the `opens-at` lower bound and the `closes-at` upper bound, while `check-in-state`'s `:window-open?` checked **only** the upper bound. The close-bound idiom was duplicated across the two functions (drift risk), and the missing lower bound is a latent bug: once a scheduled-open path sets a future `opens-at` (see rts-1tm), `check-in-player` would accept check-ins *before* the window begins.

## Change

Extracted a private predicate:

```clojure
(defn- window-open? [^Instant now ^Instant opens-at ^Instant closes-at]
  (and (or (nil? opens-at)  (not (.isBefore now opens-at)))
       (or (nil? closes-at) (.isBefore now closes-at))))
```

enforcing the half-open interval `[opens-at, closes-at)` (nil bound = open-ended on that side), and call it from both `is-registration-open?` and `check-in-state`. `check-in-state` keeps its existing `opened?` + `pending` guards; today `open-check-in` always stamps `opens-at = now`, so the added lower bound is a no-op until scheduled-open lands.

## Tests

Added `check-in-state-future-open-not-yet-open` (a future `opens-at` reports the window closed). Full rts-domain tournament suite: 80 tests, 142 assertions, 0 failures. `cljfmt` and `clj-kondo` clean.

Closes rts-68o. Pairs with rts-1tm (scheduled start times). Follow-up from the rts-928 review (#8 + reuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)