### PR TITLE
Synthesize post-write match in check-in mutations (rts-f8a)

### DIFF
--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/tournament.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/tournament.clj
@@ -421,19 +421,22 @@
 (defn open-match-check-in!
   "Open (or extend) the series check-in window on a match, stamping
   `:check-in-opens-at` / `:check-in-closes-at`. Prior per-side check-ins are
-  preserved — re-opening extends the window rather than resetting confirmations."
+  preserved — re-opening extends the window rather than resetting confirmations.
+  Returns the transaction report; the caller synthesizes the post-write match
+  from the pre-write entity it already holds rather than re-reading."
   [conn match-eid {:keys [opens-at closes-at]}]
   (dl/transact!
    conn
    [{:match/eid                match-eid
      :match/check-in-opens-at  (->date opens-at)
      :match/check-in-closes-at (->date closes-at)
-     :match/updated-at         (Date.)}])
-  (match-by-eid conn match-eid))
+     :match/updated-at         (Date.)}]))
 
 (defn record-match-check-in!
   "Record a player's series check-in by stamping the timestamp for their
-  side. `side` is `:player-one` or `:player-two`."
+  side. `side` is `:player-one` or `:player-two`. Returns the transaction
+  report; the caller synthesizes the post-write match from the pre-write
+  entity it already holds rather than re-reading."
   [conn match-eid side checked-at]
   (let [attr (case side
                :player-one :match/player-one-checked-at
@@ -442,8 +445,7 @@
      conn
      [{:match/eid        match-eid
        attr              (->date checked-at)
-       :match/updated-at (Date.)}])
-    (match-by-eid conn match-eid)))
+       :match/updated-at (Date.)}])))
 
 ;;; ─── Game mutations ────────────────────────────────────────────────────────
 

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -344,8 +344,12 @@
             (let [now       (Instant/now)
                   opens-at  (or (->instant (:check-in-opens-at match)) now)
                   closes-at (.plus now (Duration/ofMinutes check-in-window-minutes))
-                  updated   (db/open-match-check-in! conn match-eid
-                                                     {:opens-at opens-at :closes-at closes-at})]
+                  _         (db/open-match-check-in! conn match-eid
+                                                     {:opens-at opens-at :closes-at closes-at})
+                  updated   (assoc match
+                                   :check-in-opens-at  (Date/from opens-at)
+                                   :check-in-closes-at (Date/from closes-at)
+                                   :updated-at         (Date/from now))]
               {:type     :tournament/check-in-opened
                :match    (tag-match updated)
                :check-in (check-in-state updated now)}))))))
@@ -392,7 +396,13 @@
           {:type :tournament/check-in-error :message "The check-in window is not open."}
 
           :else
