### PR TITLE
Store replay parsed-data as an EDN string instead of idoc (rts-200)

### DIFF
--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/replay.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/replay.clj
@@ -1,6 +1,7 @@
 (ns com.devereux-henley.rts-data-access.query.datalog.replay
   "Datalevin reads + mutations for the replay domain."
   (:require
+   [clojure.edn :as edn]
    [com.devereux-henley.datalog.contract :as dl])
   (:import
    [java.time Instant]
@@ -27,7 +28,7 @@
      :played-at                     (:replay/played-at m)
      :victory-condition             (:replay/victory-condition m)
      :parser-format                 (:replay/parser-format m)
-     :parsed-data                   (:replay/parsed-data m)
+     :parsed-data                   (some-> (:replay/parsed-data m) edn/read-string)
      :uploader-local-alliance-index (:replay/uploader-local-alliance-index m)
      :uploaded-by-sub               (:replay/uploaded-by-sub m)
      :created-at                    (->instant (:replay/created-at m))
@@ -41,8 +42,8 @@
 (defn create-replay!
   "Transact a new replay row. Audit columns (`:created-at`,
   `:updated-at`) are stamped here so the handler stays thin. The
-  caller has already converted `:parsed-data` from the parser-emitted
-  JSON to a Clojure map; Datalevin stores it as `:db.type/idoc`."
+  caller passes `:parsed-data` as a Clojure map; it is stored as an
+  EDN string and read back as a map by `replay-by-eid`."
   [conn {:keys [eid match-id-external played-at victory-condition parser-format
                 parsed-data uploader-local-alliance-index uploaded-by-sub]}]
   (let [now (Date.)
@@ -50,7 +51,7 @@
                      :replay/match-id-external match-id-external
                      :replay/played-at         played-at
                      :replay/parser-format     parser-format
-                     :replay/parsed-data       parsed-data
+                     :replay/parsed-data       (pr-str parsed-data)
                      :replay/uploaded-by-sub   uploaded-by-sub
                      :replay/created-at        now
                      :replay/updated-at        now}

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/replay.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/replay.clj
@@ -9,8 +9,7 @@
    :replay/played-at                     {:db/valueType :db.type/string}
    :replay/victory-condition             {:db/valueType :db.type/string}
    :replay/parser-format                 {:db/valueType :db.type/string}
-   :replay/parsed-data                   {:db/valueType  :db.type/idoc
-                                          :db/idocFormat :json}
+   :replay/parsed-data                   {:db/valueType :db.type/string}
    :replay/uploader-local-alliance-index {:db/valueType :db.type/long}
    :replay/uploaded-by-sub               {:db/valueType :db.type/string}
    :replay/created-at                    {:db/valueType :db.type/instant}


### PR DESCRIPTION
## Summary
- `:replay/parsed-data` was a `:db.type/idoc` (JSON) attribute, which trips the upstream Datalevin idoc reopen bug (rts-tku): once any replay is submitted, `init-doc-refs` throws `MDB_BAD_VALSIZE` on the next connection open, breaking `restart!` and requiring a JVM kill + store wipe.
- The attribute is now `:db.type/string`. `create-replay!` serializes the parsed map with `pr-str`; `replay-by-eid` reads it back with `clojure.edn/read-string`, so the map-in/map-out contract API is unchanged and no callers needed touching (`:parsed-data` has no consumers outside the replay data-access namespace).
- No migration needed: the project is not deployed, and dev stores are wiped + reseeded on schema changes.

## Verification
- Temp-store repro of the bead's failure mode: open → `create-replay!` with a rich parsed map → close → reopen → `replay-by-eid` round-trips the map exactly (previously the reopen threw).
- Dev-store end-to-end: fresh store + full 8.0 seed (~6.5k entities, so the replay lands at a high eid, matching the bug's trigger condition) → `create-replay!` → `(claude-workspace/restart!)` succeeds → replay reads back intact.
- `clojure -M:poly check` OK; `clojure -M:poly test` green (e2e, rts-domain, rts-api bricks; replay handler tests 9/9); cljfmt + clj-kondo clean on the changed files.

Closes rts-200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)