### PR TITLE
Add per-game submit→confirm/dispute gate to Player Console (rts-6vy)

### DIFF
--- a/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
+++ b/bases/rts-api/src/com/devereux_henley/rts_api/configuration.clj
@@ -119,6 +119,8 @@
             :com.devereux-henley.rts-web.web.actions.tournament/open-check-in
             :com.devereux-henley.rts-web.web.actions.dispute/resolve-dispute
             :com.devereux-henley.rts-web.web.actions.dispute/dismiss-dispute
+            :com.devereux-henley.rts-web.web.actions.match-game/confirm-game
+            :com.devereux-henley.rts-web.web.actions.match-game/dispute-game
             :com.devereux-henley.rts-web.web.actions.league/create-league
             :com.devereux-henley.rts-web.web.actions.season/create-season))
 
@@ -135,6 +137,7 @@
   {:com.devereux-henley.rts-web.web.actions.draft/web-triggers      {}
    :com.devereux-henley.rts-web.web.actions.tournament/web-triggers {}
    :com.devereux-henley.rts-web.web.actions.dispute/web-triggers    {}
+   :com.devereux-henley.rts-web.web.actions.match-game/web-triggers {}
    :com.devereux-henley.rts-web.orchestration/registry              {:sources (integrant.core/refset :com.devereux-henley.rts-web.orchestration/web-trigger-source)}
    :com.devereux-henley.rts-web.orchestration/middleware            {:registry (integrant.core/ref :com.devereux-henley.rts-web.orchestration/registry)}})
 

--- a/components/e2e/tests/replay-submission.spec.js
+++ b/components/e2e/tests/replay-submission.spec.js
@@ -177,11 +177,32 @@ test.describe('Replay submission (Datalevin)', () => {
     );
     expect(submitRes.status()).toBe(200);
     // Mutations signal success via HX-Trigger, never a structured body.
-    expect(submitRes.headers()['hx-trigger-after-settle']).toContain('match-game-recorded');
+    expect(submitRes.headers()['hx-trigger']).toContain('game-submitted');
     const submitHtml = await submitRes.text();
     expect(submitHtml.toLowerCase()).toContain('game 1 submitted');
 
-    // The recorded game + its replay persist and render on the match detail page.
+    // The game is recorded pending confirmation — submitting does NOT complete
+    // the match. The non-uploader (dev-player-two) sees the confirm panel on the
+    // series page, whose confirm button carries the pending game's eid.
+    const seriesRes = await request.get(
+      `${BASE}/view/game/${GAME_EID}/tournament/${eid}/player/series.html`,
+      { headers: { Accept: 'application/htmx+html', Cookie: 'dev_impersonation=dev-player-two' } },
+    );
+    expect(seriesRes.status()).toBe(200);
+    const seriesHtml = await seriesRes.text();
+    const gm = seriesHtml.match(/match\/[0-9a-f-]{36}\/game\/([0-9a-f-]{36})\/confirm/);
+    expect(gm, 'the confirm panel should expose the pending game eid').not.toBeNull();
+    const gameEid = gm[1];
+
+    // Confirming a Bo1 game clinches the match.
+    const confirmRes = await request.post(
+      `${BASE}/actions/tournament/${eid}/match/${matchEid}/game/${gameEid}/confirm`,
+      { headers: actionHeaders('dev-player-two') },
+    );
+    expect(confirmRes.status()).toBe(200);
+    expect(confirmRes.headers()['hx-trigger']).toContain('game-confirmed');
+
+    // Now the recorded game + its replay persist and the match reads complete.
     const matchRes = await request.get(`${BASE}/api/match/${matchEid}`, {
       headers: htmlHeaders('dev-admin'),
     });

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/contract.clj
@@ -146,6 +146,9 @@
 (def set-match-lobby-code!           query.datalog.tournament/set-match-lobby-code!)
 (def create-game!                    query.datalog.tournament/create-game!)
 (def games-for-match                 query.datalog.tournament/games-for-match)
+(def match-game-by-eid               query.datalog.tournament/match-game-by-eid)
+(def confirm-game!                   query.datalog.tournament/confirm-game!)
+(def dispute-game!                   query.datalog.tournament/dispute-game!)
 
 ;;; ─── Stats DB entities ─────────────────────────────────────────────────────
 

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/tournament.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/query/datalog/tournament.clj
@@ -68,6 +68,9 @@
 (def ^:private match-game-pattern
   [:match-game/eid :match-game/game-index :match-game/winner-sub
    :match-game/uploader-local-alliance-index :match-game/created-at
+   :match-game/status :match-game/submitted-by-sub
+   :match-game/confirmed-by-sub :match-game/confirmed-at
+   :match-game/confirm-deadline
    {:match-game/replay [:replay/eid]}
    {:match-game/player-one-draft [:draft/eid]}
    {:match-game/player-two-draft [:draft/eid]}
@@ -153,7 +156,12 @@
      :replay-eid                    (some-> m :match-game/replay :replay/eid)
      :player-one-draft-eid          (some-> m :match-game/player-one-draft :draft/eid)
      :player-two-draft-eid          (some-> m :match-game/player-two-draft :draft/eid)
-     :created-at                    (:match-game/created-at m)}))
+     :created-at                    (:match-game/created-at m)
+     :status                        (:match-game/status m)
+     :submitted-by-sub              (:match-game/submitted-by-sub m)
+     :confirmed-by-sub              (:match-game/confirmed-by-sub m)
+     :confirmed-at                  (:match-game/confirmed-at m)
+     :confirm-deadline              (:match-game/confirm-deadline m)}))
 
 ;;; ─── Tournament reads ──────────────────────────────────────────────────────
 
@@ -469,26 +477,38 @@
 
 ;;; ─── Game mutations ────────────────────────────────────────────────────────
 
