### PR TITLE
Restore idoc for replay parsed-data via dtlvnative native bump (rts-qff)

### DIFF
--- a/bases/rts-api/deps.edn
+++ b/bases/rts-api/deps.edn
@@ -8,7 +8,8 @@
         selmer/selmer {:mvn/version "1.12.55"}
         clj-http/clj-http {:mvn/version "3.12.3"}
         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
-        org.datalevin/datalevin-embedded {:mvn/version "0.10.16"}}
+        org.datalevin/datalevin-embedded {:mvn/version "0.10.16"}
+        org.clojars.huahaiy/dtlvnative-linux-x86_64 {:mvn/version "0.18.7"}}
  :aliases {:build {:main-opts ["-m" "com.devereux-henley.rts-api.core"]}
            :dev {:extra-paths ["dev"]}
            :test {:extra-paths ["test"]

--- a/components/datalog/deps.edn
+++ b/components/datalog/deps.edn
@@ -1,3 +1,4 @@
 {:paths ["src"]
- :deps {org.datalevin/datalevin-embedded {:mvn/version "0.10.16"}
-        metosin/malli                    {:mvn/version "0.9.2"}}}
+ :deps {org.datalevin/datalevin-embedded            {:mvn/version "0.10.16"}
+        org.clojars.huahaiy/dtlvnative-linux-x86_64 {:mvn/version "0.18.7"}
+        metosin/malli                                {:mvn/version "0.9.2"}}}

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/replay.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/replay.clj
@@ -1,7 +1,6 @@
 (ns com.devereux-henley.rts-data-access.query.datalog.replay
   "Datalevin reads + mutations for the replay domain."
   (:require
-   [clojure.edn :as edn]
    [com.devereux-henley.datalog.contract :as dl])
   (:import
    [java.time Instant]
@@ -28,7 +27,7 @@
      :played-at                     (:replay/played-at m)
      :victory-condition             (:replay/victory-condition m)
      :parser-format                 (:replay/parser-format m)
-     :parsed-data                   (some-> (:replay/parsed-data m) edn/read-string)
+     :parsed-data                   (:replay/parsed-data m)
      :uploader-local-alliance-index (:replay/uploader-local-alliance-index m)
      :uploaded-by-sub               (:replay/uploaded-by-sub m)
      :created-at                    (->instant (:replay/created-at m))
@@ -42,8 +41,8 @@
 (defn create-replay!
   "Transact a new replay row. Audit columns (`:created-at`,
   `:updated-at`) are stamped here so the handler stays thin. The
-  caller passes `:parsed-data` as a Clojure map; it is stored as an
-  EDN string and read back as a map by `replay-by-eid`."
+  caller has already converted `:parsed-data` from the parser-emitted
+  JSON to a Clojure map; Datalevin stores it as `:db.type/idoc`."
   [conn {:keys [eid match-id-external played-at victory-condition parser-format
                 parsed-data uploader-local-alliance-index uploaded-by-sub]}]
   (let [now (Date.)
@@ -51,7 +50,7 @@
                      :replay/match-id-external match-id-external
                      :replay/played-at         played-at
                      :replay/parser-format     parser-format
-                     :replay/parsed-data       (pr-str parsed-data)
+                     :replay/parsed-data       parsed-data
                      :replay/uploaded-by-sub   uploaded-by-sub
                      :replay/created-at        now
                      :replay/updated-at        now}

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/replay.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/replay.clj
@@ -9,7 +9,8 @@
    :replay/played-at                     {:db/valueType :db.type/string}
    :replay/victory-condition             {:db/valueType :db.type/string}
    :replay/parser-format                 {:db/valueType :db.type/string}
-   :replay/parsed-data                   {:db/valueType :db.type/string}
+   :replay/parsed-data                   {:db/valueType  :db.type/idoc
+                                          :db/idocFormat :json}
    :replay/uploader-local-alliance-index {:db/valueType :db.type/long}
    :replay/uploaded-by-sub               {:db/valueType :db.type/string}
    :replay/created-at                    {:db/valueType :db.type/instant}


### PR DESCRIPTION
## Summary

[datalevin/datalevin#375](https://github.com/datalevin/datalevin/issues/375) (idoc reopen `MDB_BAD_VALSIZE` / native iterator `code-30781`) is fixed in the native dlmdb library as of **dtlvnative 0.18.4** ("dlmdb copy back mp_pad when page split"). The fix is **not yet in a released `datalevin-embedded`** artifact (latest `0.10.18` predates it), but the fixed native library *is* published standalone on Clojars as `org.clojars.huahaiy/dtlvnative-<platform>`, carrying `libdtlv.so` at the same jar resource path datalevin loads from.

This PR:
- Adds `org.clojars.huahaiy/dtlvnative-linux-x86_64 0.18.7` alongside the pinned `datalevin-embedded 0.10.16`. tools.deps sorts the explicit dep **ahead** of the embedded jar (verified on the `:dev` classpath), so its fixed `.so` wins resource resolution.
- Reverts `:replay/parsed-data` to `:db.type/idoc`, removing the `pr-str`/`edn/read-string` EDN-string workaround from `160760e5` — the data-access boundary stores/reads it as a map directly again.

## Verification

- **Standalone repro** (`~/Repos/datalevin-repro`, `clojure -M:min` — writes 110 real idoc docs, close, reopen): stock `datalevin-embedded 0.10.16` → `REOPEN FAILED` (`code-30781`); with `dtlvnative 0.18.7` → `REOPEN OK`, deterministic 3/3. This is the controlled before/after.
- **Real app flow** (`create-replay!` idoc write → `restart!` close+reopen → `replay-by-eid`): reopens cleanly and round-trips the parsed-data map (keys match), both unseeded and fully-seeded.
- cljfmt clean · clj-kondo 0 errors / 0 warnings · `poly check` OK · `poly test` 234 passes / 0 failures.

> Note: I could not reproduce the original rts-200 crash in the *in-app* flow on stock 0.10.16 using a proxy payload (the bug is byte-layout-specific and non-monotonic in count, and the proxy isn't real `tw-replay-parser` output). The controlled proof of the fix is the standalone repro.

## Caveat

This leans on tools.deps **classpath ordering** to shadow the `.so` bundled inside `datalevin-embedded` (an in-jar resource can't be excluded, only out-sorted). Ordering is deterministic per dep tree and verified today. Only the `linux-x86_64` classifier is added — add `macosx-arm64`/etc. if other dev/build platforms need it.

Interim until a released `datalevin-embedded >0.10.18` bundles the fix, after which the explicit `dtlvnative` dep can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)