### PR TITLE
Bump datalevin-embedded to 1.0.0, drop dtlvnative native pin (rts-qff, rts-tku)

### DIFF
--- a/bases/rts-api/deps.edn
+++ b/bases/rts-api/deps.edn
@@ -8,8 +8,7 @@
         selmer/selmer {:mvn/version "1.12.55"}
         clj-http/clj-http {:mvn/version "3.12.3"}
         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
-        org.datalevin/datalevin-embedded {:mvn/version "0.10.16"}
-        org.clojars.huahaiy/dtlvnative-linux-x86_64 {:mvn/version "0.18.7"}}
+        org.datalevin/datalevin-embedded {:mvn/version "1.0.0"}}
  :aliases {:build {:main-opts ["-m" "com.devereux-henley.rts-api.core"]}
            :dev {:extra-paths ["dev"]}
            :test {:extra-paths ["test"]

--- a/bases/rts-demo/deps.edn
+++ b/bases/rts-demo/deps.edn
@@ -1,4 +1,3 @@
 {:paths ["src"]
- :deps {org.datalevin/datalevin-embedded            {:mvn/version "0.10.16"}
-        org.clojars.huahaiy/dtlvnative-linux-x86_64 {:mvn/version "0.18.7"}}
+ :deps {org.datalevin/datalevin-embedded {:mvn/version "1.0.0"}}
  :aliases {:run {:main-opts ["-m" "com.devereux-henley.rts-demo.core"]}}}

--- a/components/rts-data-access/deps.edn
+++ b/components/rts-data-access/deps.edn
@@ -1,5 +1,4 @@
 {:paths ["src" "resources"]
  :deps {metosin/jsonista                             {:mvn/version "0.3.5"}
         metosin/malli                                {:mvn/version "0.9.2"}
-        org.datalevin/datalevin-embedded             {:mvn/version "0.10.16"}
-        org.clojars.huahaiy/dtlvnative-linux-x86_64  {:mvn/version "0.18.7"}}}
+        org.datalevin/datalevin-embedded             {:mvn/version "1.0.0"}}}

--- a/docs/database.md
+++ b/docs/database.md
@@ -39,4 +39,4 @@ For a store populated with demo tournaments (brackets in interesting states, not
 - **Snapshot once per read.** Call `datalog.contract/db` once at the top of a read function and run every query in that function against the snapshot, so multi-step reads see a consistent view.
 - **Flatten pull results.** Read functions in `rts-data-access` flatten pull maps into the flat `*-eid` shape handlers consume (ref sub-maps become `:game-eid`, `:faction-eid`, …); handlers never see raw pull structure.
 - **`:db.type/instant` requires `java.util.Date`.** Datalevin rejects `java.time.Instant` for instant attributes. Coerce `Instant` → `Date` at the data-access boundary in every mutation function.
-- **`:db.type/idoc` caution.** Document-typed attributes (e.g. `:replay/parsed-data`) work, but certain integer-heavy documents have corrupted the idoc index on store reopen (`MDB_BAD_VALSIZE` — see bead `rts-tku`). When that bites, store the map as an EDN/transit string instead.
+- **`:db.type/idoc` for document values.** Store nested Clojure maps directly under a document-typed attribute (e.g. `:replay/parsed-data`); Datalevin round-trips them as maps across store reopen.


### PR DESCRIPTION
## Summary

Bumps `datalevin-embedded` `0.10.16` → `1.0.0` across all three `deps.edn` (`rts-api`, `rts-demo`, `rts-data-access`) and removes the interim `org.clojars.huahaiy/dtlvnative-linux-x86_64 0.18.7` native override.

datalevin-embedded 1.0.0 replaces the custom `dtlvnative` (dlmdb) native library with a `javacpp`-based LMDB binding (`org.bytedeco/javacpp 1.5.13`, bundled) and ships the fix for the idoc reopen corruption (`MDB_BAD_VALSIZE` / [datalevin#375](https://github.com/datalevin/datalevin/issues/375)) that the `dtlvnative` override existed to supply. With the fix in the released artifact, the standalone dep is obsolete rather than merely releasable.

Also refreshes the `docs/database.md` `:db.type/idoc` note — the reopen-corruption caution no longer applies on 1.0.

Resolves **rts-tku** (upstream idoc reopen bug) and **rts-qff** (bump + drop the native pin once released).

## Verification

All against a fresh store on 1.0.0:

- ✅ System boots + full seed (11k+ entities across 22 files) clean
- ✅ **idoc reopen round-trip** (the exact bug the pin protected): create a replay with integer-heavy nested `parsed-data` → `restart!` to force an LMDB close+reopen → read back an identical map
- ✅ General reads (games, factions-for-game) post-reopen
- ✅ `clojure -M:poly test` — 200+ assertions across all domain bricks, 0 failures
- ✅ `clojure -M:poly check` — OK
- ✅ Playwright e2e — 74 passed, including both `Replay submission (Datalevin)` specs (drive the idoc path through HTTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)