+(defn match-game-by-eid
+  "Fetch a single match-game by eid, flattened. Returns nil when not found."
+  [conn game-eid]
+  (let [db (d/db conn)]
+    (->game (d/pull db match-game-pattern [:match-game/eid game-eid]))))
+
 (defn create-game!
-  "Record a per-game result for a match, owned via `:match/games`. `opts`
-  may carry `:replay-eid`, `:uploader-local-alliance-index`,
-  `:player-one-draft-eid`, `:player-two-draft-eid`, which become refs to
-  the `:replay` and per-side `:draft` entities."
+  "Record a per-game result for a match, owned via `:match/games`, in
+  `:pending-confirmation` status. `opts` may carry `:replay-eid`,
+  `:uploader-local-alliance-index`, `:player-one-draft-eid`,
+  `:player-two-draft-eid` (which become refs to the `:replay` and per-side
+  `:draft` entities), plus `:submitted-by-sub` (the uploader) and
+  `:confirm-deadline` (an `Instant`/`Date` after which the game auto-settles)."
   ([conn match-eid game-index winner-sub]
    (create-game! conn match-eid game-index winner-sub {}))
   ([conn match-eid game-index winner-sub
     {:keys [replay-eid uploader-local-alliance-index
-            player-one-draft-eid player-two-draft-eid]}]
+            player-one-draft-eid player-two-draft-eid
+            submitted-by-sub confirm-deadline]}]
    (let [game-eid (random-uuid)
          game     (cond-> {:match-game/eid        game-eid
                            :match-game/game-index game-index
                            :match-game/winner-sub winner-sub
+                           :match-game/status     :pending-confirmation
                            :match-game/created-at (Date.)}
                     replay-eid                          (assoc :match-game/replay [:replay/eid replay-eid])
                     (some? uploader-local-alliance-index) (assoc :match-game/uploader-local-alliance-index
                                                                  uploader-local-alliance-index)
                     player-one-draft-eid                (assoc :match-game/player-one-draft [:draft/eid player-one-draft-eid])
-                    player-two-draft-eid                (assoc :match-game/player-two-draft [:draft/eid player-two-draft-eid]))]
+                    player-two-draft-eid                (assoc :match-game/player-two-draft [:draft/eid player-two-draft-eid])
+                    submitted-by-sub                    (assoc :match-game/submitted-by-sub submitted-by-sub)
+                    confirm-deadline                    (assoc :match-game/confirm-deadline (->date confirm-deadline)))]
      (d/transact!
       conn
       [{:match/eid match-eid :match/games [game]}])
@@ -496,7 +516,35 @@
       :match-eid                     match-eid
       :game-index                    game-index
       :winner-sub                    winner-sub
+      :status                        :pending-confirmation
+      :submitted-by-sub              submitted-by-sub
+      :confirm-deadline              confirm-deadline
       :replay-eid                    replay-eid
       :uploader-local-alliance-index uploader-local-alliance-index
       :player-one-draft-eid          player-one-draft-eid
       :player-two-draft-eid          player-two-draft-eid})))
+
+(defn confirm-game!
+  "Mark a pending game `:confirmed`, stamping `:confirmed-by-sub` (the literal
+  `\"auto\"` when settled by lapse) and `:confirmed-at`. Returns the flattened
+  game."
+  [conn game-eid confirming-sub confirmed-at]
+  (d/with-transaction [tx-conn conn]
+    (d/transact!
+     tx-conn
+     [{:match-game/eid              game-eid
+       :match-game/status           :confirmed
+       :match-game/confirmed-by-sub confirming-sub
+       :match-game/confirmed-at     (->date confirmed-at)}])
+    (match-game-by-eid tx-conn game-eid)))
+
+(defn dispute-game!
+  "Mark a pending game `:disputed`. The dispute row itself is created
+  separately via `create-dispute!`. Returns the flattened game."
+  [conn game-eid]
+  (d/with-transaction [tx-conn conn]
+    (d/transact!
+     tx-conn
+     [{:match-game/eid    game-eid
+       :match-game/status :disputed}])
+    (match-game-by-eid tx-conn game-eid)))

--- a/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/match_game.clj
+++ b/components/rts-data-access/src/com/devereux_henley/rts_data_access/schema/datalog/match_game.clj
@@ -4,7 +4,13 @@
   0-based position in the series. `:match-game/replay` refs the parsed
   `:replay`; `:player-one-draft` / `:player-two-draft` ref the per-side
   `:draft`s. `:uploader-local-alliance-index` records which alliance (0/1)
-  the uploader played, mapping the per-side drafts back to each player.")
+  the uploader played, mapping the per-side drafts back to each player.
+
+  `:status` tracks the per-game verification gate: a submitted game is
+  `:pending-confirmation` until the non-uploading player confirms
+  (`:confirmed`) or disputes it (`:disputed`). `:submitted-by-sub` is the
+  uploader; `:confirmed-by-sub` / `:confirmed-at` record who accepted the
+  result (the literal `\"auto\"` when the `:confirm-deadline` lapses).")
 
 (def schema
   {:match-game/eid                           {:db/valueType :db.type/uuid
@@ -15,4 +21,9 @@
    :match-game/uploader-local-alliance-index {:db/valueType :db.type/long}
    :match-game/player-one-draft              {:db/valueType :db.type/ref}
    :match-game/player-two-draft              {:db/valueType :db.type/ref}
-   :match-game/created-at                    {:db/valueType :db.type/instant}})
+   :match-game/created-at                    {:db/valueType :db.type/instant}
+   :match-game/status                        {:db/valueType :db.type/keyword}
+   :match-game/submitted-by-sub              {:db/valueType :db.type/string}
+   :match-game/confirmed-by-sub              {:db/valueType :db.type/string}
+   :match-game/confirmed-at                  {:db/valueType :db.type/instant}
+   :match-game/confirm-deadline              {:db/valueType :db.type/instant}})

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/contract.clj
@@ -215,4 +215,7 @@
 
 (def parse-replay-file              handlers.replay/parse-replay-file)
 (def record-game-from-parsed        handlers.replay/record-game-from-parsed)
+(def confirm-game                   handlers.replay/confirm-game)
+(def dispute-game                   handlers.replay/dispute-game)
+(def settle-expired-confirmations!  handlers.replay/settle-expired-confirmations!)
 (def pick-game-mode                 handlers.replay/pick-game-mode)

--- a/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/replay.clj
+++ b/components/rts-domain/src/com/devereux_henley/rts_domain/handlers/replay.clj
@@ -5,6 +5,7 @@
    [clojure.java.shell :as shell]
    [clojure.string :as string]
    [com.devereux-henley.rts-data-access.contract :as db]
+   [com.devereux-henley.rts-domain.handlers.dispute :as handlers.dispute]
    [com.devereux-henley.rts-domain.handlers.draft :as handlers.draft]
    [com.devereux-henley.rts-domain.handlers.tournament :as handlers.tournament]
    [com.devereux-henley.rts-domain.rules.tournament :as rules.tournament]
