### PR TITLE
Distinguish not-yet-open registration from closed on tournament page

### DIFF
--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/tournament.clj
@@ -139,6 +139,17 @@
                      (->instant (get-in state [:registration :opens-at]))
                      (->instant (get-in state [:registration :closes-at])))))
 
+(defn registration-not-yet-open?
+  "Returns true when the tournament is still in registration and hasn't been
+   closed early, but its registration window has not opened yet (`now`
+   precedes `opens-at`). Lets the UI distinguish a not-yet-open window from a
+   closed one."
+  [state ^Instant now]
+  (and (= "registration" (:status state))
+       (not (get-in state [:registration :closed-early]))
+       (when-let [opens-at (->instant (get-in state [:registration :opens-at]))]
+         (.isBefore now opens-at))))
+
 (defn create-entry
   "Creates a tournament entry for a player. Returns the entry or an error map."
   [dependencies tournament-eid player-sub]
@@ -1039,25 +1050,27 @@
           decorated-phases     (mapv decorate-bracket-phase matches-by-phase)
           current-phase-config (get phases (:current-phase state))
           phase-count          (count phases)
-          schedule             (pending-matches-schedule matches-by-phase)]
-      {:data                tournament
-       :tournament-state    (update state :standings decorate-standings (:qualifier-count state))
-       :entries             entries
-       :matches-by-phase    decorated-phases
-       :schedule            schedule
-       :current-phase-label (or (phase-type-labels (:phase-type current-phase-config))
-                                (:phase-type current-phase-config))
-       :current-round-label (current-round-label decorated-phases (:eid (first schedule)))
-       :hero-format         (format-label (count entries) phases)
-       :phase-count         phase-count
-       :single-phase?       (= 1 phase-count)
-       :league              (when (:league-eid tournament)
-                              (db/league-by-eid conn (:league-eid tournament)))
-       :season              (when (:season-eid tournament)
-                              (handlers.season/get-season-by-eid dependencies (:season-eid tournament)))
-       :has-entry           (boolean (some #(= viewer-sub (:player-sub %)) entries))
-       :registration-open   (is-registration-open? state (Instant/now))
-       :is-organizer        (= viewer-sub (:created-by-sub tournament))})
+          schedule             (pending-matches-schedule matches-by-phase)
+          now                  (Instant/now)]
+      {:data                      tournament
+       :tournament-state          (update state :standings decorate-standings (:qualifier-count state))
+       :entries                   entries
+       :matches-by-phase          decorated-phases
+       :schedule                  schedule
+       :current-phase-label       (or (phase-type-labels (:phase-type current-phase-config))
+                                      (:phase-type current-phase-config))
+       :current-round-label       (current-round-label decorated-phases (:eid (first schedule)))
+       :hero-format               (format-label (count entries) phases)
+       :phase-count               phase-count
+       :single-phase?             (= 1 phase-count)
+       :league                    (when (:league-eid tournament)
+                                    (db/league-by-eid conn (:league-eid tournament)))
+       :season                    (when (:season-eid tournament)
+                                    (handlers.season/get-season-by-eid dependencies (:season-eid tournament)))
+       :has-entry                 (boolean (some #(= viewer-sub (:player-sub %)) entries))
+       :registration-open         (is-registration-open? state now)
+       :registration-not-yet-open (registration-not-yet-open? state now)
+       :is-organizer              (= viewer-sub (:created-by-sub tournament))})
     {:type :missing/resource :name "tournament" :id eid}))
 
 (defn- current-round-progress

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/tournament_test.clj
@@ -135,6 +135,46 @@
         now   (Instant/parse "2025-06-01T00:00:00Z")]
     (is (true? (handlers.tournament/is-registration-open? state now)))))
 
