### PR TITLE
Add dispute entity, queries, and lifecycle handlers (rts-0yw)

### DIFF
--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
@@ -1,6 +1,7 @@
 (ns com.devereux-henley.rts-data-access.contract
   (:require
    [com.devereux-henley.datalog.contract :as dl]
+   [com.devereux-henley.rts-data-access.query.datalog.dispute :as query.datalog.dispute]
    [com.devereux-henley.rts-data-access.query.datalog.draft :as query.datalog.draft]
    [com.devereux-henley.rts-data-access.query.datalog.game :as query.datalog.game]
    [com.devereux-henley.rts-data-access.query.datalog.league :as query.datalog.league]
@@ -11,6 +12,7 @@
    [com.devereux-henley.rts-data-access.query.datalog.stats :as query.datalog.stats]
    [com.devereux-henley.rts-data-access.schema :as schema]
    [com.devereux-henley.rts-data-access.schema.datalog :as schema.datalog]
+   [com.devereux-henley.rts-data-access.schema.dispute :as schema.dispute]
    [com.devereux-henley.rts-data-access.schema.draft :as schema.draft]
    [com.devereux-henley.rts-data-access.schema.game :as schema.game]
    [com.devereux-henley.rts-data-access.schema.league :as schema.league]
@@ -117,6 +119,10 @@
 (def bracket-type-enum schema/bracket-type-enum)
 (def mark-enum schema/mark-enum)
 
+(def dispute-kind-enum schema/dispute-kind-enum)
+(def dispute-priority-enum schema/dispute-priority-enum)
+(def dispute-status-enum schema/dispute-status-enum)
+
 ;;; ─── Tournament Datalog queries + mutations ────────────────────────────────
 
 (def tournament-by-eid               query.datalog.tournament/tournament-by-eid)
@@ -176,6 +182,15 @@
 
 (def replay-by-eid  query.datalog.replay/replay-by-eid)
 (def create-replay! query.datalog.replay/create-replay!)
+
+;;; ─── Dispute Datalog queries + mutations ───────────────────────────────────
+
+(def dispute-by-eid                   query.datalog.dispute/dispute-by-eid)
+(def open-disputes-for-tournament     query.datalog.dispute/open-disputes-for-tournament)
+(def open-dispute-count-for-tournament query.datalog.dispute/open-dispute-count-for-tournament)
+(def create-dispute!                  query.datalog.dispute/create-dispute!)
+(def resolve-dispute!                 query.datalog.dispute/resolve-dispute!)
+(def dismiss-dispute!                 query.datalog.dispute/dismiss-dispute!)
 
 ;;; ─── Function schemas ─────────────────────────────────────────────────────
 ;;;
@@ -391,3 +406,29 @@
 (schema.contract/=>* create-replay! query.datalog.replay/create-replay!
                      [:=> [:cat dl/conn-schema schema.replay/create-spec-schema]
                       schema.replay/replay-result-schema])
+
+;; Dispute datalog
+
+(schema.contract/=>* dispute-by-eid query.datalog.dispute/dispute-by-eid
+                     [:=> [:cat dl/conn-schema :uuid]
+                      [:maybe schema.dispute/dispute-result-schema]])
+
+(schema.contract/=>* open-disputes-for-tournament query.datalog.dispute/open-disputes-for-tournament
+                     [:=> [:cat dl/conn-schema :uuid]
+                      [:sequential schema.dispute/dispute-result-schema]])
+
+(schema.contract/=>* open-dispute-count-for-tournament query.datalog.dispute/open-dispute-count-for-tournament
+                     [:=> [:cat dl/conn-schema :uuid]
+                      [:int {:min 0}]])
+
+(schema.contract/=>* create-dispute! query.datalog.dispute/create-dispute!
+                     [:=> [:cat dl/conn-schema schema.dispute/open-spec-schema]
+                      schema.dispute/dispute-result-schema])
+
+(schema.contract/=>* resolve-dispute! query.datalog.dispute/resolve-dispute!
+                     [:=> [:cat dl/conn-schema :uuid]
+                      schema.dispute/dispute-result-schema])
+
+(schema.contract/=>* dismiss-dispute! query.datalog.dispute/dismiss-dispute!
+                     [:=> [:cat dl/conn-schema :uuid]
+                      schema.dispute/dispute-result-schema])

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/dispute.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/dispute.clj
@@ -1,0 +1,132 @@
+(ns com.devereux-henley.rts-data-access.query.datalog.dispute
+  "Datalevin reads and mutations for the dispute domain — contested match
+  results raised against a match (and optionally a specific game) within a
+  tournament.
+
+  Reads return flat unqualified-key maps: enum keywords flatten to strings
+  (`:dispute/status :open` → `\"open\"`), ref sub-maps become `*-eid` fields,
+  and instants are `java.util.Date`. Mutations stamp `opened-at` /
+  `resolved-at` server-side as `java.util.Date`."
+  (:require
+   [com.devereux-henley.datalog.contract :as dl])
+  (:import
+   [java.util Date]))
+
+;;; ─── Coercions ─────────────────────────────────────────────────────────────
+
+(defn- kw->str
+  "Enum keyword → the string the handlers compare against."
+  [k]
+  (some-> k name))
+
+(def ^:private priority-rank
+  "Sort weight for the organizer queue — most urgent first."
+  {:urgent 0 :normal 1 :low 2})
+
+;;; ─── Pull pattern + result builder ─────────────────────────────────────────
+
+(def ^:private dispute-pattern
+  [:dispute/eid :dispute/kind :dispute/priority :dispute/status
+   :dispute/reporter-sub :dispute/detail
+   :dispute/opened-at :dispute/resolved-at
+   {:dispute/tournament [:tournament/eid]}
+   {:dispute/match [:match/eid]}
+   {:dispute/match-game [:match-game/eid]}])
+
+(defn- ->dispute
+  [m]
+  (when m
+    {:eid            (:dispute/eid m)
+     :tournament-eid (some-> m :dispute/tournament :tournament/eid)
+     :match-eid      (some-> m :dispute/match :match/eid)
+     :match-game-eid (some-> m :dispute/match-game :match-game/eid)
+     :kind           (kw->str (:dispute/kind m))
+     :priority       (kw->str (:dispute/priority m))
+     :status         (kw->str (:dispute/status m))
+     :reporter-sub   (:dispute/reporter-sub m)
+     :detail         (:dispute/detail m)
+     :opened-at      (:dispute/opened-at m)
+     :resolved-at    (:dispute/resolved-at m)}))
+
+;;; ─── Reads ─────────────────────────────────────────────────────────────────
+
+(defn dispute-by-eid
+  "Fetch a dispute by eid. Returns nil when not found."
+  [conn eid]
+  (->dispute (dl/pull (dl/db conn) dispute-pattern (dl/lookup-ref :dispute/eid eid))))
+
+(defn open-disputes-for-tournament
+  "All `:open` disputes for a tournament, most urgent first then oldest first
+  (priority rank asc, opened-at asc)."
+  [conn tournament-eid]
+  (let [db (dl/db conn)]
+    (->> (dl/q '[:find [(pull ?d pattern) ...]
+                 :in $ pattern ?tour-eid
+                 :where
+                 [?d :dispute/tournament ?t]
+                 [?t :tournament/eid ?tour-eid]
+                 [?d :dispute/status :open]]
+               db dispute-pattern tournament-eid)
+         (mapv ->dispute)
+         (sort-by (juxt #(get priority-rank (keyword (:priority %)) 1)
+                        (comp (fnil #(.getTime ^Date %) (Date. 0)) :opened-at)
+                        :eid))
+         vec)))
+
+(defn open-dispute-count-for-tournament
+  "Count of `:open` disputes for a tournament — backs the queue-tab badge."
+  [conn tournament-eid]
+  (or (dl/q '[:find (count ?d) .
+              :in $ ?tour-eid
+              :where
+              [?d :dispute/tournament ?t]
+              [?t :tournament/eid ?tour-eid]
+              [?d :dispute/status :open]]
+            (dl/db conn) tournament-eid)
+      0))
+
+;;; ─── Mutations ─────────────────────────────────────────────────────────────
+
+(defn create-dispute!
+  "Open a dispute in `:open` status, stamping `opened-at`. `:match-game-eid`
+  becomes a ref when present (series-level disputes omit it); `:priority`
+  defaults to `normal`. Enum-typed `:kind` / `:priority` are stored as
+  keywords. Returns the created dispute."
+  [conn {:keys [eid tournament-eid match-eid match-game-eid kind priority
+                reporter-sub detail]}]
+  (let [dispute-eid (or eid (random-uuid))]
+    (dl/transact!
+     conn
+     [(cond-> {:dispute/eid          dispute-eid
+               :dispute/tournament   [:tournament/eid tournament-eid]
+               :dispute/match        [:match/eid match-eid]
+               :dispute/kind         (keyword kind)
+               :dispute/priority     (keyword (or priority "normal"))
+               :dispute/status       :open
+               :dispute/reporter-sub reporter-sub
+               :dispute/opened-at    (Date.)}
+        match-game-eid (assoc :dispute/match-game [:match-game/eid match-game-eid])
+        detail         (assoc :dispute/detail detail))])
+    (dispute-by-eid conn dispute-eid)))
+
+(defn resolve-dispute!
+  "Mark a dispute `:resolved`, stamping `resolved-at`. Returns the updated
+  dispute."
+  [conn eid]
+  (dl/transact!
+   conn
+   [{:dispute/eid         eid
+     :dispute/status      :resolved
+     :dispute/resolved-at (Date.)}])
+  (dispute-by-eid conn eid))
+
+(defn dismiss-dispute!
+  "Mark a dispute `:dismissed`, stamping `resolved-at`. Returns the updated
+  dispute."
+  [conn eid]
+  (dl/transact!
+   conn
+   [{:dispute/eid         eid
+     :dispute/status      :dismissed
+     :dispute/resolved-at (Date.)}])
+  (dispute-by-eid conn eid))

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema.clj
@@ -192,6 +192,16 @@
 
 (def bracket-type-enum [:enum "winners" "losers" "grand-final"])
 
+;; ─── Dispute enums ──────────────────────────────────────────────────────────
+;; Closed value sets for the dispute model, shared with the domain layer.
+
+(def dispute-kind-enum
+  [:enum "conflicting-result" "missing-replay" "connection-loss" "other"])
+
+(def dispute-priority-enum [:enum "urgent" "normal" "low"])
+
+(def dispute-status-enum [:enum "open" "resolved" "dismissed"])
+
 ;; ─── Stats entities ──────────────────────────────────────────────────────────
 
 (def faction-standings-row-entity

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog.clj
@@ -32,6 +32,7 @@
    [com.devereux-henley.rts-data-access.schema.datalog.attribute :as schema.datalog.attribute]
    [com.devereux-henley.rts-data-access.schema.datalog.draft :as schema.datalog.draft]
    [com.devereux-henley.rts-data-access.schema.datalog.draft-entry :as schema.datalog.draft-entry]
+   [com.devereux-henley.rts-data-access.schema.datalog.dispute :as schema.datalog.dispute]
    [com.devereux-henley.rts-data-access.schema.datalog.faction :as schema.datalog.faction]
    [com.devereux-henley.rts-data-access.schema.datalog.game :as schema.datalog.game]
    [com.devereux-henley.rts-data-access.schema.datalog.game-mode :as schema.datalog.game-mode]
@@ -68,6 +69,7 @@
    schema.datalog.attribute/schema
    schema.datalog.draft/schema
    schema.datalog.draft-entry/schema
+   schema.datalog.dispute/schema
    schema.datalog.faction/schema
    schema.datalog.game/schema
    schema.datalog.game-mode/schema

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/dispute.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/dispute.clj
@@ -1,0 +1,25 @@
+(ns com.devereux-henley.rts-data-access.schema.datalog.dispute
+  "Datalevin attributes for the `:dispute` entity — a contested match result
+  raised by a player against a `:match` (and optionally a specific
+  `:match-game`) within a `:tournament`.
+
+  `:dispute/kind` classifies the contest (`#{:conflicting-result
+  :missing-replay :connection-loss :other}`); `:dispute/priority`
+  (`#{:urgent :normal :low}`) drives organizer-queue ordering;
+  `:dispute/status` (`#{:open :resolved :dismissed}`) tracks the lifecycle.
+  `:dispute/opened-at` stamps creation and `:dispute/resolved-at` stamps the
+  transition out of `:open` (set on both resolve and dismiss).")
+
+(def schema
+  {:dispute/eid          {:db/valueType :db.type/uuid
+                          :db/unique    :db.unique/identity}
+   :dispute/tournament   {:db/valueType :db.type/ref}
+   :dispute/match        {:db/valueType :db.type/ref}
+   :dispute/match-game   {:db/valueType :db.type/ref}
+   :dispute/kind         {:db/valueType :db.type/keyword}
+   :dispute/priority     {:db/valueType :db.type/keyword}
+   :dispute/status       {:db/valueType :db.type/keyword}
+   :dispute/reporter-sub {:db/valueType :db.type/string}
+   :dispute/detail       {:db/valueType :db.type/string}
+   :dispute/opened-at    {:db/valueType :db.type/instant}
+   :dispute/resolved-at  {:db/valueType :db.type/instant}})

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/dispute.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/dispute.clj
@@ -1,0 +1,36 @@
+(ns com.devereux-henley.rts-data-access.schema.dispute
+  "Malli return-shape and write-spec schemas for the dispute-domain Datalevin
+  queries. Enum-typed fields carry the string form the reads flatten keywords
+  into."
+  (:require
+   [com.devereux-henley.rts-data-access.schema :as schema]
+   [com.devereux-henley.schema.contract :as schema.contract]))
+
+(def dispute-result-schema
+  (schema.contract/to-schema
+   [:map
+    [:eid            :uuid]
+    [:tournament-eid [:maybe :uuid]]
+    [:match-eid      [:maybe :uuid]]
+    [:match-game-eid [:maybe :uuid]]
+    [:kind           schema/dispute-kind-enum]
+    [:priority       schema/dispute-priority-enum]
+    [:status         schema/dispute-status-enum]
+    [:reporter-sub   :string]
+    [:detail         [:maybe :string]]
+    [:opened-at      [:maybe inst?]]
+    [:resolved-at    [:maybe inst?]]]))
+
+(def open-spec-schema
+  "Caller-supplied fields for opening a dispute. `:match-game-eid` is optional
+  (series-level disputes omit it); `:priority` defaults to `normal` when
+  omitted."
+  (schema.contract/to-schema
+   [:map
+    [:tournament-eid :uuid]
+    [:match-eid      :uuid]
+    [:match-game-eid {:optional true} [:maybe :uuid]]
+    [:kind           schema/dispute-kind-enum]
+    [:priority       {:optional true} schema/dispute-priority-enum]
+    [:reporter-sub   :string]
+    [:detail         {:optional true} [:maybe :string]]]))

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
@@ -1,5 +1,6 @@
 (ns com.devereux-henley.rts-domain.contract
   (:require
+   [com.devereux-henley.rts-domain.handlers.dispute :as handlers.dispute]
    [com.devereux-henley.rts-domain.handlers.draft :as handlers.draft]
    [com.devereux-henley.rts-domain.handlers.game :as handlers.game]
    [com.devereux-henley.rts-domain.handlers.league :as handlers.league]
@@ -194,6 +195,15 @@
 (def get-game-faction-standings                   handlers.stats/get-game-faction-standings)
 (def get-league-faction-standings                 handlers.stats/get-league-faction-standings)
 (def get-season-faction-standings                 handlers.stats/get-season-faction-standings)
+
+;;; ─── Dispute handler functions ─────────────────────────────────────────────
+
+(def get-dispute-by-eid                         handlers.dispute/get-dispute-by-eid)
+(def get-open-disputes-for-tournament           handlers.dispute/get-open-disputes-for-tournament)
+(def get-open-dispute-count-for-tournament      handlers.dispute/get-open-dispute-count-for-tournament)
+(def open-dispute                               handlers.dispute/open-dispute)
+(def resolve-dispute                            handlers.dispute/resolve-dispute)
+(def dismiss-dispute                            handlers.dispute/dismiss-dispute)
 
 ;;; ─── Social Media handler functions ────────────────────────────────────────
 

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/dispute.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/dispute.clj
@@ -1,0 +1,82 @@
+(ns com.devereux-henley.rts-domain.handlers.dispute
+  "Domain handlers for the dispute lifecycle — opening a contested-result
+  ticket against a match and the organizer resolve/dismiss actions.
+
+  Fetches return nil for a missing dispute; lifecycle functions return the
+  tagged dispute on success or a typed `{:type :dispute/error :message …}`
+  map on a validation failure, which web handlers dispatch on to choose the
+  HTTP status."
+  (:require
+   [com.devereux-henley.rts-data-access.contract :as db]))
+
+(defn- tag-dispute
+  [dispute]
+  (when dispute
+    (assoc dispute :type :dispute/dispute)))
+
+(defn get-dispute-by-eid
+  "Fetches a dispute by eid and tags it with :type :dispute/dispute, or nil."
+  [dependencies eid]
+  (tag-dispute (db/dispute-by-eid (:datalog-connection dependencies) eid)))
+
+(defn get-open-disputes-for-tournament
+  "Returns the open-dispute queue for a tournament — most urgent first — each
+  tagged with :type :dispute/dispute."
+  [dependencies tournament-eid]
+  (mapv tag-dispute (db/open-disputes-for-tournament (:datalog-connection dependencies) tournament-eid)))
+
+(defn get-open-dispute-count-for-tournament
+  "Returns the count of open disputes for a tournament — backs the queue-tab
+  badge."
+  [dependencies tournament-eid]
+  (db/open-dispute-count-for-tournament (:datalog-connection dependencies) tournament-eid))
+
+(defn open-dispute
+  "Opens a dispute against a match (optionally a specific game) within a
+  tournament. Validates that the match exists, belongs to the tournament, and
+  that the referenced game belongs to the match. Returns the tagged dispute or
+  {:type :dispute/error :message ...}."
+  [dependencies {:keys [tournament-eid match-eid match-game-eid] :as spec}]
+  (let [conn  (:datalog-connection dependencies)
+        match (db/match-by-eid conn match-eid)]
+    (cond
+      (nil? match)
+      {:type :dispute/error :message "Match not found."}
+
+      (not= tournament-eid (:tournament-eid match))
+      {:type :dispute/error :message "Match does not belong to this tournament."}
+
+      (and match-game-eid
+           (not (some #(= match-game-eid (:eid %)) (db/games-for-match conn match-eid))))
+      {:type :dispute/error :message "Game does not belong to this match."}
+
+      :else
+      (tag-dispute (db/create-dispute! conn spec)))))
+
+(defn- close-dispute
+  "Shared resolve/dismiss path: loads the dispute, guards that it is still
+  open, then applies `mutate!`. Returns the tagged dispute or a typed error."
+  [dependencies eid mutate!]
+  (let [conn    (:datalog-connection dependencies)
+        dispute (db/dispute-by-eid conn eid)]
+    (cond
+      (nil? dispute)
+      {:type :dispute/error :message "Dispute not found."}
+
+      (not= "open" (:status dispute))
+      {:type :dispute/error :message "Dispute is already resolved or dismissed."}
+
+      :else
+      (tag-dispute (mutate! conn eid)))))
+
+(defn resolve-dispute
+  "Marks an open dispute resolved. Returns the tagged dispute or
+  {:type :dispute/error :message ...}."
+  [dependencies eid]
+  (close-dispute dependencies eid db/resolve-dispute!))
+
+(defn dismiss-dispute
+  "Marks an open dispute dismissed. Returns the tagged dispute or
+  {:type :dispute/error :message ...}."
+  [dependencies eid]
+  (close-dispute dependencies eid db/dismiss-dispute!))

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/dispute_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/dispute_test.clj
@@ -1,0 +1,115 @@
+(ns com.devereux-henley.rts-domain.handlers.dispute-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [com.devereux-henley.rts-data-access.contract :as data-access.contract]
+   [com.devereux-henley.rts-domain.handlers.dispute :as handlers.dispute])
+  (:import
+   [java.util UUID]))
+
+(def ^:private test-deps {:datalog-connection nil})
+(def ^:private tournament-eid (UUID/fromString "11111111-1111-1111-1111-111111111111"))
+(def ^:private match-eid (UUID/fromString "22222222-2222-2222-2222-222222222222"))
+(def ^:private game-eid (UUID/fromString "33333333-3333-3333-3333-333333333333"))
+(def ^:private dispute-eid (UUID/fromString "44444444-4444-4444-4444-444444444444"))
+
+(def ^:private test-match
+  {:eid match-eid :tournament-eid tournament-eid :status "complete"})
+
+(def ^:private valid-spec
+  {:tournament-eid tournament-eid
+   :match-eid      match-eid
+   :kind           "conflicting-result"
+   :reporter-sub   "dev-player-one"
+   :detail         "results disagree on game 4"})
+
+;; ─── tagging ────────────────────────────────────────────────────────────────
+
+(deftest get-dispute-by-eid-tags-result
+  (with-redefs [data-access.contract/dispute-by-eid
+                (fn [_ _] {:eid      dispute-eid :status       "open"           :kind "missing-replay"
+                           :priority "low"       :reporter-sub "dev-player-two"})]
+    (let [d (handlers.dispute/get-dispute-by-eid test-deps dispute-eid)]
+      (is (= :dispute/dispute (:type d)))
+      (is (= dispute-eid (:eid d))))))
+
+(deftest get-dispute-by-eid-returns-nil-when-absent
+  (with-redefs [data-access.contract/dispute-by-eid (fn [_ _] nil)]
+    (is (nil? (handlers.dispute/get-dispute-by-eid test-deps dispute-eid)))))
+
+(deftest get-open-disputes-tags-each-row
+  (with-redefs [data-access.contract/open-disputes-for-tournament
+                (fn [_ _] [{:eid (UUID/randomUUID) :status "open"}
+                           {:eid (UUID/randomUUID) :status "open"}])]
+    (let [rows (handlers.dispute/get-open-disputes-for-tournament test-deps tournament-eid)]
+      (is (= 2 (count rows)))
+      (is (every? #(= :dispute/dispute (:type %)) rows)))))
+
+(deftest get-open-dispute-count-passes-through
+  (with-redefs [data-access.contract/open-dispute-count-for-tournament (fn [_ _] 5)]
+    (is (= 5 (handlers.dispute/get-open-dispute-count-for-tournament test-deps tournament-eid)))))
+
+;; ─── open-dispute happy path + validation ────────────────────────────────────
+
+(deftest open-dispute-creates-and-tags
+  (let [captured (atom nil)]
+    (with-redefs [data-access.contract/match-by-eid    (fn [_ _] test-match)
+                  data-access.contract/games-for-match (fn [_ _] [])
+                  data-access.contract/create-dispute! (fn [_ spec]
+                                                         (reset! captured spec)
+                                                         (assoc spec :eid dispute-eid :status "open"))]
+      (let [result (handlers.dispute/open-dispute test-deps valid-spec)]
+        (is (= :dispute/dispute (:type result)))
+        (is (= "conflicting-result" (:kind @captured)))))))
+
+(deftest open-dispute-rejects-missing-match
+  (with-redefs [data-access.contract/match-by-eid (fn [_ _] nil)]
+    (is (= :dispute/error (:type (handlers.dispute/open-dispute test-deps valid-spec))))))
+
+(deftest open-dispute-rejects-match-from-other-tournament
+  (with-redefs [data-access.contract/match-by-eid
+                (fn [_ _] (assoc test-match :tournament-eid (UUID/randomUUID)))]
+    (is (= :dispute/error (:type (handlers.dispute/open-dispute test-deps valid-spec))))))
+
+(deftest open-dispute-rejects-game-not-in-match
+  (with-redefs [data-access.contract/match-by-eid    (fn [_ _] test-match)
+                data-access.contract/games-for-match (fn [_ _] [{:eid (UUID/randomUUID)}])]
+    (let [spec   (assoc valid-spec :match-game-eid game-eid)
+          result (handlers.dispute/open-dispute test-deps spec)]
+      (is (= :dispute/error (:type result))))))
+
+(deftest open-dispute-accepts-game-belonging-to-match
+  (with-redefs [data-access.contract/match-by-eid    (fn [_ _] test-match)
+                data-access.contract/games-for-match (fn [_ _] [{:eid game-eid}])
+                data-access.contract/create-dispute! (fn [_ spec] (assoc spec :eid dispute-eid :status "open"))]
+    (let [spec   (assoc valid-spec :match-game-eid game-eid)
+          result (handlers.dispute/open-dispute test-deps spec)]
+      (is (= :dispute/dispute (:type result))))))
+
+;; ─── resolve / dismiss lifecycle ──────────────────────────────────────────────
+
+(deftest resolve-dispute-marks-open-dispute-resolved
+  (with-redefs [data-access.contract/dispute-by-eid   (fn [_ _] {:eid dispute-eid :status "open"})
+                data-access.contract/resolve-dispute! (fn [_ eid] {:eid eid :status "resolved"})]
+    (let [result (handlers.dispute/resolve-dispute test-deps dispute-eid)]
+      (is (= :dispute/dispute (:type result)))
+      (is (= "resolved" (:status result))))))
+
+(deftest dismiss-dispute-marks-open-dispute-dismissed
+  (with-redefs [data-access.contract/dispute-by-eid   (fn [_ _] {:eid dispute-eid :status "open"})
+                data-access.contract/dismiss-dispute! (fn [_ eid] {:eid eid :status "dismissed"})]
+    (let [result (handlers.dispute/dismiss-dispute test-deps dispute-eid)]
+      (is (= :dispute/dispute (:type result)))
+      (is (= "dismissed" (:status result))))))
+
+(deftest resolve-dispute-rejects-missing-dispute
+  (with-redefs [data-access.contract/dispute-by-eid (fn [_ _] nil)]
+    (is (= :dispute/error (:type (handlers.dispute/resolve-dispute test-deps dispute-eid))))))
+
+(deftest resolve-dispute-rejects-already-closed-dispute
+  (testing "a non-open dispute cannot be resolved again"
+    (with-redefs [data-access.contract/dispute-by-eid (fn [_ _] {:eid dispute-eid :status "resolved"})]
+      (is (= :dispute/error (:type (handlers.dispute/resolve-dispute test-deps dispute-eid)))))))
+
+(deftest dismiss-dispute-rejects-already-closed-dispute
+  (with-redefs [data-access.contract/dispute-by-eid (fn [_ _] {:eid dispute-eid :status "dismissed"})]
+    (is (= :dispute/error (:type (handlers.dispute/dismiss-dispute test-deps dispute-eid))))))


### PR DESCRIPTION
## Summary

Net-new **dispute** model (rts-0yw) — the data layer behind the organizer Disputes queue and the player per-game dispute action. A dispute contests a match result (optionally a specific game) within a tournament. Scoped to schema + queries + domain handlers; the web routes/templates land with the downstream beads.

## Changes

**Data-access (`rts-data-access`)**
- `schema/datalog/dispute.clj` — `:dispute/{eid,tournament,match,match-game,kind,priority,status,reporter-sub,detail,opened-at,resolved-at}`; registered in the assembled `schema/datalog.clj`.
- Enums in `schema.clj`: kind `#{conflicting-result missing-replay connection-loss other}`, priority `#{urgent normal low}`, status `#{open resolved dismissed}`.
- `schema/dispute.clj` — result + open-spec Malli schemas.
- `query/datalog/dispute.clj` — reads `dispute-by-eid`, `open-disputes-for-tournament` (urgent-first), `open-dispute-count-for-tournament` (queue badge); mutations `create-dispute!`, `resolve-dispute!`, `dismiss-dispute!` (stamp `resolved-at`).
- Re-exports + `=>*` function schemas in `contract.clj`.

**Domain (`rts-domain`)**
- `handlers/dispute.clj` — fetches tag `:type :dispute/dispute`; `open-dispute` validates the match exists, belongs to the tournament, and any referenced game belongs to the match; `resolve-dispute`/`dismiss-dispute` guard `status = open`. Validation failures return a typed `{:type :dispute/error}` map. Re-exported in domain `contract.clj`.

## Testing

- `handlers/dispute_test.clj` — 14 tests / 19 assertions, green (DB boundary stubbed).
- Live Datalevin round-trip verified: create (with/without game ref), urgent-first queue ordering, count, resolve/dismiss stamping `resolved-at`, closed disputes excluded from count, clean store reopen with refs intact.
- Gates: `cljfmt` clean · `clj-kondo` 0/0 · `clojure -M:poly check` OK.

## Unblocks

- rts-6vy — player submit→confirm/dispute loop
- rts-j11 — organizer Disputes queue tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)