@@ -13,7 +14,13 @@
    [jsonista.core :as jsonista]
    [malli.core :as m])
   (:import
-   [java.time Instant]))
+   [java.time Duration Instant]
+   [java.util Date]))
+
+(def confirm-window
+  "How long the non-uploading player has to confirm a submitted game before it
+  auto-settles as confirmed on the next read."
+  (Duration/ofMinutes 10))
 
 (def ^:private json-mapper
   ;; The Rust binary emits snake_case JSON keys; we want Clojure-idiomatic
@@ -360,23 +367,131 @@
                     :game-modes      game-modes
                     :uploaded-by-sub uploaded-by-sub
                     :now             now})
+                  deadline   (.plus now confirm-window)
                   stored     (db/create-game!
                               conn match-eid game-index winner-sub
                               {:replay-eid                    (:eid replay)
                                :uploader-local-alliance-index (:uploader-local-alliance-index replay)
                                :player-one-draft-eid          player-one-draft-eid
-                               :player-two-draft-eid          player-two-draft-eid})
-                  all-games  (conj (mapv #(select-keys % [:winner-sub]) existing-games)
-                                   {:winner-sub winner-sub})
-                  clincher   (rules.tournament/check-match-complete all-games (:format match))]
-              (when clincher
-              ;; Route through the domain function so standings recalculate
-              ;; and the tournament-complete check fires.
-                (handlers.tournament/update-match-result dependencies match-eid clincher))
-              (cond-> {:type            :match-record/game-recorded
-                       :match-eid       match-eid
-                       :game            stored
-                       :game-index      game-index
-                       :winner-sub      winner-sub
-                       :match-complete? (boolean clincher)}
-                clincher (assoc :match-winner clincher)))))))))
+                               :player-two-draft-eid          player-two-draft-eid
+                               :submitted-by-sub              uploaded-by-sub
+                               :confirm-deadline              deadline})]
+              ;; The game is recorded `:pending-confirmation`; the match does
+              ;; not advance until the non-uploading player confirms (or the
+              ;; confirm window lapses). See `confirm-game` / `dispute-game`.
+              {:type                   :match-record/game-recorded
+               :match-eid              match-eid
+               :game                   stored
+               :game-eid               (:eid stored)
+               :game-index             game-index
+               :winner-sub             winner-sub
+               :awaiting-confirmation? true
+               :confirm-deadline       deadline})))))))
+
+;; ─── Per-game confirmation gate ──────────────────────────────────────────────
+
+(defn- load-pending-game-for-actor
+  "Loads a match-game and validates it awaits confirmation, belongs to `match-eid`,
+  and that `actor-sub` is the participant who did NOT submit it. Returns
+  `[:ok {:match m :game g}]` or `[:error {:type :match-record/error …}]`."
+  [dependencies match-eid game-eid actor-sub]
+  (let [conn  (:datalog-connection dependencies)
+        match (db/match-by-eid conn match-eid)
+        game  (db/match-game-by-eid conn game-eid)]
+    (cond
+      (nil? match)
+      [:error (short-circuit-error "Match not found.")]
+
+      (nil? game)
+      [:error (short-circuit-error "Game not found.")]
+
+      (not= match-eid (:match-eid game))
+      [:error (short-circuit-error "Game does not belong to this match.")]
+
+      (not= :pending-confirmation (:status game))
+      [:error (short-circuit-error "Game is not awaiting confirmation.")]
+
+      (not (valid-winner? match actor-sub))
+      [:error (short-circuit-error "Only a match participant can act on this game.")]
+
+      (= actor-sub (:submitted-by-sub game))
+      [:error (short-circuit-error "The player who submitted a game cannot confirm or dispute it.")]
+
+      :else
+      [:ok {:match match :game game}])))
+
+(defn- finalize-confirmation!
+  "Marks `game-eid` confirmed by `confirming-sub` and, when the series is now
+  clinched over confirmed games, completes the match (recalculating standings).
+  Returns `{:match-complete? bool :match-winner sub?}`."
+  [dependencies match-eid game-eid confirming-sub]
+  (let [conn      (:datalog-connection dependencies)
+        match     (db/match-by-eid conn match-eid)
+        _         (db/confirm-game! conn game-eid confirming-sub (Instant/now))
+        confirmed (filter #(= :confirmed (:status %)) (db/games-for-match conn match-eid))
+        clincher  (rules.tournament/check-match-complete confirmed (:format match))]
+    (when clincher
+      ;; Route through the domain function so standings recalculate and the
+      ;; tournament-complete check fires.
+      (handlers.tournament/update-match-result dependencies match-eid clincher))
+    (cond-> {:match-complete? (boolean clincher)}
+      clincher (assoc :match-winner clincher))))
+
+(defn confirm-game
+  "The non-uploading participant accepts a submitted game's result. Marks the
+  game `:confirmed` and, if the series is now clinched, completes the match.
+  Returns `:type :match-game/confirmed` (with `:match-complete?` / `:match-winner`)
+  or a typed `:match-record/error`."
+  [dependencies match-eid game-eid confirming-sub]
+  (let [[status v] (load-pending-game-for-actor dependencies match-eid game-eid confirming-sub)]
+    (if (= :error status)
+      v
+      (merge {:type      :match-game/confirmed
+              :match-eid match-eid
+              :game-eid  game-eid}
+             (finalize-confirmation! dependencies match-eid game-eid confirming-sub)))))
+
+(defn dispute-game
+  "The non-uploading participant contests a submitted game's result. Opens a
+  dispute ticket (defaulting to the `\"conflicting-result\"` kind) and marks the
+  game `:disputed`; the series pauses (no advancement) until an organizer resolves it.
+  Returns `:type :match-game/disputed` with the dispute eid, or a typed
+  `:match-record/error`."
+  [dependencies {:keys [match-eid game-eid reporter-sub kind detail]}]
+  (let [[status v] (load-pending-game-for-actor dependencies match-eid game-eid reporter-sub)]
+    (if (= :error status)
+      v
+      (let [conn    (:datalog-connection dependencies)
+            match   (:match v)
+            dispute (handlers.dispute/open-dispute
+                     dependencies
+                     {:tournament-eid (:tournament-eid match)
+                      :match-eid      match-eid
+                      :match-game-eid game-eid
+                      :kind           (or kind "conflicting-result")
+                      :reporter-sub   reporter-sub
+                      :detail         detail})]
+        (if (= :dispute/error (:type dispute))
+          (short-circuit-error (:message dispute))
+          (do
+            (db/dispute-game! conn game-eid)
+            {:type        :match-game/disputed
+             :match-eid   match-eid
+             :game-eid    game-eid
+             :dispute-eid (:eid dispute)}))))))
+
+(defn settle-expired-confirmations!
+  "Auto-settles every `:pending-confirmation` game on the match whose
+  `:confirm-deadline` has lapsed, confirming it on behalf of `\"auto\"` (which
+  advances the series if it clinches). Called lazily on read so a missed confirm
+  window resolves without a scheduler. Idempotent; returns the count settled."
+  [dependencies match-eid]
+  (let [conn    (:datalog-connection dependencies)
+        now     (Instant/now)
+        expired (->> (db/games-for-match conn match-eid)
+                     (filter #(= :pending-confirmation (:status %)))
+                     (filter #(when-let [^Date d (:confirm-deadline %)]
+                                (.isBefore (.toInstant d) now))))]
+    (doseq [g expired]
+      (finalize-confirmation! dependencies match-eid (:eid g) "auto"))
+    (count expired)))

--- a/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/replay_test.clj
+++ b/components/rts-domain/test/com/devereux_henley/rts_domain/handlers/replay_test.clj
@@ -6,7 +6,7 @@
    [com.devereux-henley.rts-domain.handlers.replay :as handlers.replay]
    [jsonista.core :as jsonista])
   (:import
-   [java.util UUID]))
+   [java.util Date UUID]))
 
 ;; The submit flow auto-creates one draft per side per game from the parsed
 ;; replay; the data-access fns it pulls in are defaulted here to safe