+;; ─── registration-not-yet-open? ─────────────────────────────────────────────
+
+(deftest registration-not-yet-open-true-before-opens-at
+  (let [state {:status       "registration"
+               :registration {:opens-at     (Instant/parse "2026-01-01T00:00:00Z")
+                              :closes-at    (Instant/parse "2030-01-01T00:00:00Z")
+                              :closed-early false}}
+        now   (Instant/parse "2025-06-01T00:00:00Z")]
+    (is (true? (boolean (handlers.tournament/registration-not-yet-open? state now))))))
+
+(deftest registration-not-yet-open-false-within-window
+  (let [state {:status       "registration"
+               :registration {:opens-at     (Instant/parse "2020-01-01T00:00:00Z")
+                              :closes-at    (Instant/parse "2030-01-01T00:00:00Z")
+                              :closed-early false}}
+        now   (Instant/parse "2025-06-01T00:00:00Z")]
+    (is (false? (boolean (handlers.tournament/registration-not-yet-open? state now))))))
+
+(deftest registration-not-yet-open-false-after-close
+  (let [state {:status       "registration"
+               :registration {:opens-at     (Instant/parse "2020-01-01T00:00:00Z")
+                              :closes-at    (Instant/parse "2025-01-01T00:00:00Z")
+                              :closed-early false}}
+        now   (Instant/parse "2025-06-01T00:00:00Z")]
+    (is (false? (boolean (handlers.tournament/registration-not-yet-open? state now))))))
+
+(deftest registration-not-yet-open-false-when-closed-early
+  (let [state {:status       "registration"
+               :registration {:opens-at     (Instant/parse "2026-01-01T00:00:00Z")
+                              :closes-at    (Instant/parse "2030-01-01T00:00:00Z")
+                              :closed-early true}}
+        now   (Instant/parse "2025-06-01T00:00:00Z")]
+    (is (false? (boolean (handlers.tournament/registration-not-yet-open? state now))))))
+
+(deftest registration-not-yet-open-false-when-no-opens-at
+  (let [state {:status       "registration"
+               :registration {:opens-at nil :closes-at nil :closed-early false}}
+        now   (Instant/parse "2025-06-01T00:00:00Z")]
+    (is (false? (boolean (handlers.tournament/registration-not-yet-open? state now))))))
+
 ;; ─── create-entry ────────────────────────────────────────────────────────────
 
 (deftest create-entry-returns-entry-when-open

--- a/components/rts-web/resources/rts-web/view/tournament-index.html
+++ b/components/rts-web/resources/rts-web/view/tournament-index.html
@@ -217,7 +217,7 @@
             <header class="section-header">
                 <h3 class="section-header-title" id="entry-heading">Your Entry</h3>
                 <span class="section-header-subtitle">
-                    {% if tournament-state.registration.closes-at %}Closes {{tournament-state.registration.closes-at}}{% endif %}
+                    {% if registration-not-yet-open %}{% if tournament-state.registration.opens-at %}Opens {{tournament-state.registration.opens-at}}{% endif %}{% elif tournament-state.registration.closes-at %}Closes {{tournament-state.registration.closes-at}}{% endif %}
                 </span>
             </header>
             <div class="viewer-action-card">
@@ -231,6 +231,8 @@
                 <form hx-post="/actions/tournament/{{data.eid}}/entry/me" hx-swap="none">
                     <button type="submit" class="btn btn-primary">Enter Tournament</button>
                 </form>
+                {% elif registration-not-yet-open %}
+                <div class="viewer-action-card-text muted">Registration has not opened yet.{% if tournament-state.registration.opens-at %} Opens {{tournament-state.registration.opens-at}}.{% endif %}</div>
                 {% else %}
                 <div class="viewer-action-card-text muted">Registration is closed.</div>
                 {% endif %}


### PR DESCRIPTION
## Problem

On the tournament detail page's **Your Entry** panel, a tournament whose registration window hasn't opened yet (now precedes `opens-at`) displayed **"Registration is closed"** — even though the tournament's top-level status was still `REGISTRATION`. The panel only modelled two states (open vs. closed), so an upcoming registration window fell through to the closed branch.

Spotted while auditing the create-tournament flow (a freshly created tournament with a future `opens-at` read as closed).

## Fix

- Add `registration-not-yet-open?` to the tournament handlers — true when status is `registration`, not closed early, and `now` precedes `opens-at`.
- Surface it on the view-model as `:registration-not-yet-open` (computing `now` once for both registration flags).
- `tournament-index.html` gains a distinct branch — *"Registration has not opened yet. Opens &lt;opens-at&gt;."* — with a matching *"Opens &lt;opens-at&gt;"* subtitle. The open and closed states are unchanged.

## Verification

Exercised all three states in the browser (dev-admin impersonation):

| Window | Panel |
|---|---|
| `opens-at` in the future | **Registration has not opened yet. Opens Fri Jul 10 …** (subtitle: *Opens …*) |
| now inside window | **Registration is open.** + Enter Tournament button (subtitle: *Closes …*) |
| `closes-at` in the past | **Registration is closed.** |

Added 5 unit tests for `registration-not-yet-open?` (before-open, within-window, after-close, closed-early, no-opens-at). Full `poly test` green, `poly check` OK, `cljfmt` + `clj-kondo` clean on changed files.

Closes rts-dye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)