-          (let [updated (db/record-match-check-in! conn match-eid side now)]
+          (let [checked-key (case side
+                              :player-one :player-one-checked-at
+                              :player-two :player-two-checked-at)
+                _           (db/record-match-check-in! conn match-eid side now)
+                updated     (assoc match
+                                   checked-key (Date/from now)
+                                   :updated-at (Date/from now))]
             {:type     :tournament/checked-in
              :side     side
              :match    (tag-match updated)

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
@@ -632,15 +632,15 @@
 ;; ── open-check-in ──
 
 (deftest open-check-in-opens-window-for-organizer
+  ;; The mutation returns nil — the handler synthesizes the post-write match
+  ;; from the pre-write entity it already holds, not from a read-back.
   (with-redefs [data-access.contract/match-by-eid         (fn [_ _] checkin-match)
                 data-access.contract/tournament-by-eid    (fn [_ _] (assoc test-tournament :created-by-sub "dev-admin"))
-                data-access.contract/open-match-check-in! (fn [_ _ {:keys [opens-at closes-at]}]
-                                                            (assoc checkin-match
-                                                                   :check-in-opens-at (java.util.Date/from opens-at)
-                                                                   :check-in-closes-at (java.util.Date/from closes-at)))]
+                data-access.contract/open-match-check-in! (fn [_ _ _] nil)]
     (let [result (handlers.tournament/open-check-in test-deps checkin-match-eid "dev-admin")]
       (is (= :tournament/check-in-opened (:type result)))
       (is (= :tournament/match (get-in result [:match :type])))
+      (is (some? (get-in result [:match :check-in-opens-at])) "opens-at stamped on the synthesized match")
       (is (true? (get-in result [:check-in :window-open?]))))))
 
 (deftest open-check-in-rejects-non-organizer
@@ -671,24 +671,21 @@
          :check-in-closes-at (minutes-from-now 10)))
 
 (deftest check-in-player-records-participant
+  ;; The mutation returns nil — the handler stamps the checked-at locally.
   (with-redefs [data-access.contract/match-by-eid           (fn [_ _] open-checkin-match)
-                data-access.contract/record-match-check-in! (fn [_ _ side at]
-                                                              (assoc open-checkin-match
-                                                                     (case side
-                                                                       :player-one :player-one-checked-at
-                                                                       :player-two :player-two-checked-at)
-                                                                     (java.util.Date/from at)))]
+                data-access.contract/record-match-check-in! (fn [_ _ _side _at] nil)]
     (let [result (handlers.tournament/check-in-player test-deps checkin-match-eid "sigmar_42")]
       (is (= :tournament/checked-in (:type result)))
       (is (= :player-one (:side result)))
+      (is (some? (get-in result [:match :player-one-checked-at])) "checked-at stamped on the synthesized match")
       (is (true? (get-in result [:check-in :player-one-checked?]))))))
 
 (deftest check-in-player-second-side-maps-to-player-two
   (with-redefs [data-access.contract/match-by-eid           (fn [_ _] open-checkin-match)
-                data-access.contract/record-match-check-in! (fn [_ _ _side at]
-                                                              (assoc open-checkin-match :player-two-checked-at (java.util.Date/from at)))]
+                data-access.contract/record-match-check-in! (fn [_ _ _side _at] nil)]
     (let [result (handlers.tournament/check-in-player test-deps checkin-match-eid "chaos_undivided")]
-      (is (= :player-two (:side result))))))
+      (is (= :player-two (:side result)))
+      (is (true? (get-in result [:check-in :player-two-checked?]))))))
 
 (deftest check-in-player-rejects-non-participant
   (with-redefs [data-access.contract/match-by-eid (fn [_ _] open-checkin-match)]
@@ -758,9 +755,7 @@
                   data-access.contract/tournament-by-eid    (fn [_ _] (assoc test-tournament :created-by-sub "dev-admin"))
                   data-access.contract/open-match-check-in! (fn [_ _ window]
                                                               (reset! captured window)
-                                                              (assoc checkin-match
-                                                                     :check-in-opens-at (java.util.Date/from (:opens-at window))
-                                                                     :check-in-closes-at (java.util.Date/from (:closes-at window))))]
+                                                              nil)]
       (let [result (handlers.tournament/open-check-in test-deps checkin-match-eid "dev-admin")]
         (is (= :tournament/check-in-opened (:type result)))
         (is (= (.toInstant original) (:opens-at @captured)) "re-open keeps the original open time")


### PR DESCRIPTION
## Summary

`open-match-check-in!` and `record-match-check-in!` each re-pulled the full match (16 attrs + the `{:match/tournament [:tournament/eid]}` join) via `match-by-eid` immediately after the write — purely to return it. The domain handler already holds the pre-write match and the freshly-stamped `Instant`; the only delta a read-back provides is the `Instant`→`Date` type, which the handler can synthesize locally.

## Change

- **Data-access:** both check-in mutations drop the trailing `match-by-eid` read-back (they now return the transaction report).
- **Domain:** `open-check-in` / `check-in-player` build the returned match with `(assoc match <stamped-fields>)` from the entity they already hold.

This removes one full match read per check-in. On a large bracket's round-rollover that's ~2 redundant pulls per check-in (3 round-trips → 2: the validation read + the write, no read-back).

## Tests

The mutation stubs now return `nil`, proving the handler synthesizes the result locally rather than relying on a read-back; added assertions that the stamped fields (`check-in-opens-at`, `player-*-checked-at`) appear on the synthesized `:match`. Full rts-domain tournament suite: 80 tests, 145 assertions, 0 failures. `clojure -M:poly check`, `cljfmt`, and `clj-kondo` all clean.

Closes rts-f8a. Follow-up from the rts-928 review (#10, CONFIRMED, efficiency/cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)