@@ -203,7 +203,7 @@
         (is (= 2962 (:engine-cost main-entry))
             ":engine-cost preserves the parser-emitted true cost for audit")))))
 
-(deftest record-game-persists-and-completes-bo1
+(deftest record-game-persists-pending-without-advancing
   (let [stored-replays  (atom [])
         stored-games    (atom [])
         stored-drafts   (atom [])
@@ -216,12 +216,16 @@
                                                               (swap! stored-replays conj spec)
                                                               spec)
                   data-access.contract/create-game!         (fn [_ _meid game-index winner-sub opts]
-                                                              (let [g (merge {:game-index game-index
+                                                              (let [g (merge {:eid        (UUID/randomUUID)
+                                                                              :game-index game-index
                                                                               :winner-sub winner-sub
+                                                                              :status     :pending-confirmation
                                                                               :replay-eid (:replay-eid opts)}
                                                                              (select-keys opts
                                                                                           [:player-one-draft-eid
-                                                                                           :player-two-draft-eid]))]
+                                                                                           :player-two-draft-eid
+                                                                                           :submitted-by-sub
+                                                                                           :confirm-deadline]))]
                                                                 (swap! stored-games conj g)
                                                                 g))
                   data-access.contract/update-match-result! (fn [_ _ winner] (reset! match-completed winner))
@@ -244,13 +248,19 @@
         (testing "one replay row persisted"
           (is (= 1 (count @stored-replays)))
           (is (= "sigmar_42" (-> @stored-replays first :uploaded-by-sub))))
-        (testing "one match_game row persisted"
+        (testing "one match_game row persisted as pending-confirmation"
           (is (= 1 (count @stored-games)))
-          (is (uuid? (-> @stored-games first :replay-eid))))
-        (testing "Bo1 winner crowned immediately"
-          (is (= "sigmar_42" @match-completed))
+          (is (uuid? (-> @stored-games first :replay-eid)))
+          (is (= :pending-confirmation (-> @stored-games first :status)))
+          (is (= "sigmar_42" (-> @stored-games first :submitted-by-sub)))
+          (is (some? (-> @stored-games first :confirm-deadline))))
+        (testing "match does NOT advance on submit — it awaits confirmation"
+          (is (nil? @match-completed) "no match completion on submit")
           (is (= "sigmar_42" (:winner-sub result)))
-          (is (true? (:match-complete? result))))
+          (is (true? (:awaiting-confirmation? result)))
+          (is (some? (:confirm-deadline result)))
+          (is (uuid? (:game-eid result)))
+          (is (not (contains? result :match-complete?))))
         (testing "auto-creates one draft per side"
           (is (= 2 (count @stored-drafts))
               "Bo1 with 1 game → 2 drafts (one per side)")
@@ -260,3 +270,114 @@
           (is (= {emp-faction-eid 1 chd-faction-eid 1}
                  (frequencies (map :faction-eid @stored-drafts)))
               "factions resolved from parsed faction_key per alliance"))))))
