### PR TITLE
Write seed EDN atomically and pin print vars (rts-sef, rts-6co)

### DIFF
--- a/bases/rpfm-scraper/src/com/devereux_henley/rpfm_scraper/seed_edn.clj
+++ b/bases/rpfm-scraper/src/com/devereux_henley/rpfm_scraper/seed_edn.clj
@@ -13,7 +13,9 @@
    [clojure.pprint :as pp]
    [clojure.string :as str])
   (:import
+   [java.io File]
    [java.nio.charset StandardCharsets]
+   [java.nio.file CopyOption Files StandardCopyOption]
    [java.util UUID]))
 
 (defn derived-uuid
@@ -145,17 +147,31 @@
 
 (defn write-edn!
   "Pretty-print `rows` to `file`, creating parent dirs. Skips writing when
-  `rows` is empty so the loader's absent-file handling stays intact. Returns
-  the row count written (0 when skipped)."
+  `rows` is empty so the loader's absent-file handling stays intact. Writes to
+  a sibling temp file and atomically renames it into place, so an interrupted
+  or failed write never leaves a truncated seed file behind. Pins the print
+  vars so a caller's `*print-length*`/`*print-level*` can't silently elide rows
+  into `...`. Returns the row count written (0 when skipped)."
   [file rows]
   (if (empty? rows)
     0
-    (do
-      (.mkdirs (.getParentFile file))
-      (with-open [w (io/writer file)]
-        (binding [*out* w]
-          (pp/pprint rows)))
-      (count rows))))
+    (let [parent (.getParentFile file)
+          _      (.mkdirs parent)
+          tmp    (File/createTempFile "seed-" ".edn.tmp" parent)]
+      (try
+        (with-open [w (io/writer tmp)]
+          (binding [*out*                  w
+                    *print-length*         nil
+                    *print-level*          nil
+                    *print-namespace-maps* false]
+            (pp/pprint rows)))
+        (Files/move (.toPath tmp) (.toPath file)
+                    (into-array CopyOption
+                                [StandardCopyOption/ATOMIC_MOVE
+                                 StandardCopyOption/REPLACE_EXISTING]))
+        (count rows)
+        (finally
+          (when (.exists tmp) (.delete tmp)))))))
 
 (defn write-seed-file!
   "Write `rows` to `<datalog>/<version>/<file-name>`."

--- a/bases/rpfm-scraper/test/com/devereux_henley/rpfm_scraper/seed_edn_test.clj
+++ b/bases/rpfm-scraper/test/com/devereux_henley/rpfm_scraper/seed_edn_test.clj
@@ -42,6 +42,30 @@
       (is (not (.exists tmp)) "empty input writes no file")
       (finally (.delete tmp)))))
 
+(deftest write-edn!-pins-print-vars
+  (testing "a caller's *print-length*/*print-level* can't truncate the seed"
+    (let [tmp  (File/createTempFile "seed-edn-print" ".edn")
+          rows [{:xs (vec (range 50)) :nested {:a {:b {:c {:d 1}}}}}]]
+      (try
+        (binding [*print-length* 3 *print-level* 2]
+          (seed-edn/write-edn! tmp rows))
+        (is (not (.contains (slurp tmp) "...")) "no truncation ellipsis written")
+        (is (= rows (edn/read-string (slurp tmp))) "full rows round-trip")
+        (finally (.delete tmp))))))
+
+(deftest write-edn!-replaces-existing-and-leaves-no-temp
+  (testing "the atomic rename overwrites in place and leaves no .edn.tmp behind"
+    (let [dir  (doto (File/createTempFile "seed-edn-dir" "") (.delete) (.mkdirs))
+          file (io/file dir "out.edn")]
+      (try
+        (seed-edn/write-edn! file [{:a 1}])
+        (seed-edn/write-edn! file [{:b 2} {:b 3}])
+        (is (= [{:b 2} {:b 3}] (edn/read-string (slurp file))) "second write replaces the first")
+        (is (= ["out.edn"] (vec (.list dir))) "no temp siblings remain after write")
+        (finally
+          (doseq [f (.listFiles dir)] (.delete f))
+          (.delete dir))))))
+
 ;; --- lookups against committed authoring/8.0 ---
 
 (deftest faction-key->eid-maps-slugs-to-eids


### PR DESCRIPTION
## What

`rpfm-scraper.seed-edn/write-edn!` had two failure modes when producing the Datalog seed:

- **rts-sef** — it pprinted straight to the destination file. An exception in `pp/pprint` or a Ctrl-C mid-write left a truncated EDN file that looked committed-ready; the next `clojure.edn/read` then threw `EOFException` with no signal that the *dump* had failed.
- **rts-6co** — only `*out*` was rebound. A REPL session with `*print-length*`/`*print-level*` set (common in CIDER profiles) silently wrote `...` into the seed files, and Datalevin loaded the truncated data with no error.

## How

- Write to a sibling temp file, then `Files/move` with `ATOMIC_MOVE` + `REPLACE_EXISTING`; delete the temp in a `finally` so a failed write never leaves a partial file behind.
- Bind `*print-length*`/`*print-level*` to `nil` and `*print-namespace-maps*` to `false` around `pp/pprint`.

## Tests

- `write-edn!-pins-print-vars` — writing under `*print-length* 3`/`*print-level* 2` still round-trips full rows with no `...`.
- `write-edn!-replaces-existing-and-leaves-no-temp` — the atomic rename overwrites in place and leaves no `.edn.tmp` sibling.

`clojure -M:poly test project:rpfm-scraper` green (93 assertions); `cljfmt` + `clj-kondo` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)