### PR TITLE
Issue series lobby code on series check-in (rts-xe7)

### DIFF
--- a/components/e2e/tests/player-series-lobby.spec.js
+++ b/components/e2e/tests/player-series-lobby.spec.js
@@ -1,9 +1,9 @@
 // Series lobby panel (rts-xe7): the player check-in view reveals the single
-// series lobby code once both sides have checked in. The player console is a
-// demo surface until rts-pwd wires real view-models, so this exercises the
-// template + component rendering end to end (code, copy, host/format/patch/
-// reinforcements, caster, launcher). Touching components/e2e also keeps the
-// brick in the poly test set for this PR.
+// series lobby once both sides have checked in. The player console is a demo
+// surface until rts-pwd wires real view-models, so this exercises the template
+// + component rendering end to end (lobby name + passcode each with a copy
+// button, and the host/format/patch/reinforce setup grid). Touching
+// components/e2e also keeps the brick in the poly test set for this PR.
 
 const { test, expect } = require('@playwright/test');
 
@@ -49,7 +49,7 @@ test.describe('Series lobby panel', () => {
     ]);
   });
 
-  test('check-in view reveals the series lobby code and setup', async ({ page, request }) => {
+  test('check-in view reveals the series lobby and setup', async ({ page, request }) => {
     const eid = await createTournament(request);
     await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/player/check-in.html`);
 
@@ -57,26 +57,25 @@ test.describe('Series lobby panel', () => {
     await expect(lobby).toBeVisible();
     await expect(lobby.locator('#lobby-heading')).toContainText('Series Lobby');
 
-    // One thematic code (WORD-XXXX) issued for the whole series.
-    await expect(lobby.locator('.lobby-code')).toHaveText(/^[A-Z]+-[0-9A-F]{4}$/);
+    // One thematic lobby name (WORD-XXXX) issued for the whole series, plus the
+    // passcode players join with — each copyable.
+    await expect(lobby.locator('#lobby-code')).toHaveText(/^[A-Z]+-[0-9A-F]{4}$/);
+    await expect(lobby.locator('#lobby-passcode')).not.toBeEmpty();
 
-    // Host / Format / Patch / Reinforcements setup the host applies.
+    // Host / Format / Patch / Reinforce setup the host applies.
     await expect(lobby.locator('.lobby-fields dt')).toHaveText(
-      ['Host', 'Format', 'Patch', 'Reinforcements'],
+      ['Host', 'Format', 'Patch', 'Reinforce'],
     );
-
-    // Caster spectator slot and the launcher shortcut.
-    await expect(lobby.locator('.lobby-caster')).toContainText('Caster spectator');
-    await expect(lobby.locator('a.btn-primary-lg', { hasText: 'Open in launcher' })).toBeVisible();
   });
 
-  test('copy button copies the lobby code and confirms', async ({ page, request, context }) => {
+  test('copy button copies the lobby name and confirms', async ({ page, request, context }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
     const eid = await createTournament(request);
     await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/player/check-in.html`);
 
-    const code = await page.locator('.lobby-code').textContent();
-    const copy = page.locator('.lobby-copy');
+    const block = page.locator('.lobby-code-block').first();
+    const code = await block.locator('#lobby-code').textContent();
+    const copy = block.locator('.lobby-copy');
     await copy.click();
     await expect(copy).toContainText('Copied');
 

--- a/components/e2e/tests/player-series-lobby.spec.js
+++ b/components/e2e/tests/player-series-lobby.spec.js
@@ -1,0 +1,86 @@
+// Series lobby panel (rts-xe7): the player check-in view reveals the single
+// series lobby code once both sides have checked in. The player console is a
+// demo surface until rts-pwd wires real view-models, so this exercises the
+// template + component rendering end to end (code, copy, host/format/patch/
+// reinforcements, caster, launcher). Touching components/e2e also keeps the
+// brick in the poly test set for this PR.
+
+const { test, expect } = require('@playwright/test');
+
+const BASE = process.env.RTS_API_BASE_URL || 'http://127.0.0.1:3001';
+const GAME_EID = 'eea787d7-1065-45eb-a3f6-e26f32c294a1';
+
+function actionHeaders(user) {
+  return {
+    Accept: 'application/htmx+html',
+    'Content-Type': 'application/json',
+    Cookie: `dev_impersonation=${user}`,
+  };
+}
+
+async function createTournament(request) {
+  const eid = crypto.randomUUID();
+  const res = await request.put(`${BASE}/actions/tournament/${eid}?version=1`, {
+    headers: actionHeaders('dev-admin'),
+    data: {
+      'game-eid': GAME_EID,
+      name: 'E2E Lobby Tournament',
+      description: 'Created by the series lobby e2e test.',
+      timezone: 'UTC',
+      'registration-opens-at': '2020-01-01T00:00',
+      'registration-closes-at': '2030-01-01T00:00',
+    },
+  });
+  expect(res.status()).toBe(200);
+  return eid;
+}
+
+test.describe('Series lobby panel', () => {
+  test.beforeEach(async ({ context }) => {
+    await context.addCookies([
+      {
+        name: 'dev_impersonation',
+        value: 'dev-admin',
+        domain: 'localhost',
+        path: '/',
+        httpOnly: true,
+        sameSite: 'Lax',
+      },
+    ]);
+  });
+
+  test('check-in view reveals the series lobby code and setup', async ({ page, request }) => {
+    const eid = await createTournament(request);
+    await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/player/check-in.html`);
+
+    const lobby = page.locator('.lobby-panel');
+    await expect(lobby).toBeVisible();
+    await expect(lobby.locator('#lobby-heading')).toContainText('Series Lobby');
+
+    // One thematic code (WORD-XXXX) issued for the whole series.
+    await expect(lobby.locator('.lobby-code')).toHaveText(/^[A-Z]+-[0-9A-F]{4}$/);
+
+    // Host / Format / Patch / Reinforcements setup the host applies.
+    await expect(lobby.locator('.lobby-fields dt')).toHaveText(
+      ['Host', 'Format', 'Patch', 'Reinforcements'],
+    );
+
+    // Caster spectator slot and the launcher shortcut.
+    await expect(lobby.locator('.lobby-caster')).toContainText('Caster spectator');
+    await expect(lobby.locator('a.btn-primary-lg', { hasText: 'Open in launcher' })).toBeVisible();
+  });
+
+  test('copy button copies the lobby code and confirms', async ({ page, request, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const eid = await createTournament(request);
+    await page.goto(`/view/game/${GAME_EID}/tournament/${eid}/player/check-in.html`);
+
+    const code = await page.locator('.lobby-code').textContent();
+    const copy = page.locator('.lobby-copy');
+    await copy.click();
+    await expect(copy).toContainText('Copied');
+
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toBe(code.trim());
+  });
+});

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
@@ -137,6 +137,7 @@
 (def update-match-result!            query.datalog.tournament/update-match-result!)
 (def open-match-check-in!            query.datalog.tournament/open-match-check-in!)
 (def record-match-check-in!          query.datalog.tournament/record-match-check-in!)
+(def set-match-lobby-code!           query.datalog.tournament/set-match-lobby-code!)
 (def create-game!                    query.datalog.tournament/create-game!)
 (def games-for-match                 query.datalog.tournament/games-for-match)
 

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/tournament.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/tournament.clj
@@ -60,6 +60,7 @@
    :match/status :match/format
    :match/check-in-opens-at :match/check-in-closes-at
    :match/player-one-checked-at :match/player-two-checked-at
+   :match/lobby-code
    :match/created-at :match/updated-at
    {:match/tournament [:tournament/eid]}])
 
@@ -135,6 +136,7 @@
      :check-in-closes-at    (:match/check-in-closes-at m)
      :player-one-checked-at (:match/player-one-checked-at m)
      :player-two-checked-at (:match/player-two-checked-at m)
+     :lobby-code            (:match/lobby-code m)
      :created-at            (:match/created-at m)
      :updated-at            (:match/updated-at m)}))
 
@@ -446,6 +448,18 @@
      [{:match/eid        match-eid
        attr              (->date checked-at)
        :match/updated-at (Date.)}])))
+
+(defn set-match-lobby-code!
+  "Stamp the series lobby code on a match. Issued once both sides check in
+  and reused for every game of the series. Returns the transaction report;
+  the caller synthesizes the post-write match from the pre-write entity it
+  already holds rather than re-reading."
+  [conn match-eid lobby-code]
+  (dl/transact!
+   conn
+   [{:match/eid        match-eid
+     :match/lobby-code lobby-code
+     :match/updated-at (Date.)}]))
 
 ;;; ─── Game mutations ────────────────────────────────────────────────────────
 

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/match.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/match.clj
@@ -13,7 +13,10 @@
   `:match/check-in-closes-at` bound the window the organizer opens, and
   `:match/player-one-checked-at` / `:match/player-two-checked-at` record
   when each side confirmed. A side is checked in once its timestamp is
-  present; both present is the signal the series lobby reveals.")
+  present; both present is the signal the series lobby reveals.
+  `:match/lobby-code` is the single in-game lobby code issued when both
+  sides check in — one code for the whole best-of-N, not regenerated per
+  game.")
 
 (def schema
   {:match/eid                   {:db/valueType :db.type/uuid
@@ -31,6 +34,7 @@
    :match/check-in-closes-at    {:db/valueType :db.type/instant}
    :match/player-one-checked-at {:db/valueType :db.type/instant}
    :match/player-two-checked-at {:db/valueType :db.type/instant}
+   :match/lobby-code            {:db/valueType :db.type/string}
    :match/created-at            {:db/valueType :db.type/instant}
    :match/updated-at            {:db/valueType :db.type/instant}
    :match/games                 {:db/valueType   :db.type/ref

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
@@ -160,6 +160,7 @@
 (def series-current-game-num                      rules.tournament/series-current-game-num)
 (def series-win-counts                            rules.tournament/series-win-counts)
 (def series-clinches?                             rules.tournament/series-clinches?)
+(def lobby-code                                   rules.tournament/lobby-code)
 
 ;;; ─── League / Season / Stats schemas ───────────────────────────────────────
 

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -317,7 +317,23 @@
      :player-two-checked?   (some? p2-at)
      :player-one-checked-at p1-at
      :player-two-checked-at p2-at
-     :both-checked?         (and (some? p1-at) (some? p2-at))}))
+     :both-checked?         (and (some? p1-at) (some? p2-at))
+     :lobby-code            (:lobby-code match)}))
+
+(defn- ensure-lobby-code
+  "Issues and persists the series lobby code on `match` the first time both
+   sides are checked in, returning the match with `:lobby-code` set. A match
+   that is not yet both-checked, or already carries a code, is returned
+   unchanged — the code is issued once and reused for every game of the
+   series (see `rules/lobby-code`)."
+  [conn match]
+  (if (and (some? (:player-one-checked-at match))
+           (some? (:player-two-checked-at match))
+           (str/blank? (:lobby-code match)))
+    (let [code (rules/lobby-code (:eid match))]
+      (db/set-match-lobby-code! conn (:eid match) code)
+      (assoc match :lobby-code code))
+    match))
 
 (defn open-check-in
   "Opens the series check-in window on a match. Only the tournament organizer
@@ -388,9 +404,11 @@
         (cond
           ;; Idempotent re-check — succeed without a second write, regardless of
           ;; whether the window has since closed (a double-submit shouldn't 422).
+          ;; Backfills the lobby code should both sides be checked in without one.
           already?
-          {:type  :tournament/checked-in :side     side
-           :match (tag-match match)      :check-in state}
+          (let [match (ensure-lobby-code conn match)]
+            {:type  :tournament/checked-in :side     side
+             :match (tag-match match)      :check-in (check-in-state match now)})
 
           (not (:window-open? state))
           {:type :tournament/check-in-error :message "The check-in window is not open."}
@@ -400,9 +418,11 @@
                               :player-one :player-one-checked-at
                               :player-two :player-two-checked-at)
                 _           (db/record-match-check-in! conn match-eid side now)
-                updated     (assoc match
-                                   checked-key (Date/from now)
-                                   :updated-at (Date/from now))]
+                updated     (ensure-lobby-code
+                             conn
+                             (assoc match
+                                    checked-key (Date/from now)
+                                    :updated-at (Date/from now)))]
             {:type     :tournament/checked-in
              :side     side
              :match    (tag-match updated)

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/rules/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/rules/tournament.clj
@@ -1,4 +1,6 @@
-(ns com.devereux-henley.rts-domain.rules.tournament)
+(ns com.devereux-henley.rts-domain.rules.tournament
+  (:require
+   [clojure.string :as str]))
 
 ;; Tournament status lifecycle:
 ;;   registration → active → complete
@@ -108,6 +110,27 @@
    threshold?"
   [current-wins format]
   (>= (inc current-wins) (match-win-threshold format)))
+
+;; ─── Series lobby code ───────────────────────────────────────────────────────
+
+(def ^:private lobby-code-words
+  "Thematic prefixes for series lobby codes — one is chosen deterministically
+   from the match eid."
+  ["KARAK" "ALTDORF" "NAGGAROND" "LUSTRIA" "KISLEV" "CATHAY" "NULN"
+   "MIDDENHEIM" "ULTHUAN" "SYLVANIA" "GROMRIL" "ZHUFBAR" "ATHEL" "EATAINE"
+   "AVELORN" "CARCASSONNE"])
+
+(defn lobby-code
+  "Derives the series lobby code for a match from its `eid` — a thematic word
+   joined to a four-character hex suffix (e.g. `KARAK-3F9A`). Pure and
+   deterministic: the same match always yields the same code, so it can be
+   reissued idempotently and stays constant across every game of the series."
+  [eid]
+  (let [hex    (str/replace (str eid) "-" "")
+        word   (nth lobby-code-words (mod (Long/parseLong (subs hex 0 8) 16)
+                                          (count lobby-code-words)))
+        suffix (str/upper-case (subs hex 8 12))]
+    (str word "-" suffix)))
 
 ;; ─── Swiss pairing ──────────────────────────────────────────────────────────
 

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/schema.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/schema.clj
@@ -250,6 +250,7 @@
      [:check-in-closes-at {:optional true} [:maybe inst?]]
      [:player-one-checked-at {:optional true} [:maybe inst?]]
      [:player-two-checked-at {:optional true} [:maybe inst?]]
+     [:lobby-code {:optional true} [:maybe :string]]
      [:_links
       [:map
        [:self :url]

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.test :refer [deftest is]]
    [com.devereux-henley.rts-data-access.contract :as data-access.contract]
-   [com.devereux-henley.rts-domain.handlers.tournament :as handlers.tournament])
+   [com.devereux-henley.rts-domain.handlers.tournament :as handlers.tournament]
+   [com.devereux-henley.rts-domain.rules.tournament :as rules.tournament])
   (:import
    [java.time Instant LocalDateTime ZoneId]
    [java.util UUID]))
@@ -783,3 +784,59 @@
     (let [result (handlers.tournament/check-in-player test-deps checkin-match-eid "   ")]
       (is (= :tournament/check-in-error (:type result)))
       (is (re-find #"participant" (:message result))))))
+
+;; ── series lobby code ──
+
+(deftest check-in-player-issues-lobby-code-when-both-checked
+  ;; The second side checking in flips both-checked? — a lobby code is issued,
+  ;; persisted, and surfaced on the synthesized match + derived state.
+  (let [captured (atom nil)]
+    (with-redefs [data-access.contract/match-by-eid           (fn [_ _] (assoc open-checkin-match
+                                                                               :player-one-checked-at (minutes-from-now 0)))
+                  data-access.contract/record-match-check-in! (fn [_ _ _side _at] nil)
+                  data-access.contract/set-match-lobby-code!  (fn [_ _eid code] (reset! captured code) nil)]
+      (let [result   (handlers.tournament/check-in-player test-deps checkin-match-eid "chaos_undivided")
+            expected (rules.tournament/lobby-code checkin-match-eid)]
+        (is (= :tournament/checked-in (:type result)))
+        (is (= expected @captured) "the issued code is persisted")
+        (is (= expected (get-in result [:match :lobby-code])) "code on the synthesized match")
+        (is (= expected (get-in result [:check-in :lobby-code])) "code on the derived state")
+        (is (true? (get-in result [:check-in :both-checked?])))))))
+
+(deftest check-in-player-no-lobby-code-when-only-one-checked
+  ;; The first side checking in must not issue a code — both sides are required.
+  (with-redefs [data-access.contract/match-by-eid           (fn [_ _] open-checkin-match)
+                data-access.contract/record-match-check-in! (fn [_ _ _side _at] nil)
+                data-access.contract/set-match-lobby-code!  (fn [& _] (throw (ex-info "must not issue a code with one side checked" {})))]
+    (let [result (handlers.tournament/check-in-player test-deps checkin-match-eid "sigmar_42")]
+      (is (= :tournament/checked-in (:type result)))
+      (is (nil? (get-in result [:match :lobby-code])))
+      (is (nil? (get-in result [:check-in :lobby-code]))))))
+
+(deftest check-in-player-does-not-reissue-existing-lobby-code
+  ;; A re-check on a both-checked match that already carries a code reuses it —
+  ;; one code for the whole series, never regenerated.
+  (with-redefs [data-access.contract/match-by-eid           (fn [_ _] (assoc open-checkin-match
+                                                                             :player-one-checked-at (minutes-from-now 0)
+                                                                             :player-two-checked-at (minutes-from-now 0)
+                                                                             :lobby-code "KARAK-ABCD"))
+                data-access.contract/record-match-check-in! (fn [& _] (throw (ex-info "should not write on re-check" {})))
+                data-access.contract/set-match-lobby-code!  (fn [& _] (throw (ex-info "should not reissue an existing code" {})))]
+    (let [result (handlers.tournament/check-in-player test-deps checkin-match-eid "sigmar_42")]
+      (is (= :tournament/checked-in (:type result)))
+      (is (= "KARAK-ABCD" (get-in result [:check-in :lobby-code]))))))
+
+(deftest check-in-player-backfills-missing-lobby-code-on-recheck
+  ;; A both-checked match missing its code (e.g. checked in before the feature)
+  ;; gets one backfilled on the next idempotent re-check.
+  (let [captured (atom nil)]
+    (with-redefs [data-access.contract/match-by-eid           (fn [_ _] (assoc open-checkin-match
+                                                                               :player-one-checked-at (minutes-from-now 0)
+                                                                               :player-two-checked-at (minutes-from-now 0)))
+                  data-access.contract/record-match-check-in! (fn [& _] (throw (ex-info "should not write on re-check" {})))
+                  data-access.contract/set-match-lobby-code!  (fn [_ _eid code] (reset! captured code) nil)]
+      (let [result   (handlers.tournament/check-in-player test-deps checkin-match-eid "sigmar_42")
+            expected (rules.tournament/lobby-code checkin-match-eid)]
+        (is (= :tournament/checked-in (:type result)))
+        (is (= expected @captured) "the missing code is backfilled")
+        (is (= expected (get-in result [:check-in :lobby-code])))))))

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/rules/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/rules/tournament_test.clj
@@ -374,3 +374,21 @@
   (is (true? (rules/series-clinches? 2 5))  "2 wins + 1 = 3 → clinches Bo5")
   (is (false? (rules/series-clinches? 1 5)) "1 win + 1 = 2 → does not clinch Bo5")
   (is (true? (rules/series-clinches? 0 1))  "1 win clinches Bo1"))
+
+;; ─── lobby-code ─────────────────────────────────────────────────────────────
+
+(deftest lobby-code-is-deterministic
+  (let [eid (java.util.UUID/fromString "b1f2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d")]
+    (is (= (rules/lobby-code eid) (rules/lobby-code eid))
+        "the same match always yields the same code")))
+
+(deftest lobby-code-format
+  (let [code (rules/lobby-code
+              (java.util.UUID/fromString "b1f2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"))]
+    (is (re-matches #"[A-Z]+-[0-9A-F]{4}" code)
+        "a thematic word joined to a four-character hex suffix")))
+
+(deftest lobby-code-distinguishes-matches
+  (let [a (rules/lobby-code (java.util.UUID/fromString "00000000-0000-0000-0000-000000000000"))
+        b (rules/lobby-code (java.util.UUID/fromString "ffffffff-ffff-ffff-ffff-ffffffffffff"))]
+    (is (not= a b) "different matches get different codes")))

--- a/components/rts-web/resources/rts-web/asset/style/app.css
+++ b/components/rts-web/resources/rts-web/asset/style/app.css
@@ -3480,6 +3480,7 @@ table.standings-table tbody tr td.col-num::before {
   border: 1px solid color-mix(in srgb, var(--color-primary-500) 45%, var(--color-border));
 }
 @media (max-width: 720px) { .lobby-code-block { grid-template-columns: 1fr; } }
+.lobby-code-block + .lobby-code-block { margin-top: var(--space-3); }
 .lobby-code {
   display: block;
   margin-top: 2px;
@@ -3492,11 +3493,11 @@ table.standings-table tbody tr td.col-num::before {
 .lobby-copy { white-space: nowrap; }
 .lobby-fields {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: var(--space-3);
   margin: var(--space-4) 0 0;
 }
-@media (max-width: 720px) { .lobby-fields { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 720px) { .lobby-fields { grid-template-columns: 1fr; } }
 .lobby-field {
   padding: var(--space-3);
   border: 1px solid var(--color-border);
@@ -3507,17 +3508,6 @@ table.standings-table tbody tr td.col-num::before {
   font-size: 0.9rem;
   color: var(--color-text-strong);
 }
-.lobby-caster {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: var(--space-2);
-  margin-top: var(--space-4);
-  padding-top: var(--space-4);
-  border-top: 1px solid var(--color-border);
-}
-.lobby-caster-note { font-size: 0.78rem; color: var(--color-text-muted); }
-.lobby-panel .btn-primary-lg { margin-top: var(--space-4); }
 
 /* --- Series progress strip ---------------------------------------------- */
 .series-progress {

--- a/components/rts-web/resources/rts-web/asset/style/app.css
+++ b/components/rts-web/resources/rts-web/asset/style/app.css
@@ -3468,6 +3468,57 @@ table.standings-table tbody tr td.col-num::before {
 }
 .btn-primary-lg:focus-visible { outline: 2px solid var(--color-primary-700); outline-offset: 2px; }
 
+/* --- Series lobby panel -------------------------------------------------- */
+.lobby-panel { border-color: color-mix(in srgb, var(--color-primary-500) 40%, var(--color-border)); }
+.lobby-code-block {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-4);
+  align-items: center;
+  padding: var(--space-4) var(--space-5);
+  background: color-mix(in srgb, var(--color-primary-500) 10%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-primary-500) 45%, var(--color-border));
+}
+@media (max-width: 720px) { .lobby-code-block { grid-template-columns: 1fr; } }
+.lobby-code {
+  display: block;
+  margin-top: 2px;
+  font-family: var(--font-family-mono);
+  font-size: 1.7rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  color: var(--color-primary-700);
+}
+.lobby-copy { white-space: nowrap; }
+.lobby-fields {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-3);
+  margin: var(--space-4) 0 0;
+}
+@media (max-width: 720px) { .lobby-fields { grid-template-columns: repeat(2, 1fr); } }
+.lobby-field {
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+.lobby-field dd {
+  margin: 4px 0 0;
+  font-size: 0.9rem;
+  color: var(--color-text-strong);
+}
+.lobby-caster {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-border);
+}
+.lobby-caster-note { font-size: 0.78rem; color: var(--color-text-muted); }
+.lobby-panel .btn-primary-lg { margin-top: var(--space-4); }
+
 /* --- Series progress strip ---------------------------------------------- */
 .series-progress {
   background: var(--color-surface);

--- a/components/rts-web/resources/rts-web/components/tournament/series-lobby-panel.html
+++ b/components/rts-web/resources/rts-web/components/tournament/series-lobby-panel.html
@@ -1,32 +1,46 @@
 {# Series lobby panel — revealed once both players have checked in. Shows the
-   single in-game lobby code for the whole best-of-N (code + copy), the lobby
-   setup the host applies (host / format / patch / reinforcements), the caster
-   holding the spectator slot, and a shortcut into the game launcher. Expects a
-   `lobby` map: {code host format patch reinforcements caster launcher-url}. #}
+   one in-game lobby that carries the whole best-of-N: the lobby name and
+   passcode (each with a copy button) used to join every game, plus the setup
+   the host applies (host / format / patch / reinforcements). Expects a `lobby`
+   map: {code passcode host host-you? format patch reinforcements}. #}
 <section class="panel lobby-panel" aria-labelledby="lobby-heading">
     <header class="panel-head">
         <h2 class="panel-title" id="lobby-heading">Series Lobby · {{match-label}}</h2>
-        <span class="panel-subtitle">One code for all {{total-games|default:five}} games — set it once, stay in the lobby</span>
+        <span class="panel-subtitle">One lobby for all {{total-games|default:five}} games — set it once, stay in the lobby</span>
     </header>
     <div class="panel-body">
         <div class="lobby-code-block">
             <div class="lobby-code-info">
-                <div class="eyebrow">Lobby code</div>
+                <div class="eyebrow">Lobby name</div>
                 <code class="lobby-code" id="lobby-code">{{lobby.code}}</code>
             </div>
             <button type="button" class="btn btn-secondary lobby-copy"
-                    aria-label="Copy lobby code {{lobby.code}}"
+                    aria-label="Copy lobby name {{lobby.code}}"
                     _="on click call navigator.clipboard.writeText('{{lobby.code}}')
                        then set my textContent to 'Copied ✓'
-                       then wait 1.5s then set my textContent to 'Copy code'">
-                Copy code
+                       then wait 1.5s then set my textContent to 'Copy'">
+                Copy
+            </button>
+        </div>
+
+        <div class="lobby-code-block">
+            <div class="lobby-code-info">
+                <div class="eyebrow">Passcode</div>
+                <code class="lobby-code" id="lobby-passcode">{{lobby.passcode}}</code>
+            </div>
+            <button type="button" class="btn btn-secondary lobby-copy"
+                    aria-label="Copy passcode {{lobby.passcode}}"
+                    _="on click call navigator.clipboard.writeText('{{lobby.passcode}}')
+                       then set my textContent to 'Copied ✓'
+                       then wait 1.5s then set my textContent to 'Copy'">
+                Copy
             </button>
         </div>
 
         <dl class="lobby-fields">
             <div class="lobby-field">
                 <dt class="eyebrow">Host</dt>
-                <dd class="mono">{{lobby.host}}</dd>
+                <dd class="mono">{{lobby.host}}{% if lobby.host-you? %} <span class="muted">(you)</span>{% endif %}</dd>
             </div>
             <div class="lobby-field">
                 <dt class="eyebrow">Format</dt>
@@ -37,23 +51,9 @@
                 <dd class="mono">{{lobby.patch}}</dd>
             </div>
             <div class="lobby-field">
-                <dt class="eyebrow">Reinforcements</dt>
+                <dt class="eyebrow">Reinforce</dt>
                 <dd class="mono">{{lobby.reinforcements}}</dd>
             </div>
         </dl>
-
-        <div class="lobby-caster">
-            <span class="eyebrow">Caster spectator</span>
-            {% if lobby.caster %}
-            <span class="mono">{{lobby.caster}}</span>
-            <span class="lobby-caster-note">— invite them to the lobby before game 1</span>
-            {% else %}
-            <span class="mono muted">No caster assigned</span>
-            {% endif %}
-        </div>
-
-        <a class="btn-primary-lg" href="{{lobby.launcher-url}}">
-            Open in launcher
-        </a>
     </div>
 </section>

--- a/components/rts-web/resources/rts-web/components/tournament/series-lobby-panel.html
+++ b/components/rts-web/resources/rts-web/components/tournament/series-lobby-panel.html
@@ -1,0 +1,59 @@
+{# Series lobby panel — revealed once both players have checked in. Shows the
+   single in-game lobby code for the whole best-of-N (code + copy), the lobby
+   setup the host applies (host / format / patch / reinforcements), the caster
+   holding the spectator slot, and a shortcut into the game launcher. Expects a
+   `lobby` map: {code host format patch reinforcements caster launcher-url}. #}
+<section class="panel lobby-panel" aria-labelledby="lobby-heading">
+    <header class="panel-head">
+        <h2 class="panel-title" id="lobby-heading">Series Lobby · {{match-label}}</h2>
+        <span class="panel-subtitle">One code for all {{total-games|default:five}} games — set it once, stay in the lobby</span>
+    </header>
+    <div class="panel-body">
+        <div class="lobby-code-block">
+            <div class="lobby-code-info">
+                <div class="eyebrow">Lobby code</div>
+                <code class="lobby-code" id="lobby-code">{{lobby.code}}</code>
+            </div>
+            <button type="button" class="btn btn-secondary lobby-copy"
+                    aria-label="Copy lobby code {{lobby.code}}"
+                    _="on click call navigator.clipboard.writeText('{{lobby.code}}')
+                       then set my textContent to 'Copied ✓'
+                       then wait 1.5s then set my textContent to 'Copy code'">
+                Copy code
+            </button>
+        </div>
+
+        <dl class="lobby-fields">
+            <div class="lobby-field">
+                <dt class="eyebrow">Host</dt>
+                <dd class="mono">{{lobby.host}}</dd>
+            </div>
+            <div class="lobby-field">
+                <dt class="eyebrow">Format</dt>
+                <dd class="mono">{{lobby.format}}</dd>
+            </div>
+            <div class="lobby-field">
+                <dt class="eyebrow">Patch</dt>
+                <dd class="mono">{{lobby.patch}}</dd>
+            </div>
+            <div class="lobby-field">
+                <dt class="eyebrow">Reinforcements</dt>
+                <dd class="mono">{{lobby.reinforcements}}</dd>
+            </div>
+        </dl>
+
+        <div class="lobby-caster">
+            <span class="eyebrow">Caster spectator</span>
+            {% if lobby.caster %}
+            <span class="mono">{{lobby.caster}}</span>
+            <span class="lobby-caster-note">— invite them to the lobby before game 1</span>
+            {% else %}
+            <span class="mono muted">No caster assigned</span>
+            {% endif %}
+        </div>
+
+        <a class="btn-primary-lg" href="{{lobby.launcher-url}}">
+            Open in launcher
+        </a>
+    </div>
+</section>

--- a/components/rts-web/resources/rts-web/view/player-check-in.html
+++ b/components/rts-web/resources/rts-web/view/player-check-in.html
@@ -20,9 +20,9 @@
                     <div>
                         <h3 class="checkin-headline">Confirm you're ready for this series</h3>
                         <p class="checkin-sub">
-                            You only check in once for the whole Bo5. The series lobby code is revealed
-                            as soon as both you and your opponent confirm — share it with the caster,
-                            then play through all five games in the same lobby.
+                            You only check in once for the whole Bo5. The series lobby is revealed
+                            as soon as both you and your opponent confirm — join it once, then play
+                            through all five games in the same lobby.
                         </p>
                     </div>
                     <a class="btn-primary-lg"

--- a/components/rts-web/resources/rts-web/view/player-check-in.html
+++ b/components/rts-web/resources/rts-web/view/player-check-in.html
@@ -61,6 +61,10 @@
             </div>
         </section>
 
+        {% if lobby %}
+        {% include "rts-web/components/tournament/series-lobby-panel.html" %}
+        {% endif %}
+
         <section class="panel" aria-labelledby="path-heading">
             <header class="panel-head">
                 <h2 class="panel-title" id="path-heading">Your Path to the Crown</h2>

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
@@ -156,6 +156,18 @@
    {:num          5   :map          "Skull Pass — Winter" :result nil      :winner nil
     :submitted-by nil :confirmed-by nil                   :size   "5.2 MB"}])
 
+(def ^:private demo-lobby
+  "Demo series-lobby setup revealed once both sides check in. The code is the
+   real `domain/lobby-code` derivation over a fixed demo match eid so the
+   panel mirrors what the live flow issues."
+  {:code           (domain/lobby-code #uuid "b1f2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d")
+   :host           "sigmar_42"
+   :format         "Best of 5"
+   :patch          "8.0"
+   :reinforcements "Disabled"
+   :caster         "grand_marshal_cast"
+   :launcher-url   "totalwar://lobby/join"})
+
 (def ^:private demo-path
   [{:stage "Group Stage A" :label "3-0" :state "done" :detail "Top seed Group A"}
    {:stage "QF 1" :label "vs chaos_undivided" :state "active" :detail "Bo5 · live"}
@@ -251,7 +263,8 @@
                                       :opponent             demo-player-opponent
                                       :path                 demo-path
                                       :check-in-window      "Window closes at 13:55 UTC · 7 min remaining · one check-in covers all five games"
-                                      :opponent-checked-in? true})))))
+                                      :opponent-checked-in? true
+                                      :lobby                demo-lobby})))))
 
 (defn- find-current-player-match
   "Returns the earliest pending match (lowest phase-index, then round-index)

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
@@ -157,16 +157,17 @@
     :submitted-by nil :confirmed-by nil                   :size   "5.2 MB"}])
 
 (def ^:private demo-lobby
-  "Demo series-lobby setup revealed once both sides check in. The code is the
-   real `domain/lobby-code` derivation over a fixed demo match eid so the
-   panel mirrors what the live flow issues."
+  "Demo series-lobby setup revealed once both sides check in. `:code` is the
+   real `domain/lobby-code` derivation over a fixed demo match eid, so the panel
+   mirrors the lobby name the live flow issues; the remaining fields are the
+   host's lobby setup the players read off before game 1."
   {:code           (domain/lobby-code #uuid "b1f2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d")
+   :passcode       "QF1-4471"
    :host           "sigmar_42"
-   :format         "Best of 5"
-   :patch          "8.0"
-   :reinforcements "Disabled"
-   :caster         "grand_marshal_cast"
-   :launcher-url   "totalwar://lobby/join"})
+   :host-you?      true
+   :format         "Best of 5 · 4,000 pts"
+   :patch          "6.0.2"
+   :reinforcements "Disabled · stream delay 3 min"})
 
 (def ^:private demo-path
   [{:stage "Group Stage A" :label "3-0" :state "done" :detail "Top seed Group A"}


### PR DESCRIPTION
## What

A series gets **one** in-game lobby code, issued the moment both players check in and reused for every game of the best-of-N — never regenerated per game. This builds directly on the series check-in state machine (rts-928): `:both-checked?` is the reveal trigger.

Closes **rts-xe7**. Unblocks rts-pwd (real player-console view-models), which will swap the demo check-in view-model for live `check-in-state`/lobby data.

## Changes

**rts-data-access**
- New `:match/lobby-code` attribute; surfaced in the match read pattern + `->match`.
- `set-match-lobby-code!` mutation (+ contract re-export).

**rts-domain**
- `rules/lobby-code` — pure, deterministic `WORD-XXXX` code derived from the match eid (thematic prefix + 4 hex chars), so it is stable, unique, and idempotently reissuable.
- `check-in-player` issues + persists the code via a shared `ensure-lobby-code` the first time both sides are checked in, and **backfills** it on an idempotent re-check. `check-in-state` and `match-resource` now carry `:lobby-code`.

**rts-web**
- `series-lobby-panel` component: code + copy button, Host / Format / Patch / Reinforcements, caster spectator slot, and *Open in launcher*. Revealed on the player check-in view once the lobby is issued. War-room CSS to match the console.

## Tests
- Rule + handler unit tests: issue-on-both-checked, no-issue-with-one-side, no-reissue-of-existing, backfill-on-recheck, code format/determinism.
- E2E spec for the lobby panel render + copy-to-clipboard.
- `poly check` clean; `poly test` green; cljfmt + clj-kondo clean over changed files.
- Verified end-to-end against live Datalevin: one side → no code; both sides → code issued, persisted, and read back.

![series lobby panel](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/series-lobby/series-lobby-panel.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)