+
+;; ─── confirm-game / dispute-game / auto-settle ─────────────────────────────
+
+(def ^:private bo3-match (assoc bo1-match :format 3))
+
+(def ^:private game-eid (UUID/fromString "00000000-0000-4000-8000-0000000000aa"))
+
+(defn- pending-game
+  "A submitted-but-unconfirmed game: winner sigmar_42 uploaded it, so runemaster
+  is the participant who must confirm or dispute."
+  [& {:as overrides}]
+  (merge {:eid              game-eid
+          :match-eid        match-eid
+          :game-index       0
+          :status           :pending-confirmation
+          :winner-sub       "sigmar_42"
+          :submitted-by-sub "sigmar_42"}
+         overrides))
+
+(deftest confirm-game-completes-bo1-on-loser-confirm
+  (let [confirmed (atom nil)
+        completed (atom nil)]
+    (with-redefs [data-access.contract/match-by-eid         (fn [_ _] bo1-match)
+                  data-access.contract/match-game-by-eid    (fn [_ _] (pending-game))
+                  data-access.contract/confirm-game!        (fn [_ geid sub _at]
+                                                              (reset! confirmed [geid sub])
+                                                              (pending-game :status :confirmed :confirmed-by-sub sub))
+                  data-access.contract/games-for-match      (fn [_ _] [(pending-game :status :confirmed)])
+                  data-access.contract/update-match-result! (fn [_ _ w] (reset! completed w))]
+      (let [r (handlers.replay/confirm-game deps match-eid game-eid "runemaster")]
+        (is (= :match-game/confirmed (:type r)))
+        (is (= [game-eid "runemaster"] @confirmed))
+        (is (true? (:match-complete? r)))
+        (is (= "sigmar_42" (:match-winner r)))
+        (is (= "sigmar_42" @completed) "match completed with the clinching winner")))))
+
+(deftest confirm-game-rejects-submitter-self-confirm
+  (with-redefs [data-access.contract/match-by-eid      (fn [_ _] bo1-match)
+                data-access.contract/match-game-by-eid (fn [_ _] (pending-game))]
+    (let [r (handlers.replay/confirm-game deps match-eid game-eid "sigmar_42")]
+      (is (= :match-record/error (:type r)))
+      (is (re-find #"submitted a game cannot" (:message r))))))
+
+(deftest confirm-game-rejects-non-participant
+  (with-redefs [data-access.contract/match-by-eid      (fn [_ _] bo1-match)
+                data-access.contract/match-game-by-eid (fn [_ _] (pending-game))]
+    (let [r (handlers.replay/confirm-game deps match-eid game-eid "stranger")]
+      (is (= :match-record/error (:type r)))
+      (is (re-find #"match participant" (:message r))))))
+
+(deftest confirm-game-rejects-already-settled
+  (with-redefs [data-access.contract/match-by-eid      (fn [_ _] bo1-match)
+                data-access.contract/match-game-by-eid (fn [_ _] (pending-game :status :confirmed))]
+    (let [r (handlers.replay/confirm-game deps match-eid game-eid "runemaster")]
+      (is (= :match-record/error (:type r)))
+      (is (re-find #"not awaiting confirmation" (:message r))))))
+
+(deftest confirm-game-does-not-complete-when-not-clinched
+  (let [completed (atom nil)]
+    (with-redefs [data-access.contract/match-by-eid         (fn [_ _] bo3-match)
+                  data-access.contract/match-game-by-eid    (fn [_ _] (pending-game))
+                  data-access.contract/confirm-game!        (fn [_ _ _ _] (pending-game :status :confirmed))
+                  data-access.contract/games-for-match      (fn [_ _] [(pending-game :status :confirmed)])
+                  data-access.contract/update-match-result! (fn [_ _ w] (reset! completed w))]
+      (let [r (handlers.replay/confirm-game deps match-eid game-eid "runemaster")]
+        (is (= :match-game/confirmed (:type r)))
+        (is (false? (:match-complete? r)))
+        (is (nil? @completed) "one win in a Bo3 does not clinch")))))
+
+(deftest dispute-game-opens-ticket-and-pauses-series
+  (let [disputed    (atom nil)
+        completed   (atom nil)
+        dispute-eid (UUID/randomUUID)]
+    (with-redefs [data-access.contract/match-by-eid         (fn [_ _] bo3-match)
+                  data-access.contract/match-game-by-eid    (fn [_ _] (pending-game))
+                  data-access.contract/games-for-match      (fn [_ _] [(pending-game)])
+                  data-access.contract/create-dispute!      (fn [_ spec]
+                                                              {:eid          dispute-eid
+                                                               :status       "open"
+                                                               :kind         (:kind spec)
+                                                               :reporter-sub (:reporter-sub spec)})
+                  data-access.contract/dispute-game!        (fn [_ geid]
+                                                              (reset! disputed geid)
+                                                              (pending-game :status :disputed))
+                  data-access.contract/update-match-result! (fn [_ _ w] (reset! completed w))]
+      (let [r (handlers.replay/dispute-game
+               deps {:match-eid    match-eid    :game-eid game-eid
+                     :reporter-sub "runemaster" :detail   "wrong winner detected"})]
+        (is (= :match-game/disputed (:type r)))
+        (is (= dispute-eid (:dispute-eid r)))
+        (is (= game-eid @disputed) "the game is marked disputed")
+        (is (nil? @completed) "disputing does not advance the series")))))
+
+(deftest settle-expired-confirmations-settles-only-lapsed
+  (let [confirms  (atom [])
+        now-ms    (System/currentTimeMillis)
+        g-expired (UUID/randomUUID)
+        g-fresh   (UUID/randomUUID)]
+    (with-redefs [data-access.contract/match-by-eid         (fn [_ _] bo3-match)
+                  data-access.contract/games-for-match      (fn [_ _]
+                                                              [{:eid              g-expired                :match-eid  match-eid
+                                                                :status           :pending-confirmation    :winner-sub "sigmar_42"
+                                                                :confirm-deadline (Date. (- now-ms 60000))}
+                                                               {:eid              g-fresh                   :match-eid  match-eid
+                                                                :status           :pending-confirmation     :winner-sub "sigmar_42"
+                                                                :confirm-deadline (Date. (+ now-ms 600000))}])
+                  data-access.contract/confirm-game!        (fn [_ geid sub _at] (swap! confirms conj [geid sub]) nil)
+                  data-access.contract/update-match-result! (fn [_ _ _] nil)]
+      (let [n (handlers.replay/settle-expired-confirmations! deps match-eid)]
+        (is (= 1 n) "only the lapsed game auto-settles")
+        (is (= [[g-expired "auto"]] @confirms) "auto-confirmed on behalf of \"auto\"")))))

--- a/components/rts-web/resources/rts-web/components/tournament/player-game-confirmed.html
+++ b/components/rts-web/resources/rts-web/components/tournament/player-game-confirmed.html
@@ -1,0 +1,25 @@
+{# Returned by the confirm /actions handler after the non-uploading player
+   accepts a submitted game. Reports the confirmation and, if the game clinched
+   the series, that the match is decided. #}
+<div class="replay-submitted{% if match-complete? %} replay-submitted--match-complete{% endif %}"
+     role="status"
+     aria-live="polite">
+    <div class="replay-submitted-mark" aria-hidden="true">✓</div>
+    <div class="replay-submitted-body">
+        <div class="eyebrow">Result confirmed</div>
+        <h3 class="replay-submitted-headline">You confirmed the game</h3>
+        <p class="replay-submitted-sub">
+            {% if match-complete? %}
+            That clinches the series — <strong>{{match-winner}}</strong> takes the match.
+            The bracket advances from here.
+            {% else %}
+            The result is recorded and the series continues. Play the next game and
+            submit its replay when it's done.
+            {% endif %}
+        </p>
+        <div class="replay-submitted-actions">
+            <a class="btn btn-ghost btn-sm"
+               href="/view/game/{{game-eid}}/tournament/{{data.eid}}/player/series.html">Back to series</a>
+        </div>
+    </div>
+</div>

--- a/components/rts-web/resources/rts-web/components/tournament/player-step-awaiting.html
+++ b/components/rts-web/resources/rts-web/components/tournament/player-step-awaiting.html
@@ -1,0 +1,46 @@
+{# The uploading player waits for the opponent to confirm the submitted game.
+   A live countdown ticks down to the confirm deadline; the result auto-settles
+   as confirmed if the window lapses. #}
+<div class="await-view" role="status" aria-live="polite">
+    <div class="await-view-spinner" aria-hidden="true">
+        <span class="await-view-spinner-ring await-view-spinner-ring--progress"></span>
+        <span class="await-view-spinner-label mono js-confirm-countdown"
+              data-confirm-deadline="{{pending-game.confirm-deadline-ms}}">—:—</span>
+    </div>
+    <div class="await-view-info">
+        <div class="eyebrow">Awaiting confirmation</div>
+        <h3 class="await-view-headline">
+            Waiting for your opponent to confirm Game {{pending-game.game-index|add:1}}
+        </h3>
+        <p class="await-view-sub">
+            You submitted the replay · {{pending-game.winner-sub}} won. Your opponent can
+            confirm or dispute it. If they don't respond before the window closes, the
+            result confirms automatically.
+        </p>
+        <ul class="await-view-checklist">
+            <li><span class="await-view-pip await-view-pip--done" aria-hidden="true">✓</span> Replay submitted</li>
+            <li><span class="await-view-pip await-view-pip--live" aria-hidden="true">●</span> Opponent to confirm or dispute</li>
+            <li><span class="await-view-pip await-view-pip--pending" aria-hidden="true">·</span> Series advances on confirm</li>
+        </ul>
+    </div>
+    <div class="await-view-actions">
+        <a class="btn btn-ghost btn-sm"
+           href="/view/game/{{game-eid}}/tournament/{{data.eid}}/player/series.html">Refresh</a>
+    </div>
+</div>
+<script>
+ (function () {
+   var el = document.querySelector('.js-confirm-countdown[data-confirm-deadline]');
+   if (!el) return;
+   var deadline = parseInt(el.getAttribute('data-confirm-deadline'), 10);
+   if (isNaN(deadline)) { el.textContent = '—:—'; return; }
+   function tick() {
+     var ms = deadline - Date.now();
+     if (ms <= 0) { el.textContent = '0:00'; return; }
+     var s = Math.floor(ms / 1000);
+     el.textContent = Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
+   }
+   tick();
+   setInterval(tick, 1000);
+ })();
+</script>

--- a/components/rts-web/resources/rts-web/components/tournament/player-step-confirm.html
+++ b/components/rts-web/resources/rts-web/components/tournament/player-step-confirm.html
@@ -1,0 +1,33 @@
+{# The non-uploading player reviews the submitted game and either confirms the
+   auto-detected winner (advancing the series) or disputes it (opening a ticket
+   for an organizer and pausing the series). #}
+<div class="confirm-view">
+    <div class="confirm-view-info">
+        <div class="eyebrow">Game {{pending-game.game-index|add:1}} · confirm result</div>
+        <h3 class="confirm-view-headline">
+            {{pending-game.submitted-by-sub}} submitted the replay — {{pending-game.winner-sub}} won
+        </h3>
+        <p class="confirm-view-sub">
+            Confirm to record the result and advance the series, or dispute it to open
+            a ticket for an organizer to review. Disputing pauses the series until it's
+            resolved.
+        </p>
+    </div>
+    <div class="confirm-view-actions cluster">
+        <button type="button"
+                class="btn btn-primary"
+                hx-post="/actions/tournament/{{data.eid}}/match/{{match-eid}}/game/{{pending-game.eid}}/confirm"
+                hx-target="closest .panel-body"
+                hx-swap="innerHTML">
+            Confirm · {{pending-game.winner-sub}} won
+        </button>
+        <button type="button"
+                class="btn btn-ghost"
+                hx-post="/actions/tournament/{{data.eid}}/match/{{match-eid}}/game/{{pending-game.eid}}/dispute"
+                hx-target="closest .panel-body"
+                hx-swap="innerHTML"
+                hx-confirm="Dispute this result? The series pauses until an organizer resolves it.">
+            Dispute result
+        </button>
+    </div>
+</div>

--- a/components/rts-web/resources/rts-web/components/tournament/player-step-disputed.html
+++ b/components/rts-web/resources/rts-web/components/tournament/player-step-disputed.html
@@ -1,0 +1,19 @@
+{# Shown once a game has been disputed: the series is paused while an organizer
+   reviews the ticket. Rendered inline by the series view and returned by the
+   dispute /actions handler after the losing player raises a dispute. #}
+<div class="disputed-view" role="status" aria-live="polite">
+    <div class="disputed-view-mark" aria-hidden="true">⚑</div>
+    <div class="disputed-view-info">
+        <div class="eyebrow">Result disputed</div>
+        <h3 class="disputed-view-headline">This game is under review</h3>
+        <p class="disputed-view-sub">
+            A dispute has been opened and the series is paused. An organizer will review
+            the replay and settle the result — you'll be able to continue once it's
+            resolved.
+        </p>
+    </div>
+    <div class="disputed-view-actions">
+        <a class="btn btn-ghost btn-sm"
+           href="/view/game/{{game-eid}}/tournament/{{data.eid}}/player/series.html">Refresh</a>
+    </div>
+</div>

--- a/components/rts-web/resources/rts-web/view/player-series.html
+++ b/components/rts-web/resources/rts-web/view/player-series.html
@@ -21,6 +21,21 @@
             </header>
             <div class="panel-body">
 
+                {% if real-step %}
+                {# A real submitted game on the current match takes over from the
+                   demo walkthrough: the uploader waits, the opponent confirms or
+                   disputes, and a disputed game shows the paused state. #}
+                {% ifequal real-step "awaiting" %}
+                {% include "rts-web/components/tournament/player-step-awaiting.html" %}
+                {% endifequal %}
+                {% ifequal real-step "confirm" %}
+                {% include "rts-web/components/tournament/player-step-confirm.html" %}
+                {% endifequal %}
+                {% ifequal real-step "disputed" %}
+                {% include "rts-web/components/tournament/player-step-disputed.html" %}
+                {% endifequal %}
+                {% else %}
+
                 {% if step-live? %}
                 {% include "rts-web/components/tournament/player-step-live.html" %}
                 {% endif %}
@@ -42,6 +57,8 @@
 
                 {% if step-opp-uploading? %}
                 {% include "rts-web/components/tournament/player-step-await.html" %}
+                {% endif %}
+
                 {% endif %}
 
             </div>

--- a/components/rts-web/src/com/devereux_henley/rts_web/contract.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/contract.clj
@@ -3,6 +3,7 @@
    [com.devereux-henley.rts-web.orchestration]
    [com.devereux-henley.rts-web.render :as render]
    [com.devereux-henley.rts-web.web.actions.dispute]
+   [com.devereux-henley.rts-web.web.actions.match-game]
    [com.devereux-henley.rts-web.web.actions.draft]
    [com.devereux-henley.rts-web.web.actions.league]
    [com.devereux-henley.rts-web.web.actions.season]

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/actions/match_game.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/actions/match_game.clj
@@ -1,0 +1,71 @@
+(ns com.devereux-henley.rts-web.web.actions.match-game
+  "/actions handlers for the per-game confirmation gate on the Player Console:
+  the non-uploading player confirms a submitted game (advancing the series if it
+  clinches) or disputes it (opening a ticket and pausing the series). Confirm and
+  dispute fire HX-Triggers in the `:player-series` group; a dispute additionally
+  fires the `:dispute-queue` group so the organizer console refreshes."
+  (:require
+   [com.devereux-henley.rts-domain.contract :as domain]
+   [com.devereux-henley.rts-web.orchestration :as orchestration]
+   [com.devereux-henley.rts-web.render :as render]
+   [com.devereux-henley.rts-web.web.actions.common :as common]
+   [integrant.core]))
+
+(derive ::web-triggers ::orchestration/web-trigger-source)
+
+(defmethod integrant.core/init-key ::web-triggers
+  [_init-key _config]
+  {:player-series ["game-submitted" "game-confirmed" "game-disputed"]
+   :dispute-queue ["dispute-opened"]})
+
+(defn- series-context
+  "Template context shared by the confirm/dispute response fragments and the
+  inline series-view panels, so both render with the same variable names:
+  `game-eid` (the catalog game, for the series back-link), `data.eid` (the
+  tournament), `match-eid`, and `pending-game.eid` (the match-game). Resolves the
+  tournament once to recover its catalog `:game-eid`."
+  [dependencies tournament-eid match-eid game-eid]
+  (let [tournament (domain/get-tournament-by-eid dependencies tournament-eid)]
+    {:game-eid     (:game-eid tournament)
+     :data         {:eid tournament-eid}
+     :match-eid    match-eid
+     :pending-game {:eid game-eid}}))
+
+(defmethod integrant.core/init-key ::confirm-game
+  [_init-key dependencies]
+  (fn [{{{:keys [tournament-eid match-eid game-eid]} :path} :parameters
+        session                                             :ory-session
+        :as                                                 _request}]
+    (let [confirming-sub (get-in session [:identity :id])
+          result         (domain/confirm-game dependencies match-eid game-eid confirming-sub)]
+      (if (= :match-record/error (:type result))
+        (common/error-fragment 422 (:message result))
+        {:status  200
+         :headers {"Content-Type" "text/html; charset=utf-8"
+                   "HX-Trigger"   "game-confirmed"}
+         :body    (render/render-component
+                   "tournament/player-game-confirmed.html"
+                   (merge (series-context dependencies tournament-eid match-eid game-eid)
+                          {:match-complete? (:match-complete? result)
+                           :match-winner    (:match-winner result)}))}))))
+
+(defmethod integrant.core/init-key ::dispute-game
+  [_init-key dependencies]
+  (fn [{{{:keys [tournament-eid match-eid game-eid]} :path} :parameters
+        session                                             :ory-session
+        :as                                                 _request}]
+    (let [reporter-sub (get-in session [:identity :id])
+          result       (domain/dispute-game
+                        dependencies
+                        {:match-eid    match-eid
+                         :game-eid     game-eid
+                         :reporter-sub reporter-sub})]
+      (if (= :match-record/error (:type result))
+        (common/error-fragment 422 (:message result))
+        {:status  200
+         :headers {"Content-Type" "text/html; charset=utf-8"
+                   ;; Both the player series panel and the organizer queue react.
+                   "HX-Trigger"   "game-disputed, dispute-opened"}
+         :body    (render/render-component
+                   "tournament/player-step-disputed.html"
+                   (series-context dependencies tournament-eid match-eid game-eid))}))))

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/routes.clj
@@ -3,6 +3,7 @@
    [com.devereux-henley.rts-domain.contract :as domain]
    [com.devereux-henley.rts-web.orchestration :as orchestration]
    [com.devereux-henley.rts-web.web.actions.dispute :as web.actions.dispute]
+   [com.devereux-henley.rts-web.web.actions.match-game :as web.actions.match-game]
    [com.devereux-henley.rts-web.web.actions.draft :as web.actions.draft]
    [com.devereux-henley.rts-web.web.api :as web.api]
    [com.devereux-henley.rts-web.web.actions.league :as web.actions.league]
@@ -394,6 +395,22 @@
                                  [:tournament-eid :uuid]
                                  [:match-eid :uuid]])}
             :handler    (integrant.core/ref ::web.tournament.view/player-replay-submit-fragment)}}]
+   ["/tournament/:tournament-eid/match/:match-eid/game/:game-eid/confirm"
+    {:post {:produces   ["application/htmx+html"]
+            :parameters {:path (schema.contract/to-schema
+                                [:map
+                                 [:tournament-eid :uuid]
+                                 [:match-eid :uuid]
+                                 [:game-eid :uuid]])}
+            :handler    (integrant.core/ref ::web.actions.match-game/confirm-game)}}]
+   ["/tournament/:tournament-eid/match/:match-eid/game/:game-eid/dispute"
+    {:post {:produces   ["application/htmx+html"]
+            :parameters {:path (schema.contract/to-schema
+                                [:map
+                                 [:tournament-eid :uuid]
+                                 [:match-eid :uuid]
+                                 [:game-eid :uuid]])}
+            :handler    (integrant.core/ref ::web.actions.match-game/dispute-game)}}]
    ["/tournament/:tournament-eid/dispute/:eid/resolve"
     {:post {:produces   ["application/htmx+html"]
             :parameters {:path (schema.contract/to-schema

--- a/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
+++ b/components/rts-web/src/com/devereux_henley/rts_web/web/tournament/view.clj
@@ -344,7 +344,23 @@
          (let [step          (or (get-in request [:parameters :query :step]) "live")
                step          (if (#{"live" "declare" "submitting" "opp_uploading"} step) step "live")
                user-sub      (get-in request [:ory-session :identity :id])
-               current-match (find-current-player-match dependencies (:eid tournament) user-sub)]
+               current-match (find-current-player-match dependencies (:eid tournament) user-sub)
+               ;; Lazily settle any lapsed confirm windows so a missed
+               ;; confirmation advances the series without a scheduler.
+               _             (when current-match
+                               (domain/settle-expired-confirmations! dependencies (:eid current-match)))
+               ;; The latest not-yet-confirmed game on the real match drives the
+               ;; verification panel, overriding the demo `?step` walkthrough.
+               active-game   (when current-match
+                               (->> (db/games-for-match (:datalog-connection dependencies) (:eid current-match))
+                                    (remove #(= :confirmed (:status %)))
+                                    (sort-by :game-index)
+                                    last))
+               real-step     (when active-game
+                               (cond
+                                 (= :disputed (:status active-game))          "disputed"
+                                 (= user-sub (:submitted-by-sub active-game)) "awaiting"
+                                 :else                                        "confirm"))]
            (cond-> (assoc (series-view-model step)
                           :data                tournament
                           :parse-log-rows      (single-game-parse-log)
@@ -354,7 +370,13 @@
                           ;; mid-animation rather than after it.
                           :parse-swap-delay-ms (* 2 parse-log-stagger-ms))
              current-match (assoc :current-match current-match
-                                  :match-eid (:eid current-match)))))))))
+                                  :match-eid (:eid current-match))
+             real-step     (assoc :real-step real-step
+                                  :pending-game {:eid                 (:eid active-game)
+                                                 :winner-sub          (:winner-sub active-game)
+                                                 :submitted-by-sub    (:submitted-by-sub active-game)
+                                                 :game-index          (:game-index active-game)
+                                                 :confirm-deadline-ms (some-> (:confirm-deadline active-game) inst-ms)}))))))))
 
 ;; ─── Post-match modal helpers ───────────────────────────────────────────────
 
@@ -888,8 +910,8 @@
                   fresh-match (-> (db/match-by-eid (:datalog-connection dependencies) match-eid)
                                   (assoc :game-eid (:game-eid tournament)))]
               {:status  200
-               :headers {"Content-Type"            "text/html; charset=utf-8"
-                         "HX-Trigger-After-Settle" "match-game-recorded"}
+               :headers {"Content-Type" "text/html; charset=utf-8"
+                         "HX-Trigger"   "game-submitted"}
                :body    (render/render-component
                          "player-replay-submitted-fragment.html"
                          {:match           fresh-match
@@ -900,8 +922,9 @@
                           :opponent-sub    (if (= uploader (:player-one-sub fresh-match))
                                              (:player-two-sub fresh-match)
                                              (:player-one-sub fresh-match))
-                          :match-complete? (:match-complete? result)
-                          :match-winner    (:match-winner result)})})
+                          ;; Submitting never clinches now — the game awaits the
+                          ;; opponent's confirmation before the series advances.
+                          :match-complete? false})})
 
             :match-record/error
             (error-fragment (:message result))))))))


