### PR TITLE
Fix 400 on standalone tournament creation (:optional-uuid form selects)

### DIFF
--- a/components/rts-domain/src/com/devereux_henley/rts_domain/schema.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/schema.clj
@@ -215,8 +215,8 @@
   (schema.contract/to-schema
    [:map
     [:game-eid :uuid]
-    [:league-eid {:optional true} [:maybe :uuid]]
-    [:season-eid {:optional true} [:maybe :uuid]]
+    [:league-eid {:optional true} :optional-uuid]
+    [:season-eid {:optional true} :optional-uuid]
     [:name {:min 1} :string]
     [:description {:min 1} :string]
     [:timezone :timezone-id]

--- a/components/schema/src/com/devereux_henley/schema/contract.clj
+++ b/components/schema/src/com/devereux_henley/schema/contract.clj
@@ -121,6 +121,28 @@
                       :error/message       {:en "Should be a valid IANA timezone (e.g. US/Eastern, Europe/London)."}}
     :pred            (partial instance? ZoneId)}))
 
+(defn- coerce-optional-uuid
+  "Coerce a form-supplied value to a UUID, nil, or the untouched value.
+   Blank strings (what an unselected optional `<select>` submits) become
+   nil; a well-formed uuid string parses to a UUID; anything else passes
+   through so validation reports a coercion error rather than throwing."
+  [value]
+  (cond
+    (uuid? value)                                          value
+    (and (string? value) (not (clojure.string/blank? value)))
+    (try (java.util.UUID/fromString value) (catch Exception _ value))
+    :else                                                  nil))
+
+(def optional-uuid
+  (malli.core/-simple-schema
+   {:type            :optional-uuid
+    :type-properties {:decode/json        coerce-optional-uuid
+                      :decode/string      coerce-optional-uuid
+                      :json-schema/type   "string"
+                      :json-schema/format "uuid"
+                      :error/message      {:en "Should be a valid UUID or blank."}}
+    :pred            (fn [value] (or (nil? value) (uuid? value)))}))
+
 (def registry
   (merge
    (malli.core/default-schemas)
@@ -128,6 +150,7 @@
     :local-date     local-date
     :local-datetime local-datetime
     :timezone-id    timezone-id
+    :optional-uuid  optional-uuid
     :instant        instant
     :instance       instance
     :neg-int        (malli.core/-simple-schema

--- a/components/schema/test/com/devereux_henley/schema/contract_test.clj
+++ b/components/schema/test/com/devereux_henley/schema/contract_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer [deftest is]]
    [com.devereux-henley.schema.contract :as schema.contract]
    [malli.core :as m]
+   [malli.transform :as mt]
    [malli.util]
    [reitit.core :as reitit]))
 
@@ -69,3 +70,35 @@
            (get-in result [:_links :league])))
     (is (= (str "http://localhost:3001/api/season/" season-eid)
            (get-in result [:_links :season])))))
+
+(def ^:private optional-uuid-spec
+  (schema.contract/to-schema
+   [:map [:league-eid {:optional true} :optional-uuid]]))
+
+(defn- decode-league-eid
+  [value]
+  (:league-eid
+   (m/decode optional-uuid-spec {:league-eid value} (mt/transformer mt/json-transformer))))
+
+(deftest optional-uuid-coerces-blank-to-nil
+  (is (nil? (decode-league-eid ""))
+      "an empty string (unselected optional <select>) coerces to nil")
+  (is (nil? (decode-league-eid "   "))
+      "a whitespace-only string coerces to nil")
+  (is (m/validate optional-uuid-spec
+                  (m/decode optional-uuid-spec {:league-eid ""}
+                            (mt/transformer mt/json-transformer)))
+      "a blank optional-uuid passes validation after decoding")
+  (is (m/validate optional-uuid-spec {})
+      "an absent optional-uuid key is valid"))
+
+(deftest optional-uuid-parses-and-rejects
+  (let [uuid #uuid "22222222-2222-2222-2222-222222222222"]
+    (is (= uuid (decode-league-eid (str uuid)))
+        "a well-formed uuid string parses to a UUID")
+    (is (= uuid (decode-league-eid uuid))
+        "an already-parsed UUID is left intact"))
+  (is (not (m/validate optional-uuid-spec
+                       (m/decode optional-uuid-spec {:league-eid "not-a-uuid"}
+                                 (mt/transformer mt/json-transformer))))
+      "a malformed uuid string fails validation rather than coercing to nil"))


### PR DESCRIPTION
## Problem

Creating a tournament via the create form (`/view/game/:game-eid/tournament/create.html`) **failed with a 400** on the default **Standalone (no league)** path — nothing was created and the page did not navigate.

**Root cause:** the optional League and Season `<select>` inputs carry a `<option value="">` "none" choice. Under htmx `json-enc`, leaving them on that default submits `"league-eid": ""` (empty string). `create-tournament-specification` declared these as `[:maybe :uuid]`, and reitit body coercion cannot turn `""` into a UUID-or-nil, so it rejects the request at the coercion boundary with a **400** (not a 422 domain error). This is the first genuinely-optional UUID `<select>` in the app — the draft form's empty options sit on *required* fields, so the browser blocks empty submission and they never hit this.

## Fix

- Add an `:optional-uuid` schema type to `schema.contract`. Its `:decode/json` / `:decode/string` maps blank strings → `nil`, parses well-formed UUID strings → `UUID`, and passes malformed values through so validation still reports a proper error.
- Use `:optional-uuid` for `league-eid` and `season-eid` in `create-tournament-specification`.

## Verification

| Case | Before | After |
|---|---|---|
| Standalone (empty `league-eid`) | 400 | **200** |
| Empty league + empty season | 400 | **200** |
| Real `league-eid` UUID | 200 | **200** |
| Malformed uuid string | 400 | **400** (still rejected) |
| Full browser submit | fails | navigates to the new tournament, renders cleanly, no console errors |

Added unit tests in `schema/contract_test.clj` (`optional-uuid-coerces-blank-to-nil`, `optional-uuid-parses-and-rejects`). `poly check` OK, full `poly test` green, `cljfmt` + `clj-kondo` clean on changed files.

Closes rts-ufb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)