### PR DESCRIPTION
## What

Adds the **verification half** of the per-game result protocol on the Player Console (rts-6vy). The winner→submit path already existed; this inserts the confirmation gate:

**winner submits → game recorded `:pending-confirmation` (no advance) → the non-uploading player confirms (→ clinch-check + match completes) or disputes (→ opens a ticket, series pauses) → a lapsed confirm window auto-settles lazily on read.**

Recording a game previously clinched the match immediately with no loser sign-off. Now advancement is deferred until the result is confirmed.

## Changes

- **Schema** — `match-game` gains `status` / `submitted-by-sub` / `confirmed-by-sub` / `confirmed-at` / `confirm-deadline` (additive; no migration).
- **Data-access** — `create-game!` records `:pending-confirmation`; new `confirm-game!`, `dispute-game!`, `match-game-by-eid`.
- **Domain** — `record-game-from-parsed` defers advancement; new `confirm-game`, `dispute-game` (reuses the existing `open-dispute` model), and `settle-expired-confirmations!` (lazy auto-settle, 10-minute `confirm-window`, no scheduler).
- **Web** — `POST /actions/.../game/:game-eid/confirm|dispute` handlers + routes, a registered `:player-series` HX-Trigger group (replacing an orphan trigger), and real **awaiting** / **confirm-or-dispute** / **disputed** panels driven by the current match's verification state.

Per the agreed scope, the full de-demo of the series *board* (real opponent / per-game results / series score) is **deferred to rts-pwd** — the confirm/dispute loop is real; the surrounding board stays demo.

## Screenshots

| Confirm (loser) | Awaiting (winner) |
|---|---|
| ![confirm](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/player-per-game-confirm-dispute/01-confirm-panel.png) | ![awaiting](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/player-per-game-confirm-dispute/02-awaiting-panel.png) |

| Confirmed → match clinched | Disputed → series paused |
|---|---|
| ![confirmed](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/player-per-game-confirm-dispute/03-confirmed.png) | ![disputed](https://raw.githubusercontent.com/Devereux-Henley/images.com.devereux-henley/main/player-per-game-confirm-dispute/04-disputed-panel.png) |

## Verification

- **Domain unit tests**: 16/16 (7 new — confirm/dispute/auto-settle + guards).
- **Live Datalevin store**: confirm completes a Bo1, self-confirm rejected, dispute opens a ticket + pauses + shows in the organizer queue.
- **HTTP end-to-end**: confirm → 200 + `game-confirmed`, re-confirm → 422, dispute → 200 + `game-disputed, dispute-opened`, self-dispute → 422.
- **`clojure -M:poly test`** green (e2e brick now drives submit→confirm→complete) · cljfmt clean · clj-kondo 0/0 · `poly check` OK.

## Follow-ups

- rts-pwd — real domain view-models / de-demo the series board (unblocked by this).
- rts-qwa — finalize-series stage; rts-hmm — organizer "Open replays / Request replay" row actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)